### PR TITLE
feat: clickable parent span navigation in waterfall

### DIFF
--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import type { Span } from '../api/types'
 import {
   formatDuration,
@@ -12,11 +12,19 @@ import './SpanTimeline.css'
 type Props = {
   span: Span
   traceStartTimeUs: number
+  onNavigateToSpan?: (spanId: string) => void
 }
 
 type Tab = 'overview' | 'attributes' | 'events'
 
-export function SpanDetail({ span, traceStartTimeUs }: Props) {
+const spanLinkStyle: React.CSSProperties = {
+  color: '#60a5fa',
+  cursor: 'pointer',
+  textDecoration: 'underline',
+  textUnderlineOffset: 2,
+}
+
+export function SpanDetail({ span, traceStartTimeUs, onNavigateToSpan }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>('overview')
 
   const attributes = parseAttributes(span.attributes)
@@ -90,7 +98,13 @@ export function SpanDetail({ span, traceStartTimeUs }: Props) {
           {span.parentSpanId && (
             <>
               <span className="span-detail-label">Parent Span ID</span>
-              <span className="span-detail-value">{span.parentSpanId}</span>
+              <span className="span-detail-value">
+                {onNavigateToSpan ? (
+                  <span style={spanLinkStyle} onClick={() => onNavigateToSpan(span.parentSpanId)}>
+                    {span.parentSpanId}
+                  </span>
+                ) : span.parentSpanId}
+              </span>
             </>
           )}
 

--- a/web/src/components/SpanWaterfall.tsx
+++ b/web/src/components/SpanWaterfall.tsx
@@ -35,6 +35,14 @@ export function SpanWaterfall({ spans, totalDurationUs }: Props) {
     setSelectedSpanId(selectedSpanId === spanId ? null : spanId)
   }
 
+  const navigateToSpan = (spanId: string) => {
+    setSelectedSpanId(spanId)
+    const row = document.querySelector(`[data-testid="waterfall-row-${spanId}"]`)
+    if (row) {
+      row.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }
+
   const handleMouseMove = (e: React.MouseEvent, span: Span) => {
     setHoveredSpanId(span.spanId)
     setTooltipPos({ x: e.clientX + 12, y: e.clientY + 12 })
@@ -109,6 +117,7 @@ export function SpanWaterfall({ spans, totalDurationUs }: Props) {
               <SpanDetail
                 span={span}
                 traceStartTimeUs={traceStartTimeUs}
+                onNavigateToSpan={navigateToSpan}
               />
             )}
           </React.Fragment>


### PR DESCRIPTION
## Summary
- Parent Span ID in the span detail panel is now a clickable link
- Clicking it scrolls to and selects that span in the waterfall, making it easy to navigate up the call chain

## Test plan
- [ ] Open a trace with nested spans
- [ ] Click a child span to open its detail
- [ ] Click the parent span ID link — should scroll to and open the parent span's detail