### PR TITLE
fix: remove SPANBARN_SELF_API_KEY — use main API key for self-tracing

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -1,32 +1,31 @@
-apiVersion: ENC[AES256_GCM,data:k04=,iv:WKE8EwWu6axjSgO1AnK20T1CxfJfvCZaPbqfIsyEuoE=,tag:HT6xLuU5OqD8v4FO58EbMw==,type:str]
-kind: ENC[AES256_GCM,data:DnjbZnec,iv:ohESsV1IIu44XUaJJdQyzdUx28AED+4Ug77r8ivX8+U=,tag:H0GV5jl2utDYOWJtfGXkVQ==,type:str]
+apiVersion: ENC[AES256_GCM,data:u54=,iv:6x9iq4uDR0vbleSIJjXlW1UXcl3nK4InfeoJ49Qk8zA=,tag:E/PzRPF6yWK8FXWVPoScdg==,type:str]
+kind: ENC[AES256_GCM,data:gnOTVgeb,iv:krVagDugbb85mcZI0RE5L8C98fSmbr0GCmRcjJhK4s0=,tag:BtYL8rNk8BEkRPWvHSyBIQ==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:ME5zc+/b4FZPZk5irKzX6w==,iv:1zCMim9SaEpvnb/K7U/iraF7U5+sDEaA6bWRmTmz73g=,tag:FGfMfEMtCtlN4hURQYd1Mw==,type:str]
-    namespace: ENC[AES256_GCM,data:NVctL3Frba73xJNXPWklu7dvFA==,iv:2uUfabwxroCWBOoZMLoUEtT2Rz6AVwF6zfe9mmjTIsw=,tag:T+gfcUOKFs3Znm+WrmGyJw==,type:str]
-type: ENC[AES256_GCM,data:GnSlQbFJ,iv:xOZsFqlb6yIDCe9n9VnEwakVJ0+0CnB1feyjzvtYeUI=,tag:uqBrmjF6bHEv6IS3C1S75g==,type:str]
+    name: ENC[AES256_GCM,data:i/eHocVdGhIP+lm8tmJwuQ==,iv:rBG9fsEsiZHEexOkY5GpcQLxpVDusWuaoVB9+skqJ5w=,tag:ZGIEP/u7Fhvb8FpJv5n4YQ==,type:str]
+    namespace: ENC[AES256_GCM,data:KvpkXXwNX0mvBomUZ2f1YMt8ZA==,iv:aCJA0TZPbxIlppYwTedOou0R22z3Yp3KiZ/yx83H5Vk=,tag:SA89Pd3yxeONvFUSoBODag==,type:str]
+type: ENC[AES256_GCM,data:kIQSyZhm,iv:rnKN3Pah/tuOmhkzWCtX/K4bqq48gf2ddAPBaXQlBYU=,tag:cCD0zVDIcedCY2zhYHYNgw==,type:str]
 stringData:
-    SPANBARN_API_KEY: ENC[AES256_GCM,data:b2BytnvBiGprkuo+0nmb4uAjYRiZAeqYlsUAWLf5z2EqrEjZ9tIomA==,iv:6K1nqoGNhoCMIdw+MIcym7kUDCmg9pfEbHFwggl4Vgs=,tag:nMxswRfG9sLYJxF33AnenQ==,type:str]
-    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:YQ+kkztu+QGXq1AZd1LGWOOtVgzU9mSNBcqGIKuApj5R0w8sYJ1cuXG37lQyzxpioqpRzBw5qOezhvU+Zyd1Aw==,iv:8/yp+/6hoDWbGUo7hhiu66I1UEl9i/pbPI4mooJQbAs=,tag:+TUkB2Eg8w0dLT1LcBrE2Q==,type:str]
-    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:BFzWUgM0geGCPPwKDUsaU9cN22RcldVSsncip5U/YVgNC5hxk+xKEQ==,iv:P0B3IIcmIPfO5uNNkapTaNJYzSppuLva3aHCCXnp8KU=,tag:sEB3P9tqbjbMjFqqwiNY+A==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:sBvzO0ATlD1BazpWRnwqvu0PJUeGlR3QAlxcaFAksglGEzNi3xOH8w==,iv:wBWUoTszLY2+PWUdAoonASpySSBWoygpT4F1uSgMCDg=,tag:/kAxaDptjMGFsdZy0IYf9g==,type:str]
-    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:DiKUpSWwQxYryg==,iv:mSyssnk4xQ16AWsfVAcOYOy8yvlemPhJvVoh6NIbkCg=,tag:j3wqrgfIj83pBcSWfi1HsQ==,type:str]
-    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:REs52IE=,iv:b0zbr4a/f4Xim5+QxKwzeDtynBLkSquzbNfhtcl6OrA=,tag:xbqmrwhO+lTY941j34BPOg==,type:str]
-    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:9yO2eAc0A2c=,iv:NJVXILcIkKM1Fa7d3atI+5W/A/qXyIEQ/4esyZXmdQg=,tag:l76dnRKpnCgt5sHVDua4gA==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:2VbXSZfw3xrRm8yjb425feUeUdAS,iv:qiJsUtd1j21k+YNXFGjdF/qkTpkznosACyRxG/28sHw=,tag:+rZjmOFJzuaSeBD/MdYrLA==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:uMvgabzWmYOGj67uX52jlw2ANAAZ,iv:2h3F6i+n5/HnqTVdY+7HE4a9QESY2VhvIQob4nannKY=,tag:PrccQmWiQH3nUb2d8hWedA==,type:str]
-    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:Y5FZZnnEuMaRAoFLq59oOu77bZXq,iv:Y3nMUE+P7B7wEVZKYARAWVI4pgdtaxfF192C+Pt1IbU=,tag:gltPDlkbGs0IAoEOEysPvQ==,type:str]
+    SPANBARN_API_KEY: ENC[AES256_GCM,data:m/pscISGxbnYELf2/h2I2dtTlovouqjtDzOrEazGQ6vItu2CTT6QYQ==,iv:QT3dgAJPxRrtAity6pSxCZOGjZ2KMuDwaVruwTDvWbE=,tag:0VA5rO8EUW2YAlnAJY4a1A==,type:str]
+    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:Ikz8T/HnbKpZf04CdEkuDD4EznfOQufL16SfX6GlEnWSRG+LvQ+SI6X4Zs8kGdDrsRfLU+X4dZLjfd1zULXfUA==,iv:CaFxnwvCjcukmnuvtbB8fnt9HmZ6hGNH7zv3Bk+jF2Y=,tag:xEpXmlH88Oyki6QRaaHHvg==,type:str]
+    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:RzxJkN88gzSIUtpPY54SwWcmJ6Vd57CUEy8w8+sYHYIchBfY17Ue1g==,iv:srGYtUdeaGlLYpUs/b0AV6xiykSdD5Bi4VTcggccZHU=,tag:60ZbonfCcOk89ok4s+uk6w==,type:str]
+    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:sgjY9V9R9LQuEQ==,iv:dpARMVqXfyTaFC33PSA3mvi7AGgPj1uobwVCWvggTMM=,tag:3nlPyCFKgiAMFWrSX26LuA==,type:str]
+    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:CNacd7E=,iv:RDhecuAAdrznLKE9KeNafczPUaxpYlk2/U77ppuGGT4=,tag:5DD6Nxi/lDtW0YU7Ewif1Q==,type:str]
+    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:7SdepuElCr0=,iv:Xb6PfYt5HqPEw/IQUH6j7qax6uJtI6ryNwFd0IxA9sU=,tag:wvFaQrsOti+MYWUQfMl8eg==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:v78b2IBWCddWXdCwGzRhplXCAVry,iv:cuSgg3nvSRP0rxmcQ2RMLXaW5V0GzfK5qKN7Ys4i59g=,tag:e2p+lA8sRonCrcNXNWMr1g==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:QIp96pHScHcOGax0zPKPBW9YZsh6,iv:LlRvDrIPqNgznprhydNr1LiJLRFMNQQDqyxG2gl9Z3E=,tag:36yVj8l9xVgorZDWPuoF5g==,type:str]
+    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:2K2b1HUNKeIbQ52rJ0Aw8kD3KNu6,iv:zsasSJagR9sNue4SRD1OjaqMyayLCqi4GBio2as/nc8=,tag:WOJJDYt+hl9GOAv90r7G5Q==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlWWlna0d6YzhqL09wMktq
-            NUFJUEFvdHJWUEdYamJNNmlPMEFqMzI1eDNjClR0MmVzUCtNZUR2bUtZM0FMejFp
-            RENiRXNBS0VqaExWcDdBa2grVnhwRzAKLS0tIHZPNU9ZQzloN1BpbzBuN252dnp1
-            U0dQZ0Q3WjdLZExTR2szRzVTWlREb00KLcpYAkqfUqeXT2Gl1PNSGd1I2YB54oKl
-            opEyHe1eQ43fpB6jss7N0VVXAZDFcIzH5erKON1Ds8UD8mPF5yC8CA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3UmVVZnhPQ3dPYzE2UzB0
+            NWdFeTA4ckE0UDRPWms3NW5IUVFoMmEwSGdFCmlndGpVSFpYK0paWXRnUU5OQU0v
+            VytLbTQ4YmQzakZZeG1iRWtMTmpVcEkKLS0tIHl2ZWNhYXRaSnBWNkROb3pCY3lN
+            eDlyOFBrRG8zL29ZZEtnZE9HWHNrWlkKor0kNewAOGeL1px/MI8f2S2ad6iL7qBD
+            I2Of+Z2cjIdmgvLgwFhWYnSzzgC1+plFdTlM/CoVDdS+odu2zfEIlQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-06T09:30:05Z"
-    mac: ENC[AES256_GCM,data:41u5EC3+bAPOO+FK6p9SDwLQ3jAwBxwHLM0DSbnmK9PoGxNsAFct1CEbv7govTdWpU9mAomOc8b5yRY2xvaFHamq9PhiaUK6S2JXGUMGpyMYsIsVztp0pxtUe5oijduEbYg9jbKK30gUXcb+fZ61gY5DL9NBh1cPz40aKMFOp8E=,iv:NJOrWkP0a6gELWN1oIGatN/n+3gM4zBQPhVUd0rxL3w=,tag:GHPI2x0LUHXuN5tHMsIzjw==,type:str]
+    lastmodified: "2026-05-06T14:09:38Z"
+    mac: ENC[AES256_GCM,data:AtuxIMWvjyuZZXsAqh/ObHk/RIRRaxZ+VdvmPMrER9iscRcDv9SJJYg+JDEdstOpjbS4FEvykRBRTwkDkiK0ve1wm9SxKGCsgaKEMHWh2iNvZ3h4O0VLvptPYXzYD8Tbq+kexp47P5SlbZeo9sQiyQEBmfevd+Rti0oVAMxWIWQ=,iv:4gBWyAhdFxp7jZLEyJItreVCoetcKK62eWzqPS3s9Ys=,tag:cLLZ93ldEs4sNQ3nNB/aDA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -1,32 +1,31 @@
-apiVersion: ENC[AES256_GCM,data:5z8=,iv:d2/5wUbeccyJcKcD+A6RsQiCwFDk8pu9Mdhz5O8KWO8=,tag:n9g47DMkYgcKVZeaD4026Q==,type:str]
-kind: ENC[AES256_GCM,data:4iqAvZNR,iv:6gdjn3tiPal32/G7ekOlAlBSOh1XXSirvHVrYnrP0P4=,tag:4PoVXsbeurkyJPsU+eO7nQ==,type:str]
+apiVersion: ENC[AES256_GCM,data:dao=,iv:+97hrobcLODXHVRpHwj8lqEY89PHKgYvEJG2IaDh30s=,tag:jHGvXWdMHjQIQgXL00mSvQ==,type:str]
+kind: ENC[AES256_GCM,data:3zC8xjpE,iv:mGT7LDM/yY+d+SmSJp4Za322Q4HT+RuOBMJDl28pE40=,tag:J1Z+8draTMi+AOXsgOhEBg==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:uepPjhII3bBJ874EWaNbXA==,iv:4pmFBtL4RDhJNJg+ksz2n98k/VZnQ42HCxOf0NRIhc0=,tag:WZZvg2bWiQtUTOauDfUu7Q==,type:str]
-    namespace: ENC[AES256_GCM,data:v/xuQNrvoWNej7dKZfijrQ==,iv:IDx2w/HmHtgYmHSoSJi7onRuCMhq6+310y1BHFCs/dw=,tag:wnKCbbGaAdbRUKucEJMKTw==,type:str]
-type: ENC[AES256_GCM,data:ItoqTO7k,iv:+nAFXungNgUziZDRyyQucfEQquYv4WMMvtAEO5cWm1U=,tag:lV7OKot14okB8ccCN2dyFQ==,type:str]
+    name: ENC[AES256_GCM,data:dd+83ah/NSAc1voeIJ7nvA==,iv:lbJ1eIVCoCwYgbsQBaNMJPluCkKTBFB1Nm3KG34YNbw=,tag:WVcKnK7vIj4fv3jx78hW4Q==,type:str]
+    namespace: ENC[AES256_GCM,data:eX+Onaz2P13vhaJuJvAJRQ==,iv:0ulPogAMox5wLSmfxZpdvaDUkD+RMWGKx6Lo/OVNUeo=,tag:qE/5fvDyacxnt/dQFhhzBw==,type:str]
+type: ENC[AES256_GCM,data:NmHf0fe/,iv:vf+eZ+lxRH50tCTq1xb+F/+N/XPX8+lEZC+Z8RsWnxM=,tag:UZsbcX9gWNC4OL4x9FdDUw==,type:str]
 stringData:
-    SPANBARN_API_KEY: ENC[AES256_GCM,data:xDuX9DUU7CSKiuNq4J2Z9ss47Rnr1vnGmkLcVZCuenaGtY2A79ZdJw==,iv:pd5tPdsTwZPYvYbEyXiVr1lwPg1OkPhk9lwK8R7VzUA=,tag:g1zCY2PUZFh3GaoZTBpEGA==,type:str]
-    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:Qj0jGCM/r++cf1dX7IP+YDiONVusyswxNTYwALFG2AJpmO/Kz9I4qNQLMSzaOkaCTFP7WM+5aboQW8DVwzuAqg==,iv:kmQcy1tq4neotAbg7HYaLfLo3fSmaX3i82gd7G17Whg=,tag:Qb8XV1RILwSVvOW1/kqbCw==,type:str]
-    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:T8Ke+h7rLqnqKFUBpPu1iDUbMzxMqeBy3U+9o4179lgqwskuxGWE6A==,iv:gqK3K8pj243jve92fCVg9a5FsHjtRoyIsDZzfhVSpe0=,tag:KMTCfknGXU7gump7sfqVzg==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:xpX3lnnIbzrHe/RIDPUN8vlDYRacLCrPCteTpYUi5nf2jHCHikuIZg==,iv:Kv6xhijVqKOcUIkUDFynvZR+rQ4TbUjSGVry3g6+ZP0=,tag:YSZbb+nKmB2aSSR0nRDN8A==,type:str]
-    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:2WQaGYCF+A==,iv:4vLUnZVQtuJ5o6Dbh5NAHIU4ihh/3MGRmqxNocpfbu4=,tag:tGWOio23NYzST7rfm7cVHQ==,type:str]
-    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:L09D97I=,iv:QxVRbvr1Ywx/hk1Pqeys2uExwURxVn35W6o6VeKf74s=,tag:wUOhyhgzATbaJ5Olm/RAaA==,type:str]
-    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:1SvhRkG58XU=,iv:T8f9heYMCmf9DJq+z01AIsntSyic9+WhQYE6AVMPlJA=,tag:iaWhV4alk+vzgyXXVQwT4w==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:aXPpfVNZgbRXeN1gTua6ipqkS5JI,iv:590E9mIogLSARPGkOQitA4sMglPqSQ582oKgyOzWWPY=,tag:iEyVYbusJ3osiUCBfTr7Eg==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:xBp+ejem2UTGWcAEzpKIeNXR8SCs,iv:qHi7DKD9OJZjqkqfDxYCFX8yDzEyAME59sC9i1zGdyE=,tag:vG0qH+eCqtb4SRkaV1IsiQ==,type:str]
-    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:4smw5MTMK+c2t5qkBPXbb4NGtvQA,iv:MjCbB4k/JSnfCz9qTgTXrkUBaLu2H/juwbAQMzQ5jos=,tag:b0qHQNzLS0SDN+uDSckdSw==,type:str]
+    SPANBARN_API_KEY: ENC[AES256_GCM,data:NCMPKB/WDdcRXa9haipdWpE7Nu0pqKq89j2EEmSlOkZZBWnsJbU+tw==,iv:bfnM/71hCrErsVem7tzBE2Eoz+bV1ynaen4ST4OJGcc=,tag:5V/3cNogNvCfJy4Uxte+0w==,type:str]
+    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:Ug7NaqLNTP9+vVUeyTlIuyix+1TFjX2qBeNZYv7u2IjIAMWVsmJJmcLpA577yVhOE5Uz3Xlk9d+mwSGmgIJMBA==,iv:tGEzNiJSDcXRg2bhU6wvi0zwoo18LlHSWZeZiX0VP68=,tag:Jeg6gvQSJAFo4lSnhRO7WA==,type:str]
+    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:bBrzw4aadxojbpUaMMr/e8aDlH5Id5Byb41l3dsZW5s5G6LTZvaPeA==,iv:yDsCf+S0p/KaAA0MO+y31GMmelVodX0Ry1THBuVo6js=,tag:bZX3KEdST0TEuVXXcavaIg==,type:str]
+    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:edaO8juLOg==,iv:QB3oIr96xHPXKZCkJs2jaPtIvgnH0FGgBzD8YOjj39k=,tag:YYOT6Oqfi0bLvu3/5NaQaQ==,type:str]
+    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:A5gvdeU=,iv:3coX72Qk5+RWvTsN7d/7rq586yX/H+gKSImj197iLPk=,tag:KB9d/zWK1s2BcBFJnmM8HA==,type:str]
+    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:9Pv49G9MxZU=,iv:wxquaEftUElUyc0HvCbGXJ2NNwMxvx4TTTGNwZNy3Gk=,tag:ZbVnJkzzAGaFh/SiCeD/zA==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:0mH2iheIhxU9pdAUtAZNzkQF94k3,iv:D6cTY4aGPYuSpPfItdfrHz5ar9evYJ1zCPMQO/67erk=,tag:y1RqgE9HpJopQmRIHZVUWA==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:ZKHcSZUynQ3kHacM39m7+5yfXLtP,iv:1eXumHWSD7tBJz3KZ+p5T1x0emaWOQbpaYIDQ85SOU8=,tag:5zEctiaSxylOEjWEHlcolg==,type:str]
+    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:BaATHLJHN1YMV464ZqhJEUgoKdgh,iv:vgEz5GcW4y6FWYKcU66crBO6vvR77ZKdnoi9ZP+U+B4=,tag:8ckmgQlmg5Anyc3a62scgg==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0VDQvcHZmaWttSnJqMHNm
-            TmxqWCt3eUVYcU5zSWRsM2p5N3BzMFI1c3dRCkdYblUyZHR5dVAxbDVtUXBQS0Y4
-            ZHgxeTdQbDlUc05JdEtPbjlOQmF0RlUKLS0tIERTUnZLT1I1aWZCczFTeWoyWnBH
-            ZmVmRGdGK2dkSllCRW5aeXg4Q0VtdkkKKUbzoLFtHJrxa0rxV0GOJFbcp5JEE0xY
-            +3+cvNnbxZcy7HhLY1OzJZ6UmPbZ6XXWSDyQ6lqLFgo2SrrlcT8XGA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhMjZNYzlwVUg1QWs0MnQz
+            Z3Zra21qVkJxUlRDb1JOcUN2MGFpSy9HTEJVCnJwZHBKUUh4SStNZDIxQ2syTGRI
+            YnQvOE8zaXV4aUZHWTVwUjFLZS9DYW8KLS0tIG52WWtTUEdHWThRdG1YZys5eXF6
+            cjBqMWlpSGh0ZVZwTDJBc1hxTWhVS28KVRrcFG8BqBGNdIsh+y2ZgyWDmQymR0xM
+            myQ0EQVDPn5O8j5f28JEprlUMsUkKgYMit3GnXTulfSC11njYbvoNQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-06T09:30:04Z"
-    mac: ENC[AES256_GCM,data:8Y2E7rVwDAOpaCgzlniv/C12PE9CVT0oChV6sVtjWKsIbGmn/KDZeY4JD0PvSVbRlSiNhVcbOrOFQeo51Z2HrO0Bo3N/AD8CsuJ+5KaQax8untr36Qnu5nWJovRul1OKfVEMx36AglDgkURkye3BiGKvjig6UR+BgC4iGEnlbt4=,iv:GjgRvxG6YjAV1MM3vYQ/f6KupO7frIkYo08P4JiWC5c=,tag:n7MWaFsdc7aU/qQuEiMkJA==,type:str]
+    lastmodified: "2026-05-06T14:09:38Z"
+    mac: ENC[AES256_GCM,data:okqlCU3Ial3MFr7JR8HUEncPWsUwMx7j7ENTzqipY2w3gz1FVIcvJ6YB6Ez368nIgm6j3ubSFlyXcvlBCgIC3MkfCARPewVKAuxfv+yqbpIQc1wA3yFoYTntIkteocfFEuyKfmSF9RDzVxkYeXRH0uohHZR1sqpeF+2FYmvOxYw=,iv:x5OmCdTYsb4HkGHoFQnMd+nn5wmC3H+hNHleay0JGGc=,tag:OVJmzAKIFOquDOeWi96Nfw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -1,32 +1,31 @@
-apiVersion: ENC[AES256_GCM,data:Vlw=,iv:hfLT3d1qeAUCjxGRzPMC1YN5/L3SPuDIaX6vaugU41k=,tag:o5bEJelfgshpVG/nLjFWsw==,type:str]
-kind: ENC[AES256_GCM,data:09oQtLV7,iv:NFWWfIuwD8uxhK7OsWxDkiF8oXTvRrCgicCIEWWhtxM=,tag:wctJRndiKNteL4Bp0F+6AA==,type:str]
+apiVersion: ENC[AES256_GCM,data:Te4=,iv:tScgIyONbDDDFCrq8zFPqqpJBLqko3ca+rwJf80MBPM=,tag:X7zt5JDFC5XnhFwM4H/9BQ==,type:str]
+kind: ENC[AES256_GCM,data:pN7n+OED,iv:KgSaGUTaxkCoAXk6RoBj83pMj1HivOPyZzaIskBg+FQ=,tag:ivCqWuu6VCvKXIsD5wVIEA==,type:str]
 metadata:
-    name: ENC[AES256_GCM,data:uoblEGX2VrgNtDNrafKkxA==,iv:0XOHj3sQ3UXzd/44bbKI0jycWPJ/Y9JYXtb7LnARcts=,tag:dS3xamWxjRMn7Bub1VpIyQ==,type:str]
-    namespace: ENC[AES256_GCM,data:Cfe73wnvXcrm5CuZI6VO+w==,iv:OMyb1yVE+l/2Fq17LnX+krWzccJnAdmtRZQk6m/CT2Y=,tag:YOlJFhTKSj4VtffzaCEQWw==,type:str]
-type: ENC[AES256_GCM,data:0VylXneq,iv:nu5OdzktnFZqSEfBXeGi3KJbsu+6cyPzAizKG4ke9B4=,tag:Cax2dU3QRDs4TafIvwQqHw==,type:str]
+    name: ENC[AES256_GCM,data:kKJM4nJQQAW87k26PwU6AA==,iv:fk3vJGoP/IxYXSHu0SxACyliNbqDMInY3sb4iaUDdnU=,tag:3pDklaj+ri/hXGvC4wuTDA==,type:str]
+    namespace: ENC[AES256_GCM,data:F9XJT2jk2Ut4VXSnCoZtuQ==,iv:FK7Xw4i00rsXIMFwXj7w5srVWpOdQByJ2IyLtjQ5+UQ=,tag:RToaAWLZMjdjadLoFeItag==,type:str]
+type: ENC[AES256_GCM,data:YfWTGRfB,iv:7ATo+iMAnkoXI3bkLmqWsr5WKqJaChkcBFPQrWkJA7Q=,tag:xd9ubfop/I019Fz52Vw9oQ==,type:str]
 stringData:
-    SPANBARN_API_KEY: ENC[AES256_GCM,data:2Ac6QH+zhhucN+DIy58XQga3+tLzk14LuCIReDqK/ngfL1fP93Hc6w==,iv:I5zAiH/jGEsjO7dP8GJo5bKSDKGo2QC6trnWgpbW6Tw=,tag:9Z4vY6Xh7JqNYWXkpiEq7Q==,type:str]
-    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:h7C7pKtGZbxBJ4Pz7PB7dA4RQTiQXQUypANZ4V/FgZLRUrR+qK4aat3OP97C/thIAMchH0fmvLsZHRS6s9SwpA==,iv:f9QfAxileABPNoSPkyOLA+U4s9WSgvEITu4uJtv+yDk=,tag:4JXA9g4OTtXx3toQ0tnVBA==,type:str]
-    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:Xm+plEuQGNt7tJOQ1Mtv1bB99vmHTnce4/T68p0xhHr60Jd/wPbsVg==,iv:ZwDG1ryqyqlnjSg99piDNpuAacK3hbHWRfxxvVogCaI=,tag:O1697r53lVh+4ic17yisZw==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:v8cT4U3mK33Op2EV/7HRoVe3CSFqfEChsC2V5IvDDOGXqmtHF41cXw==,iv:dui+38cPe5kifwM2xRE9uxZPaTaLsToEnfkTpvwJud8=,tag:6RNdPcxwNpWD/fHqRIgaMQ==,type:str]
-    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:t9cBosKBDg==,iv:f33ZpXX4zlI0HZt39xGUHqkUwTQ8J5Vk9WdzHxiT3Fk=,tag:adACtpvn9cvftwduCaUWSA==,type:str]
-    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:thwUWwY=,iv:OtTdW0atITfzcHu169OSpuopZ0az45a6DgQnuXVG9ro=,tag:bxMPthn0W+SVL97Lkie2kQ==,type:str]
-    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:OCj6/k3K9O4=,iv:rVq8ARBbbEzN2pDjZRjiv6D6XWZHD6G5jxTjmhSPE4w=,tag:naZE70XAagZLTrYJ+wDv1g==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:F57M7q/MFqVFTH1GLrMN2rJuIOGv,iv:pOmXZ/5hu6WEC0tYv7PdSzDklNIDJGXIVyaFORkiDGA=,tag:Yv+Yh4LpnWlGqnBfxJoEtw==,type:str]
-    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:A3JY2HQmTSqCUg+dFD+lPuQVHGiH,iv:9N4olT60UamlOSNRS+u+jvYLWVd27amE7DsBeuIszEQ=,tag:JItAVJd+BvjwyzCSFTEDMg==,type:str]
-    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:Ipgbh5p66eMe80yUT0zB3N2+6U7V,iv:XUI+LBOi1J2ltvHXt8hnChGkwSyvmExSumH4IQvAmjY=,tag:4oNHf6VV+haZawYhGcOCEA==,type:str]
+    SPANBARN_API_KEY: ENC[AES256_GCM,data:DDCV8ZJIhhAd5T1/wLiDortUDQZ9PbpQWe6heyzT+Mhh1gcjaqFsZQ==,iv:JBlWUKSxb4TpclZGuI4CiL0DjRdOG7fEj8utDxvPDg0=,tag:C7zz01kpK2DQFG7hdmP5Jw==,type:str]
+    SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:/ufJUQtmN2PNXzMW8GD0lBrvcoFAel5uUzqGAvePaV1UROgfIAOsXBOfeF5tQO1LOmR2wrS9FxxCsqkW8jdubQ==,iv:49a/FKyT/1tfnmJl1F4JzQjNXkHegKmZSbFZ62Xdzig=,tag:u/+qMPlxKSROnu18T/F5xQ==,type:str]
+    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:yhWB6DRX8AoE/aEmbmbzDCDez5MX7oR4xYFodwrLWx6kQojFq+bhiA==,iv:kttq/T650QDW200XN6+UqfT1hEy/EX69UOhfWprIqVo=,tag:CC6EqkYMKidUIwN52Pu6Ag==,type:str]
+    SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:BU/m+TCqIQ==,iv:2qaINE5MUI2K0h9v9bD9/x9yPlozkf6U59Xwp+E3fJo=,tag:LifQG7qfwS6xpZHo62nTOw==,type:str]
+    SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:K9MNb8M=,iv:OPpb4H6A69c/+ntore3/YyxWGjOuSvk4UAK2LYU8ZEo=,tag:J64RuFhndNrKI5QIJvD7/A==,type:str]
+    SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:jY2FsbfDbhs=,iv:ItEIc5ywvZWDzOMLWwNoxImA1bCJGmJ4HZXfm8d+Lr4=,tag:MpfkuraCqAXPwOkDfvGVeA==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:C0Ieasg2zVprMO1rybn5A3FBay+a,iv:xSrJw55qqLTbW0BL88gjfEOrMmkI2AnfnWrfhl78d50=,tag:/P7wGcFPgvBFDnDWCmirmQ==,type:str]
+    LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:iXy2nqXGalXEmTRmaynYOrE6GWqE,iv:8VJyT4Hh/9CHIJUFemTw2m3i/V1sFmO3vacq7RrTt1o=,tag:3xSSx+sUGkfWLceVYCq5CQ==,type:str]
+    LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:44G3bO0bgKkUAI3o4dqVAFhXVZZ6,iv:658FCrMUwBvHvI0vv8r0IR0XlGoeqTDxCC6LsM34iaM=,tag:7QXayVBT6l/Akg57C1EJSQ==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBURXQyL1BmTzFYc09yQmJI
-            WG83VDB4eTJDK25ZNnkzUGNzQVZHV0t1ZFJJCllPY0M4RTZkd3A2Y2tlTWN6MUpG
-            eWxDUDNkVzFEb3BRUjRuaVZpWUZ6ZUUKLS0tIG1qcW5IUzc1VllsbXh4SzlMRVlU
-            MWZoOUl0WHJNTjJuckc3ZjJWK3Z0TjgK2Vc+ZAzNh6PSggMy1LNx3Na/oLCVTvdL
-            ZdviFtpM7N+wUmk0CrB5cf20uDvgj5aeFZaud9zkB+cRgBByI+7e5w==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Y29XYUdnNHdzZlhxU203
+            VlBobk5LU0VpSnArOFVkVjJnaHlLeHpkOWpJCkRDeFRDcGM1QUg1VUxUanM4d0VM
+            YVhNcngwbXdpbXVYb0J5V202bnFCL2cKLS0tIEpwaWVMOWF2bUZ5YjBzSnhoNTZn
+            K0tidDJjR0FnVDFHUk5JcUdnazlvaGcKDYR+MZ+IaWCopVzDR7GLdcGGB0FQfBb7
+            zMEEqScFJOopEc1BA9u1AuFa15wWmHxnBAIAFo16yTKDSqkY0/dd7w==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-06T09:30:03Z"
-    mac: ENC[AES256_GCM,data:rEid38LZYHU7cxQM87W8VTufRRVPhRgEpTiB9BpqwjtL6gXHBY2HhcCoCboa/tPqqEEsmJ4sJ91EC1wUU5oF/L1GA7ibBTHcguhcIONOeOTG8k8dF0hCXP6l56yOdwQgPDxBYVoOfxy11L/US1jHP0ap3gvaqhDlV2HDVKLRkD8=,iv:AedT4KP8i8FwNnsxv0XW1pfTlp9Ddn7fDp/rweh588E=,tag:BWet+yYv94Mt4owfBZAN+w==,type:str]
+    lastmodified: "2026-05-06T14:09:29Z"
+    mac: ENC[AES256_GCM,data:4foEJha4i5r+aFEkDv54kTbFBcm/3krxrIxTEsNbKAk3MPrMe2KCt52lqIyE8nznlbH/xwaRQe6tYLOfegwRppJP4GLmNzz0O26IWF/i3NwB4eAjzTGHsnmuDoHWljVIFA6h6icwLxC/VopQ2Jo6S/yziTwv1RVAtstDTE/UMYM=,iv:Zp/7QaobTev3WRtpxKoJz3/vv8ACJtiOyDoxI3kaKD0=,tag:7DKU/tEgsZE+o/tDqXC5Bw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary
- Self-instrumentation OTLP exporter was getting 401 because `SPANBARN_SELF_API_KEY` differed from `SPANBARN_API_KEY`
- Removed `SPANBARN_SELF_API_KEY` from all env secrets so code falls back to `SPANBARN_API_KEY`

## Test plan
- [ ] Deploy to testing, verify `/v1/traces` no longer returns 401 in logs
- [ ] Verify traces appear in SpanBarn UI