### PR TITLE
feat: GitHub Actions self-hosted runner infrastructure

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,20 @@
+SHELL := /bin/bash
+
+ANSIBLE_ROLES_PATH ?= ../rapid-root/infra/roles
+INVENTORY ?= inventory.ini
+
+setup-runners:
+	ANSIBLE_ROLES_PATH=$(ANSIBLE_ROLES_PATH) ansible-playbook -i $(INVENTORY) github-runner.yml
+
+setup-runners-macos:
+	ANSIBLE_ROLES_PATH=$(ANSIBLE_ROLES_PATH) ansible-playbook -i $(INVENTORY) github-runner-macos.yml -K
+
+ping:
+	ansible -i $(INVENTORY) -m ping runners
+	ansible -i $(INVENTORY) -m ping macos_runners
+
+help:
+	@echo "Available targets:"
+	@echo "  setup-runners        Provision Linux GitHub Actions runners"
+	@echo "  setup-runners-macos  Provision macOS GitHub Actions runners"
+	@echo "  ping                 Test runner host connectivity"

--- a/infra/ansible.cfg
+++ b/infra/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+roles_path = ../rapid-root/infra/roles
+inventory = inventory.ini
+host_key_checking = False
+retry_files_enabled = False

--- a/infra/github-runner-macos.yml
+++ b/infra/github-runner-macos.yml
@@ -1,0 +1,12 @@
+---
+# GitHub Actions Runner setup for macOS (Mac Mini + Mac Laptop)
+# Run with: GITHUB_TOKEN=<token> make setup-runners-macos
+
+- hosts: macos_runners
+  become: yes
+
+  vars:
+    github_runner_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+
+  roles:
+    - github-runner-macos

--- a/infra/github-runner.yml
+++ b/infra/github-runner.yml
@@ -1,0 +1,23 @@
+---
+- hosts: runners
+  become: yes
+
+  vars:
+    github_runner_enabled: true
+    github_runner_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+    github_runner_version: "2.332.0"
+    github_runner_base_dir: /home/deployer/github-runner
+    github_runner_user: deployer
+    github_runners:
+      - name: "spanbarn-1"
+        repo: "wiebe-xyz/spanbarn"
+        labels: "build"
+      - name: "spanbarn-2"
+        repo: "wiebe-xyz/spanbarn"
+        labels: "build"
+      - name: "spanbarn-deploy-1"
+        repo: "wiebe-xyz/spanbarn"
+        labels: "deploy"
+
+  roles:
+    - github-runner

--- a/infra/host_vars/mac-laptop.yml
+++ b/infra/host_vars/mac-laptop.yml
@@ -1,0 +1,15 @@
+# Mac Laptop - GitHub Actions runner configuration for SpanBarn
+# Battery-aware runners should only run when on AC power.
+
+github_runner_enabled: true
+github_runner_version: "2.332.0"
+github_runner_base_dir: /Users/wiebe/github-runners
+github_runner_user: wiebe
+github_runner_battery_aware: true
+github_runners:
+  - name: "spanbarn-laptop-1"
+    repo: "wiebe-xyz/spanbarn"
+    labels: "build,mac-laptop,macos,arm64"
+  - name: "spanbarn-laptop-2"
+    repo: "wiebe-xyz/spanbarn"
+    labels: "build,mac-laptop,macos,arm64"

--- a/infra/host_vars/mac-mini.yml
+++ b/infra/host_vars/mac-mini.yml
@@ -1,0 +1,14 @@
+# Mac Mini - GitHub Actions runner configuration for SpanBarn
+
+github_runner_enabled: true
+github_runner_version: "2.332.0"
+github_runner_base_dir: /Users/wiebe/github-runners
+github_runner_user: wiebe
+github_runner_battery_aware: false
+github_runners:
+  - name: "spanbarn-mac-1"
+    repo: "wiebe-xyz/spanbarn"
+    labels: "build,mac-mini,macos,arm64"
+  - name: "spanbarn-mac-2"
+    repo: "wiebe-xyz/spanbarn"
+    labels: "build,mac-mini,macos,arm64"

--- a/infra/inventory.ini
+++ b/infra/inventory.ini
@@ -1,0 +1,7 @@
+[runners]
+pxe-github-runners ansible_host=192.168.4.105 ansible_user=root ansible_ssh_private_key_file=~/.ssh/id_rsa
+germany ansible_host=193.24.209.222 ansible_user=root ansible_ssh_private_key_file=~/.ssh/id_rsa
+
+[macos_runners]
+mac-mini ansible_connection=local ansible_python_interpreter=/usr/bin/python3
+mac-laptop ansible_connection=local ansible_python_interpreter=/usr/bin/python3


### PR DESCRIPTION
## Summary

Adds Ansible-based provisioning for self-hosted GitHub Actions runners, mirroring the BugBarn convention.

- Linux runners (`spanbarn-1`, `spanbarn-2`, `spanbarn-deploy-1`) via `github-runner.yml`
- macOS runners on mac-mini (`spanbarn-mac-1`, `spanbarn-mac-2`) and mac-laptop (`spanbarn-laptop-1`, `spanbarn-laptop-2`, battery-aware) via host_vars
- Shared Ansible roles consumed from `../rapid-root/infra/roles` (overridable via `ANSIBLE_ROLES_PATH`)
- Makefile targets: `setup-runners`, `setup-runners-macos`, `ping`

## Why

SpanBarn CI currently has no dedicated runner capacity. Project-specific runner registration keeps the SpanBarn fleet isolated from other Barn projects while reusing the shared homelab role definitions.

## Test plan

- [ ] `cd infra && make ping` — macOS runners respond
- [ ] `GITHUB_TOKEN=<pat> make setup-runners-macos` provisions 4 macOS runners
- [ ] All 4 runners appear as Idle at https://github.com/wiebe-xyz/spanbarn/settings/actions/runners
- [ ] A CI workflow run picks up on the new runners