### PR TITLE
fix: use local time for trace search date pickers

### DIFF
--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -21,14 +21,19 @@ type Filters = {
   to: string
 }
 
+function toLocalDatetime(d: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
 const defaultFilters = (): Filters => ({
   service: '',
   operation: '',
   status: '',
   minDurationMs: '',
   minSpans: '',
-  from: new Date(Date.now() - 3600_000).toISOString().slice(0, 16),
-  to: new Date().toISOString().slice(0, 16),
+  from: toLocalDatetime(new Date(Date.now() - 3600_000)),
+  to: toLocalDatetime(new Date()),
 })
 
 function filtersFromParams(params: URLSearchParams): Filters {


### PR DESCRIPTION
## Summary
- The From/To datetime pickers on the Traces page used `toISOString().slice(0,16)` which returns UTC, but `<input type="datetime-local">` interprets the value as local time — causing a 2-hour offset in CEST

## Fix
- Added `toLocalDatetime()` helper that formats using `getHours()`/`getMinutes()` (local) instead of the UTC-based ISO string