### PR TITLE
fix: Python SDK lint and Dockerfile Go version

### DIFF
--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM golang:1.25-alpine AS build
 
 WORKDIR /src
 

--- a/sdks/python/spanbarn/__init__.py
+++ b/sdks/python/spanbarn/__init__.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import json
-import os
 import secrets
 import sys
 import threading
 import time
 import urllib.request
 import urllib.error
-from contextlib import contextmanager
 from contextvars import ContextVar
 from queue import Empty, Queue
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -495,7 +493,7 @@ class SpanBarnWSGIMiddleware:
                 else:
                     span.set_status("ok")
                 return response
-        except Exception as exc:
+        except Exception:
             span.set_attribute("http.status_code", status_code)
             raise
 


### PR DESCRIPTION
## Summary

- Remove unused imports (`os`, `contextmanager`) and unused variable (`exc`) in Python SDK `__init__.py`
- Bump Dockerfile Go base image from 1.24 to 1.25 to match `go.mod` requirement (1.25.7)

These were the remaining CI blockers preventing build and deploy.