### PR TITLE
fix: reset spool cursor after file rotation

### DIFF
--- a/internal/spool/spool.go
+++ b/internal/spool/spool.go
@@ -90,6 +90,7 @@ func (s *Spool) Write(records []model.SpanRecord) error {
 
 // Read reads records from the spool file starting at byte offset cursor.
 // It returns up to limit records and the next cursor position.
+// If the cursor is past the end of the file (e.g. after rotation), it resets to 0.
 func (s *Spool) Read(cursor int64, limit int) ([]model.SpanRecord, int64, error) {
 	path := filepath.Join(s.dir, spoolFileName)
 	f, err := os.Open(path)
@@ -102,8 +103,17 @@ func (s *Spool) Read(cursor int64, limit int) ([]model.SpanRecord, int64, error)
 	defer f.Close()
 
 	if cursor > 0 {
-		if _, err := f.Seek(cursor, io.SeekStart); err != nil {
-			return nil, cursor, fmt.Errorf("spool seek: %w", err)
+		info, err := f.Stat()
+		if err != nil {
+			return nil, cursor, fmt.Errorf("spool stat: %w", err)
+		}
+		if cursor > info.Size() {
+			cursor = 0
+		}
+		if cursor > 0 {
+			if _, err := f.Seek(cursor, io.SeekStart); err != nil {
+				return nil, cursor, fmt.Errorf("spool seek: %w", err)
+			}
 		}
 	}
 

--- a/internal/spool/spool_test.go
+++ b/internal/spool/spool_test.go
@@ -196,6 +196,57 @@ func TestSpoolRotation(t *testing.T) {
 	}
 }
 
+func TestSpoolReadResetsCursorAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	sp, err := NewSpool(dir, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sp.Close()
+
+	// Write enough to trigger rotation and save a cursor past the rotated file.
+	for batch := 0; batch < 5; batch++ {
+		if err := sp.Write(makeRecords(5)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Simulate a stale cursor pointing into the old (rotated) file.
+	staleCursor := int64(50000)
+	if err := sp.SaveCursor(staleCursor); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write new data to the current (post-rotation) spool file.
+	newRec := []model.SpanRecord{{
+		ProjectID: 1, SpanID: "after-rotation", Name: "op",
+		Service: "svc", Kind: "SERVER", Status: "OK",
+	}}
+	if err := sp.Write(newRec); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read with the stale cursor — should auto-reset and return the new data.
+	got, _, err := sp.Read(staleCursor, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 {
+		t.Fatal("Read() with stale cursor returned 0 records, expected auto-reset")
+	}
+
+	found := false
+	for _, r := range got {
+		if r.SpanID == "after-rotation" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected to find 'after-rotation' record after cursor reset")
+	}
+}
+
 func TestSpoolConcurrentWrites(t *testing.T) {
 	dir := t.TempDir()
 	sp, err := NewSpool(dir, DefaultMaxBytes)


### PR DESCRIPTION
## Summary

- After spool rotation (at 64 MiB), the worker cursor pointed past EOF of the new file, silently dropping all new spans until process restart
- Production was affected for ~5 hours — 36MB of spool data accumulated but was never processed
- Fixed by detecting cursor > file size and resetting to 0
- Added regression test for the stale-cursor-after-rotation scenario

## Test plan

- [x] `TestSpoolReadResetsCursorAfterRotation` — verifies data is readable after rotation with a stale cursor
- [x] `TestWorkerProcessesBatch` — verifies normal cursor advancement still works
- [x] Full test suite passes
- [x] Production cursor manually reset, writer restarted — 321 spans/min flowing again