### PR TITLE
fix: align ingress hostnames with split-horizon DNS

### DIFF
--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: spanbarn-staging.wiebe.xyz
+    - host: spanbarn-staging.nijmegen.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - spanbarn-staging.wiebe.xyz
+        - spanbarn-staging.nijmegen.wiebe.xyz

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ingressClassName: traefik
   rules:
-    - host: spanbarn.test.wiebe.xyz
+    - host: spanbarn-test.nijmegen.wiebe.xyz
       http:
         paths:
           - path: /api
@@ -28,4 +28,4 @@ spec:
                   name: http
   tls:
     - hosts:
-        - spanbarn.test.wiebe.xyz
+        - spanbarn-test.nijmegen.wiebe.xyz


### PR DESCRIPTION
## Summary

- testing: `spanbarn-test.nijmegen.wiebe.xyz` (was `spanbarn.test.wiebe.xyz`)
- staging: `spanbarn-staging.nijmegen.wiebe.xyz` (was `spanbarn-staging.wiebe.xyz`)
- production: `spanbarn.wiebe.xyz` (unchanged)

Matches the `*.nijmegen.wiebe.xyz` split-horizon DNS convention used by funnelbarn and bugbarn, terminated at Caddy on 192.168.4.111.