### PR TITLE
feat: performance, tiered retention, and dashboard features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Self-hosted telemetry aggregator. Lightweight OTLP-compatible tracing with intel
 
 SpanBarn collects distributed traces from your applications and gives you performance visibility without the operational overhead of Jaeger, Tempo, or Datadog.
 
-**Smart retention**: full-fidelity spans are kept for a configurable window (default: 4 hours). After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept indefinitely. Error and slow spans are sampled and preserved in detail. Uneventful spans are dropped.
+**Smart retention**: full-fidelity spans are kept for a configurable window (default: 72 hours). Error and slow spans get extended retention (default: 7 days). After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept for 30 days. Uneventful spans are dropped first; interesting spans are preserved longer.
 
 This gives you:
-- **Recent debugging**: full traces for the last few hours to investigate live issues
+- **Recent debugging**: full traces for the last 72 hours to investigate live issues
 - **Long-term trends**: aggregated latency/throughput/error-rate timeseries per service, route, operation, and dependency
 - **Error forensics**: detailed error spans kept with full context regardless of age
 - **Dependency visibility**: S3, database, HTTP, gRPC call performance broken down by target
@@ -182,12 +182,15 @@ spanbarn apikey create --project=my-app --scope=ingest
 | `SPANBARN_ADMIN_PASSWORD` | | Dashboard login password |
 | `SPANBARN_SESSION_SECRET` | | HMAC key for sessions |
 | `SPANBARN_SESSION_TTL_SECONDS` | `43200` | Session lifetime (12h) |
-| `SPANBARN_MAX_BODY_BYTES` | `4194304` | Max ingest body (4 MiB) |
+| `SPANBARN_MAX_BODY_BYTES` | `1048576` | Max ingest body (1 MiB) |
 | `SPANBARN_MAX_SPOOL_BYTES` | | Spool backpressure limit |
-| `SPANBARN_RETENTION_FULL_HOURS` | `4` | Hours to keep full spans |
-| `SPANBARN_RETENTION_AGGREGATED_DAYS` | `365` | Days to keep aggregates |
-| `SPANBARN_RETENTION_ERROR_DAYS` | `30` | Days to keep error samples |
-| `SPANBARN_SLOW_THRESHOLD_MS` | `1000` | Slow span threshold |
+| `SPANBARN_RETENTION_FULL_HOURS` | `72` | Hours to keep all spans |
+| `SPANBARN_RETENTION_INTERESTING_HOURS` | `168` | Hours to keep error/slow spans (7 days) |
+| `SPANBARN_RETENTION_AGGREGATED_DAYS` | `30` | Days to keep aggregates |
+| `SPANBARN_RETENTION_ERROR_DAYS` | `90` | Days to keep error samples |
+| `SPANBARN_INGEST_SAMPLE_RATE` | `1.0` | Fraction of normal spans to keep (0-1, 1=keep all) |
+| `SPANBARN_SLOW_THRESHOLD_MS` | `500` | Slow span threshold (ms) |
+| `SPANBARN_QUERY_TIMEOUT_SECONDS` | `30` | Query timeout for dashboard queries |
 | `SPANBARN_AGGREGATION_INTERVAL` | `1m` | Aggregation bucket size |
 | `SPANBARN_ALLOWED_ORIGINS` | `*` | CORS origins (CSV) |
 | `SPANBARN_SELF_ENDPOINT` | | Self-reporting endpoint |

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -84,6 +84,9 @@ func run() error {
 	logger.Info("storage", "path", cfg.DBPath)
 
 	repo := repository.NewRepository(db.DB)
+	if cfg.QueryTimeoutSeconds > 0 {
+		repo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
+	}
 
 	if cfg.AdminUsername != "" && cfg.AdminPassword != "" {
 		if err := bootstrapAdmin(repo, cfg, logger); err != nil {
@@ -107,6 +110,9 @@ func run() error {
 	ingestHandler.Start(ctx)
 
 	w := worker.NewWorker(eventSpool, &workerRepoAdapter{repo: repo}, logger)
+	if cfg.IngestSampleRate < 1.0 {
+		w.SetIngestSampling(cfg.IngestSampleRate, int64(cfg.SlowThresholdMS)*1000)
+	}
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("worker", func() { w.Run(workerCtx) })
@@ -115,10 +121,11 @@ func run() error {
 	aggregator := aggregation.NewAggregator(repo, aggInterval, logger)
 
 	retentionCfg := retention.Config{
-		FullRetentionHours:     cfg.RetentionFullHours,
-		ErrorRetentionDays:     cfg.RetentionErrorDays,
-		AggregateRetentionDays: cfg.RetentionAggregatedDays,
-		SlowThresholdUS:        int64(cfg.SlowThresholdMS) * 1000,
+		FullRetentionHours:        cfg.RetentionFullHours,
+		InterestingRetentionHours: cfg.RetentionInterestingHours,
+		ErrorRetentionDays:        cfg.RetentionErrorDays,
+		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
+		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
 	}
 	retentionWorker := retention.NewRetentionWorker(repo, aggregator, retentionCfg, logger)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)

--- a/internal/aggregation/aggregator.go
+++ b/internal/aggregation/aggregator.go
@@ -18,6 +18,7 @@ var tracer = otel.Tracer("spanbarn/aggregation")
 // AggregateWriter is the subset of repository methods needed to persist aggregates.
 type AggregateWriter interface {
 	UpsertAggregate(agg repository.Aggregate) error
+	UpsertAggregates(aggs []repository.Aggregate) error
 }
 
 // Aggregator groups raw spans into bucketed aggregates.
@@ -111,19 +112,16 @@ func (a *Aggregator) AggregateSpans(ctx context.Context, spans []repository.Span
 	return out, nil
 }
 
-// Persist writes each aggregate to the repository via UpsertAggregate.
+// Persist writes all aggregates to the repository in a single transaction.
 func (a *Aggregator) Persist(ctx context.Context, aggregates []repository.Aggregate) error {
 	_, span := tracer.Start(ctx, "aggregation.persist")
 	span.SetAttributes(attribute.Int("aggregate_count", len(aggregates)))
 	defer span.End()
 
-	for _, agg := range aggregates {
-		if err := a.repo.UpsertAggregate(agg); err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			return fmt.Errorf("upsert aggregate for %s/%s bucket %s: %w",
-				agg.Service, agg.Operation, agg.Bucket.Format(time.RFC3339), err)
-		}
+	if err := a.repo.UpsertAggregates(aggregates); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("upsert %d aggregates: %w", len(aggregates), err)
 	}
 	a.logger.Info("persisted aggregates", "count", len(aggregates))
 	return nil

--- a/internal/aggregation/aggregator_test.go
+++ b/internal/aggregation/aggregator_test.go
@@ -9,13 +9,18 @@ import (
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
 
-// mockWriter records calls to UpsertAggregate.
+// mockWriter records calls to UpsertAggregate/UpsertAggregates.
 type mockWriter struct {
 	calls []repository.Aggregate
 }
 
 func (m *mockWriter) UpsertAggregate(agg repository.Aggregate) error {
 	m.calls = append(m.calls, agg)
+	return nil
+}
+
+func (m *mockWriter) UpsertAggregates(aggs []repository.Aggregate) error {
+	m.calls = append(m.calls, aggs...)
 	return nil
 }
 

--- a/internal/api/export.go
+++ b/internal/api/export.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type exportHandlers struct {
+	repo *repository.Repository
+}
+
+func (h *exportHandlers) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+
+	filter := repository.SpanFilter{
+		From:    from,
+		To:      to,
+		Service: r.URL.Query().Get("service"),
+		Status:  r.URL.Query().Get("status"),
+		Limit:   100000,
+	}
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			filter.Limit = n
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Content-Disposition", "attachment; filename=spans.ndjson")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, _ := w.(http.Flusher)
+	enc := json.NewEncoder(w)
+
+	_ = h.repo.StreamSpans(filter, func(s repository.Span) error {
+		if err := enc.Encode(s); err != nil {
+			return err
+		}
+		if flusher != nil {
+			flusher.Flush()
+		}
+		return nil
+	})
+}

--- a/internal/api/livetail.go
+++ b/internal/api/livetail.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/wiebe-xyz/spanbarn/internal/livetail"
+)
+
+type liveTailHandler struct {
+	broadcaster *livetail.Broadcaster
+}
+
+func (h *liveTailHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, "streaming not supported", "")
+		return
+	}
+
+	serviceFilter := r.URL.Query().Get("service")
+	statusFilter := r.URL.Query().Get("status")
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	sub := h.broadcaster.Subscribe(256)
+	defer h.broadcaster.Unsubscribe(sub)
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case record := <-sub.C:
+			if serviceFilter != "" && record.Service != serviceFilter {
+				continue
+			}
+			if statusFilter != "" && record.Status != statusFilter {
+				continue
+			}
+
+			data, err := json.Marshal(record)
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -187,6 +187,17 @@ func authorizerOrBearerAuth(a *auth.Authorizer, next http.Handler) http.Handler 
 	})
 }
 
+// cacheMiddleware sets Cache-Control on successful GET responses.
+func cacheMiddleware(maxAge int, next http.Handler) http.Handler {
+	val := fmt.Sprintf("private, max-age=%d", maxAge)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.Header().Set("Cache-Control", val)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func originAllowed(origin string, allowed []string) bool {
 	for _, a := range allowed {
 		if a == "*" || a == origin {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -262,6 +262,32 @@ func (h *queryHandlers) handleDatabaseQueryDetail(w http.ResponseWriter, r *http
 	writeJSON(w, http.StatusOK, spans)
 }
 
+func (h *queryHandlers) handleServiceMap(w http.ResponseWriter, r *http.Request) {
+	ctx, span := apiTracer.Start(r.Context(), "api.query.service_map")
+	defer span.End()
+
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+
+	projectID := parseInt64Param(r, "project_id", 0)
+
+	sm, err := h.svc.GetServiceMap(ctx, projectID, from, to)
+	if err != nil {
+		writeServerError(w, r, "query failed", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, sm)
+}
+
 // routeQuery is a handler that dispatches query routes based on URL path pattern.
 // It handles the following patterns:
 //

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -38,19 +38,29 @@ func (s *Server) registerRoutes() {
 	s.mux.Handle("/v1/traces", ingestRL(otlpAuth(http.HandlerFunc(s.handleOTLP))))
 
 	// Query endpoints — rate limited + session auth required.
+	// List/aggregate endpoints get a short cache (30s); detail endpoints are not cached.
 	if s.querySvc != nil && s.sessionMgr != nil {
 		qh := &queryHandlers{svc: s.querySvc}
 		sessionAuth := SessionMiddleware(s.sessionMgr)
+		cache30 := func(h http.Handler) http.Handler { return cacheMiddleware(30, h) }
 
-		s.mux.Handle("/api/v1/services", apiRL(sessionAuth(http.HandlerFunc(qh.handleServices))))
-		s.mux.Handle("/api/v1/services/", apiRL(sessionAuth(qh)))
-		s.mux.Handle("/api/v1/traces", apiRL(sessionAuth(http.HandlerFunc(qh.handleTraces))))
-		s.mux.Handle("/api/v1/traces/", apiRL(sessionAuth(qh)))
-		s.mux.Handle("/api/v1/dependencies", apiRL(sessionAuth(http.HandlerFunc(qh.handleDependencies))))
-		s.mux.Handle("/api/v1/database", apiRL(sessionAuth(http.HandlerFunc(qh.handleDatabaseQueries))))
+		s.mux.Handle("/api/v1/services", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handleServices)))))
+		s.mux.Handle("/api/v1/services/", apiRL(sessionAuth(cache30(qh))))
+		s.mux.Handle("/api/v1/traces", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handleTraces)))))
+		s.mux.Handle("/api/v1/traces/", apiRL(sessionAuth(http.HandlerFunc(qh.handleTraceDetail))))
+		s.mux.Handle("/api/v1/dependencies", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handleDependencies)))))
+		s.mux.Handle("/api/v1/database", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handleDatabaseQueries)))))
 		s.mux.Handle("/api/v1/database/detail", apiRL(sessionAuth(http.HandlerFunc(qh.handleDatabaseQueryDetail))))
-		s.mux.Handle("/api/v1/prompts", apiRL(sessionAuth(http.HandlerFunc(qh.handlePrompts))))
+		s.mux.Handle("/api/v1/prompts", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handlePrompts)))))
 		s.mux.Handle("/api/v1/prompts/detail", apiRL(sessionAuth(http.HandlerFunc(qh.handlePromptDetail))))
+		s.mux.Handle("/api/v1/service-map", apiRL(sessionAuth(cache30(http.HandlerFunc(qh.handleServiceMap)))))
+	}
+
+	// Live tail SSE endpoint — session auth required.
+	if s.ingest != nil && s.sessionMgr != nil {
+		lth := &liveTailHandler{broadcaster: s.ingest.Broadcaster()}
+		sessionAuth := SessionMiddleware(s.sessionMgr)
+		s.mux.Handle("/api/v1/spans/live", sessionAuth(lth))
 	}
 
 	// Alert endpoints — rate limited + session auth required.
@@ -69,6 +79,23 @@ func (s *Server) registerRoutes() {
 
 		s.mux.Handle("/api/v1/settings", apiRL(sessionAuth(sh)))
 		s.mux.Handle("/api/v1/stats", apiRL(sessionAuth(sh)))
+	}
+
+	// Saved queries endpoints — rate limited + session auth required.
+	if s.repo != nil && s.sessionMgr != nil {
+		sqh := &savedQueryHandlers{repo: s.repo}
+		sessionAuth := SessionMiddleware(s.sessionMgr)
+
+		s.mux.Handle("/api/v1/saved-queries", apiRL(sessionAuth(sqh)))
+		s.mux.Handle("/api/v1/saved-queries/", apiRL(sessionAuth(sqh)))
+	}
+
+	// Export endpoint — rate limited + session auth required, streams NDJSON.
+	if s.repo != nil && s.sessionMgr != nil {
+		eh := &exportHandlers{repo: s.repo}
+		sessionAuth := SessionMiddleware(s.sessionMgr)
+
+		s.mux.Handle("/api/v1/export", apiRL(sessionAuth(eh)))
 	}
 
 	// Setup endpoint — public, no auth required.

--- a/internal/api/saved_queries.go
+++ b/internal/api/saved_queries.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type savedQueryHandlers struct {
+	repo *repository.Repository
+}
+
+func (h *savedQueryHandlers) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimSuffix(r.URL.Path, "/")
+
+	switch {
+	case path == "/api/v1/saved-queries" && r.Method == http.MethodGet:
+		h.handleList(w, r)
+	case path == "/api/v1/saved-queries" && r.Method == http.MethodPost:
+		h.handleCreate(w, r)
+	case strings.HasPrefix(path, "/api/v1/saved-queries/") && r.Method == http.MethodDelete:
+		h.handleDelete(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
+}
+
+func (h *savedQueryHandlers) handleList(w http.ResponseWriter, r *http.Request) {
+	projectID := parseInt64Param(r, "project_id", 1)
+	queries, err := h.repo.ListSavedQueries(projectID)
+	if err != nil {
+		writeServerError(w, r, "failed to list saved queries", err)
+		return
+	}
+	if queries == nil {
+		queries = []repository.SavedQuery{}
+	}
+	writeJSON(w, http.StatusOK, queries)
+}
+
+func (h *savedQueryHandlers) handleCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ProjectID     int64  `json:"projectId"`
+		Name          string `json:"name"`
+		Service       string `json:"service"`
+		Operation     string `json:"operation"`
+		Status        string `json:"status"`
+		MinDurationUs int64  `json:"minDurationUs"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
+		return
+	}
+	if body.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required", "")
+		return
+	}
+	if body.ProjectID == 0 {
+		body.ProjectID = 1
+	}
+
+	id, err := h.repo.CreateSavedQuery(repository.SavedQuery{
+		ProjectID:     body.ProjectID,
+		Name:          body.Name,
+		Service:       body.Service,
+		Operation:     body.Operation,
+		Status:        body.Status,
+		MinDurationUs: body.MinDurationUs,
+	})
+	if err != nil {
+		writeServerError(w, r, "failed to create saved query", err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]int64{"id": id})
+}
+
+func (h *savedQueryHandlers) handleDelete(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(r.URL.Path, "/")
+	if len(parts) < 5 {
+		writeError(w, http.StatusBadRequest, "missing id", "")
+		return
+	}
+	id, err := strconv.ParseInt(parts[4], 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid id", "")
+		return
+	}
+	if err := h.repo.DeleteSavedQuery(id); err != nil {
+		writeServerError(w, r, "failed to delete saved query", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -53,9 +53,11 @@ func (h *settingsHandlers) handleUpdateSettings(w http.ResponseWriter, r *http.R
 	}
 
 	allowed := map[string]bool{
-		"retention_full_hours":      true,
-		"retention_aggregated_days": true,
-		"retention_error_days":      true,
+		"retention_full_hours":        true,
+		"retention_interesting_hours": true,
+		"retention_aggregated_days":   true,
+		"retention_error_days":        true,
+		"ingest_sample_rate":          true,
 	}
 
 	for k, v := range body {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,8 +24,10 @@ type Config struct {
 	RetentionFullHours     int
 	RetentionAggregatedDays int
 	RetentionErrorDays     int
-	SlowThresholdMS        int
-	AggregationInterval    string
+	RetentionInterestingHours int
+	IngestSampleRate          float64
+	SlowThresholdMS           int
+	AggregationInterval       string
 	AllowedOrigins         []string
 	SelfEndpoint           string
 	SelfAPIKey             string
@@ -36,6 +38,7 @@ type Config struct {
 	IngestRatePerMinute    int
 	APIRatePerMinute       int
 	MetricsToken           string
+	QueryTimeoutSeconds    int
 	Mode                   string // "writer" (default) or "ingest"
 	WriterURL              string // URL of writer pod, used when Mode=ingest
 }
@@ -59,7 +62,9 @@ func Load() Config {
 		RetentionFullHours:      getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
 		RetentionAggregatedDays: getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
 		RetentionErrorDays:      getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
-		SlowThresholdMS:         getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
+		RetentionInterestingHours: getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
+		IngestSampleRate:          getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
+		SlowThresholdMS:           getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:     getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),
 		SelfEndpoint:            os.Getenv("SPANBARN_SELF_ENDPOINT"),
 		SelfAPIKey:              os.Getenv("SPANBARN_SELF_API_KEY"),
@@ -70,6 +75,7 @@ func Load() Config {
 		IngestRatePerMinute:     getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),
 		APIRatePerMinute:        getenvInt("SPANBARN_API_RATE_PER_MINUTE", 300),
 		MetricsToken:            os.Getenv("SPANBARN_METRICS_TOKEN"),
+		QueryTimeoutSeconds:     getenvInt("SPANBARN_QUERY_TIMEOUT_SECONDS", 30),
 		Mode:                    getenv("SPANBARN_MODE", "writer"),
 		WriterURL:               os.Getenv("SPANBARN_WRITER_URL"),
 	}
@@ -104,6 +110,15 @@ func getenvInt(key string, fallback int) int {
 func getenvInt64(key string, fallback int64) int64 {
 	if raw := os.Getenv(key); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return fallback
+}
+
+func getenvFloat(key string, fallback float64) float64 {
+	if raw := os.Getenv(key); raw != "" {
+		if parsed, err := strconv.ParseFloat(raw, 64); err == nil && parsed >= 0 && parsed <= 1 {
 			return parsed
 		}
 	}

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/wiebe-xyz/spanbarn/internal/livetail"
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 	"github.com/wiebe-xyz/spanbarn/internal/spool"
 )
@@ -27,6 +28,7 @@ type Handler struct {
 	spool         *spool.Spool
 	flushInterval time.Duration
 	logger        *slog.Logger
+	broadcaster   *livetail.Broadcaster
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -45,7 +47,13 @@ func NewHandler(queue *Queue, sp *spool.Spool, flushInterval time.Duration, logg
 		spool:         sp,
 		flushInterval: flushInterval,
 		logger:        logger,
+		broadcaster:   livetail.NewBroadcaster(),
 	}
+}
+
+// Broadcaster returns the live tail broadcaster for SSE streaming.
+func (h *Handler) Broadcaster() *livetail.Broadcaster {
+	return h.broadcaster
 }
 
 // Start begins the background flush goroutine.
@@ -55,8 +63,9 @@ func (h *Handler) Start(ctx context.Context) {
 	go h.flushLoop(ctx)
 }
 
-// Enqueue delegates to the underlying queue.
+// Enqueue delegates to the underlying queue and publishes to live tail.
 func (h *Handler) Enqueue(record model.SpanRecord) bool {
+	h.broadcaster.Publish(record)
 	return h.queue.Enqueue(record)
 }
 

--- a/internal/livetail/broadcast.go
+++ b/internal/livetail/broadcast.go
@@ -1,0 +1,71 @@
+package livetail
+
+import (
+	"sync"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+type Subscriber struct {
+	C      chan model.SpanRecord
+	done   chan struct{}
+	closed bool
+	mu     sync.Mutex
+}
+
+func (s *Subscriber) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		s.closed = true
+		close(s.done)
+	}
+}
+
+type Broadcaster struct {
+	mu   sync.RWMutex
+	subs map[*Subscriber]struct{}
+}
+
+func NewBroadcaster() *Broadcaster {
+	return &Broadcaster{subs: make(map[*Subscriber]struct{})}
+}
+
+func (b *Broadcaster) Subscribe(bufSize int) *Subscriber {
+	if bufSize <= 0 {
+		bufSize = 100
+	}
+	s := &Subscriber{
+		C:    make(chan model.SpanRecord, bufSize),
+		done: make(chan struct{}),
+	}
+	b.mu.Lock()
+	b.subs[s] = struct{}{}
+	b.mu.Unlock()
+	return s
+}
+
+func (b *Broadcaster) Unsubscribe(s *Subscriber) {
+	b.mu.Lock()
+	delete(b.subs, s)
+	b.mu.Unlock()
+	s.Close()
+}
+
+func (b *Broadcaster) Publish(record model.SpanRecord) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for s := range b.subs {
+		select {
+		case s.C <- record:
+		default:
+			// drop if subscriber is slow
+		}
+	}
+}
+
+func (b *Broadcaster) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}

--- a/internal/repository/migrations/006_saved_queries.go
+++ b/internal/repository/migrations/006_saved_queries.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up006, down006)
+}
+
+func up006(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS saved_queries (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id INTEGER NOT NULL REFERENCES projects(id),
+			name       TEXT NOT NULL,
+			service    TEXT NOT NULL DEFAULT '',
+			operation  TEXT NOT NULL DEFAULT '',
+			status     TEXT NOT NULL DEFAULT '',
+			min_duration_us INTEGER NOT NULL DEFAULT 0,
+			created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+		);
+		CREATE INDEX IF NOT EXISTS idx_saved_queries_project ON saved_queries(project_id);
+	`)
+	return err
+}
+
+func down006(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS saved_queries`)
+	return err
+}

--- a/internal/repository/repo_aggregates.go
+++ b/internal/repository/repo_aggregates.go
@@ -26,6 +26,45 @@ func (r *Repository) UpsertAggregate(agg Aggregate) error {
 	return err
 }
 
+func (r *Repository) UpsertAggregates(aggs []Aggregate) error {
+	if len(aggs) == 0 {
+		return nil
+	}
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`INSERT INTO aggregates
+		(project_id, service, operation, resource, kind, bucket, count, error_count, p50_us, p95_us, p99_us, max_us, sum_duration_us)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project_id, service, operation, resource, kind, bucket)
+		DO UPDATE SET
+			count = count + excluded.count,
+			error_count = error_count + excluded.error_count,
+			p50_us = excluded.p50_us,
+			p95_us = excluded.p95_us,
+			p99_us = excluded.p99_us,
+			max_us = MAX(max_us, excluded.max_us),
+			sum_duration_us = sum_duration_us + excluded.sum_duration_us`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, agg := range aggs {
+		if _, err := stmt.Exec(
+			agg.ProjectID, agg.Service, agg.Operation, agg.Resource, agg.Kind,
+			agg.Bucket, agg.Count, agg.ErrorCount,
+			agg.P50Us, agg.P95Us, agg.P99Us, agg.MaxUs, agg.SumDurationUs,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 func (r *Repository) QueryAggregates(f AggregateFilter) ([]Aggregate, error) {
 	var where []string
 	var args []any
@@ -66,7 +105,9 @@ func (r *Repository) QueryAggregates(f AggregateFilter) ([]Aggregate, error) {
 		q += fmt.Sprintf(" OFFSET %d", f.Offset)
 	}
 
-	rows, err := r.db.Query(q, args...)
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/repo_saved_queries.go
+++ b/internal/repository/repo_saved_queries.go
@@ -1,0 +1,53 @@
+package repository
+
+import "time"
+
+type SavedQuery struct {
+	ID           int64     `json:"id"`
+	ProjectID    int64     `json:"projectId"`
+	Name         string    `json:"name"`
+	Service      string    `json:"service"`
+	Operation    string    `json:"operation"`
+	Status       string    `json:"status"`
+	MinDurationUs int64    `json:"minDurationUs"`
+	CreatedAt    time.Time `json:"createdAt"`
+}
+
+func (r *Repository) CreateSavedQuery(q SavedQuery) (int64, error) {
+	res, err := r.db.Exec(`INSERT INTO saved_queries
+		(project_id, name, service, operation, status, min_duration_us)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		q.ProjectID, q.Name, q.Service, q.Operation, q.Status, q.MinDurationUs,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+func (r *Repository) ListSavedQueries(projectID int64) ([]SavedQuery, error) {
+	rows, err := r.db.Query(
+		`SELECT id, project_id, name, service, operation, status, min_duration_us, created_at
+		FROM saved_queries WHERE project_id = ? ORDER BY created_at DESC`,
+		projectID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []SavedQuery
+	for rows.Next() {
+		var q SavedQuery
+		if err := rows.Scan(&q.ID, &q.ProjectID, &q.Name, &q.Service, &q.Operation, &q.Status, &q.MinDurationUs, &q.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, q)
+	}
+	return out, rows.Err()
+}
+
+func (r *Repository) DeleteSavedQuery(id int64) error {
+	_, err := r.db.Exec("DELETE FROM saved_queries WHERE id = ?", id)
+	return err
+}

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -132,6 +132,26 @@ func (r *Repository) DeleteSpansByIDs(ids []int64) (int64, error) {
 	return res.RowsAffected()
 }
 
+func (r *Repository) DeleteSpansByMaxID(maxID int64) (int64, error) {
+	res, err := r.db.Exec("DELETE FROM spans WHERE id <= ?", maxID)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (r *Repository) DeleteBoringSpans(olderThan, newerThan time.Time, slowThresholdUS int64) (int64, error) {
+	res, err := r.db.Exec(`DELETE FROM spans
+		WHERE ingested_at < ? AND ingested_at >= ?
+		AND status NOT IN ('error','ERROR','Error')
+		AND duration_us <= ?`,
+		olderThan, newerThan, slowThresholdUS)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
 	res, err := r.db.Exec("DELETE FROM spans WHERE ingested_at < ?", cutoff)
 	if err != nil {
@@ -150,8 +170,78 @@ func (r *Repository) GetSpansForAggregation(cutoff time.Time, limit int) ([]Span
 	)
 }
 
+func (r *Repository) StreamSpans(f SpanFilter, fn func(Span) error) error {
+	var where []string
+	var args []any
+
+	if f.ProjectID != 0 {
+		where = append(where, "project_id = ?")
+		args = append(args, f.ProjectID)
+	}
+	if f.Service != "" {
+		where = append(where, "service = ?")
+		args = append(args, f.Service)
+	}
+	if f.Operation != "" {
+		where = append(where, "name = ?")
+		args = append(args, f.Operation)
+	}
+	if f.Status != "" {
+		where = append(where, "status = ?")
+		args = append(args, f.Status)
+	}
+	if f.MinDuration > 0 {
+		where = append(where, "duration_us >= ?")
+		args = append(args, f.MinDuration)
+	}
+	if !f.From.IsZero() {
+		where = append(where, "ingested_at >= ?")
+		args = append(args, f.From)
+	}
+	if !f.To.IsZero() {
+		where = append(where, "ingested_at <= ?")
+		args = append(args, f.To)
+	}
+
+	q := "SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at FROM spans"
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	q += " ORDER BY ingested_at DESC"
+
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100000
+	}
+	q += fmt.Sprintf(" LIMIT %d", limit)
+
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var s Span
+		if err := rows.Scan(
+			&s.ID, &s.ProjectID, &s.TraceID, &s.SpanID, &s.ParentSpanID,
+			&s.Name, &s.Service, &s.Resource, &s.Kind, &s.Status,
+			&s.StartTimeUs, &s.DurationUs, &s.Attributes, &s.Events, &s.IngestedAt,
+		); err != nil {
+			return err
+		}
+		if err := fn(s); err != nil {
+			return err
+		}
+	}
+	return rows.Err()
+}
+
 func (r *Repository) scanSpans(query string, args ...any) ([]Span, error) {
-	rows, err := r.db.Query(query, args...)
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -196,13 +286,15 @@ func (r *Repository) QueryServiceStatsFromSpans(projectID int64, from, to time.T
 		args = append(args, to)
 	}
 
-	q := "SELECT service, COUNT(*) as cnt, SUM(CASE WHEN status IN ('error','ERROR','Error') THEN 1 ELSE 0 END) as err_cnt FROM spans"
+	q := `SELECT service, duration_us, CASE WHEN status IN ('error','ERROR','Error') THEN 1 ELSE 0 END as is_error FROM spans`
 	if len(where) > 0 {
 		q += " WHERE " + strings.Join(where, " AND ")
 	}
-	q += " GROUP BY service"
+	q += " ORDER BY service, duration_us"
 
-	rows, err := r.db.Query(q, args...)
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -212,52 +304,22 @@ func (r *Repository) QueryServiceStatsFromSpans(projectID int64, from, to time.T
 	var order []string
 	for rows.Next() {
 		var svc string
-		var cnt, errCnt int64
-		if err := rows.Scan(&svc, &cnt, &errCnt); err != nil {
+		var dur, isError int64
+		if err := rows.Scan(&svc, &dur, &isError); err != nil {
 			return nil, err
 		}
-		statsMap[svc] = &ServiceStats{Service: svc, Count: cnt, ErrorCount: errCnt}
-		order = append(order, svc)
+		s, ok := statsMap[svc]
+		if !ok {
+			s = &ServiceStats{Service: svc}
+			statsMap[svc] = s
+			order = append(order, svc)
+		}
+		s.Count++
+		s.ErrorCount += isError
+		s.Durations = append(s.Durations, dur)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
-	}
-
-	for _, svc := range order {
-		dq := "SELECT duration_us FROM spans WHERE service = ?"
-		dargs := []any{svc}
-		if projectID != 0 {
-			dq += " AND project_id = ?"
-			dargs = append(dargs, projectID)
-		}
-		if !from.IsZero() {
-			dq += " AND ingested_at >= ?"
-			dargs = append(dargs, from)
-		}
-		if !to.IsZero() {
-			dq += " AND ingested_at <= ?"
-			dargs = append(dargs, to)
-		}
-		dq += " ORDER BY duration_us"
-
-		drows, err := r.db.Query(dq, dargs...)
-		if err != nil {
-			return nil, err
-		}
-		var durations []int64
-		for drows.Next() {
-			var d int64
-			if err := drows.Scan(&d); err != nil {
-				drows.Close()
-				return nil, err
-			}
-			durations = append(durations, d)
-		}
-		drows.Close()
-		if err := drows.Err(); err != nil {
-			return nil, err
-		}
-		statsMap[svc].Durations = durations
 	}
 
 	result := make([]ServiceStats, 0, len(order))
@@ -296,11 +358,12 @@ func (r *Repository) QueryOperationStatsFromSpans(projectID int64, service strin
 		args = append(args, to)
 	}
 
-	q := `SELECT name, resource, kind, COUNT(*) as cnt,
-		SUM(CASE WHEN status IN ('error','ERROR','Error') THEN 1 ELSE 0 END) as err_cnt
-		FROM spans WHERE ` + strings.Join(where, " AND ") + ` GROUP BY name, resource, kind`
+	q := `SELECT name, resource, kind, duration_us, CASE WHEN status IN ('error','ERROR','Error') THEN 1 ELSE 0 END as is_error
+		FROM spans WHERE ` + strings.Join(where, " AND ") + ` ORDER BY name, resource, kind, duration_us`
 
-	rows, err := r.db.Query(q, args...)
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -311,53 +374,23 @@ func (r *Repository) QueryOperationStatsFromSpans(projectID int64, service strin
 	var order []opKey
 	for rows.Next() {
 		var name, resource, kind string
-		var cnt, errCnt int64
-		if err := rows.Scan(&name, &resource, &kind, &cnt, &errCnt); err != nil {
+		var dur, isError int64
+		if err := rows.Scan(&name, &resource, &kind, &dur, &isError); err != nil {
 			return nil, err
 		}
 		k := opKey{name, resource, kind}
-		statsMap[k] = &OperationStats{Operation: name, Resource: resource, Kind: kind, Count: cnt, ErrorCount: errCnt}
-		order = append(order, k)
+		s, ok := statsMap[k]
+		if !ok {
+			s = &OperationStats{Operation: name, Resource: resource, Kind: kind}
+			statsMap[k] = s
+			order = append(order, k)
+		}
+		s.Count++
+		s.ErrorCount += isError
+		s.Durations = append(s.Durations, dur)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
-	}
-
-	for _, k := range order {
-		dq := "SELECT duration_us FROM spans WHERE service = ? AND name = ? AND resource = ? AND kind = ?"
-		dargs := []any{service, k.name, k.resource, k.kind}
-		if projectID != 0 {
-			dq += " AND project_id = ?"
-			dargs = append(dargs, projectID)
-		}
-		if !from.IsZero() {
-			dq += " AND ingested_at >= ?"
-			dargs = append(dargs, from)
-		}
-		if !to.IsZero() {
-			dq += " AND ingested_at <= ?"
-			dargs = append(dargs, to)
-		}
-		dq += " ORDER BY duration_us"
-
-		drows, err := r.db.Query(dq, dargs...)
-		if err != nil {
-			return nil, err
-		}
-		var durations []int64
-		for drows.Next() {
-			var d int64
-			if err := drows.Scan(&d); err != nil {
-				drows.Close()
-				return nil, err
-			}
-			durations = append(durations, d)
-		}
-		drows.Close()
-		if err := drows.Err(); err != nil {
-			return nil, err
-		}
-		statsMap[k].Durations = durations
 	}
 
 	result := make([]OperationStats, 0, len(order))
@@ -402,7 +435,9 @@ func (r *Repository) QuerySpanTimeseries(projectID int64, service, operation str
 		ORDER BY bucket, duration_us`,
 		intervalSec, intervalSec, strings.Join(where, " AND "))
 
-	rows, err := r.db.Query(q, args...)
+	ctx, cancel := r.queryContext()
+	defer cancel()
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,6 +1,12 @@
 package repository
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+const DefaultQueryTimeout = 30 * time.Second
 
 // Repository provides data access methods over a SQLite database.
 // Methods are organized into domain-specific files:
@@ -11,12 +17,22 @@ import "database/sql"
 //   - repo_aggregates.go — pre-computed aggregate CRUD
 //   - repo_alerts.go     — alert CRUD, error samples
 type Repository struct {
-	db *sql.DB
+	db           *sql.DB
+	queryTimeout time.Duration
 }
 
 // NewRepository creates a Repository backed by the given database connection.
 func NewRepository(db *sql.DB) *Repository {
-	return &Repository{db: db}
+	return &Repository{db: db, queryTimeout: DefaultQueryTimeout}
+}
+
+// SetQueryTimeout overrides the default query timeout.
+func (r *Repository) SetQueryTimeout(d time.Duration) {
+	r.queryTimeout = d
+}
+
+func (r *Repository) queryContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), r.queryTimeout)
 }
 
 // DB returns the underlying *sql.DB, useful for testing.

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -22,7 +22,9 @@ const defaultBatchSize = 5000
 type Repository interface {
 	GetSpansForAggregation(cutoff time.Time, limit int) ([]repository.Span, error)
 	DeleteSpansByIDs(ids []int64) (int64, error)
+	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
+	DeleteBoringSpans(olderThan, newerThan time.Time, slowThresholdUS int64) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
 	DeleteErrorSamplesOlderThan(cutoff time.Time) (int64, error)
 	DeleteAggregatesOlderThan(cutoff time.Time) (int64, error)
@@ -31,16 +33,20 @@ type Repository interface {
 
 // Config controls the retention worker's behaviour.
 type Config struct {
-	FullRetentionHours     int           // hours to keep full spans (default 4)
-	ErrorRetentionDays     int           // days to keep error samples (default 30)
-	AggregateRetentionDays int           // days to keep aggregates (default 365)
-	SlowThresholdUS        int64         // microseconds above which a span is "slow"
-	Interval               time.Duration // how often to run (default 5m)
+	FullRetentionHours        int           // hours to keep ALL spans (default 4)
+	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 168 = 7d)
+	ErrorRetentionDays        int           // days to keep error samples (default 30)
+	AggregateRetentionDays    int           // days to keep aggregates (default 365)
+	SlowThresholdUS           int64         // microseconds above which a span is "slow"
+	Interval                  time.Duration // how often to run (default 5m)
 }
 
 func (c Config) withDefaults() Config {
 	if c.FullRetentionHours <= 0 {
 		c.FullRetentionHours = 4
+	}
+	if c.InterestingRetentionHours <= 0 {
+		c.InterestingRetentionHours = 168
 	}
 	if c.ErrorRetentionDays <= 0 {
 		c.ErrorRetentionDays = 30
@@ -107,6 +113,11 @@ func (w *RetentionWorker) effectiveConfig() Config {
 			cfg.FullRetentionHours = n
 		}
 	}
+	if v, err := w.repo.GetSetting("retention_interesting_hours"); err == nil && v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.InterestingRetentionHours = n
+		}
+	}
 	if v, err := w.repo.GetSetting("retention_aggregated_days"); err == nil && v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.AggregateRetentionDays = n
@@ -127,21 +138,35 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	cfg := w.effectiveConfig()
 
 	now := time.Now().UTC()
-	spanCutoff := now.Add(-time.Duration(cfg.FullRetentionHours) * time.Hour)
+	fullCutoff := now.Add(-time.Duration(cfg.FullRetentionHours) * time.Hour)
+	interestingCutoff := now.Add(-time.Duration(cfg.InterestingRetentionHours) * time.Hour)
 	errorCutoff := now.Add(-time.Duration(cfg.ErrorRetentionDays) * 24 * time.Hour)
 	aggCutoff := now.Add(-time.Duration(cfg.AggregateRetentionDays) * 24 * time.Hour)
 
 	var totalAggregated int64
 	var totalSampled int64
 	var spansDeleted int64
+	var boringDropped int64
 
-	// Process old spans in batches.
+	// Phase 1: Drop boring (non-error, non-slow) spans that are past full
+	// retention but still within interesting retention. These don't need
+	// aggregation yet — the interesting ones survive until phase 2.
+	if interestingCutoff.Before(fullCutoff) {
+		dropped, err := w.repo.DeleteBoringSpans(fullCutoff, interestingCutoff, cfg.SlowThresholdUS)
+		if err != nil {
+			return err
+		}
+		boringDropped = dropped
+	}
+
+	// Phase 2: Process spans older than interesting retention — aggregate all
+	// remaining spans (the interesting ones that survived phase 1) and delete.
 	for {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
-		batch, err := w.repo.GetSpansForAggregation(spanCutoff, defaultBatchSize)
+		batch, err := w.repo.GetSpansForAggregation(interestingCutoff, defaultBatchSize)
 		if err != nil {
 			return err
 		}
@@ -149,10 +174,9 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 			break
 		}
 
-		// Separate error and slow spans for sampling.
 		var samples []repository.Span
 		for _, s := range batch {
-			if s.Status == "error" || s.DurationUs > w.cfg.SlowThresholdUS {
+			if s.Status == "error" || s.DurationUs > cfg.SlowThresholdUS {
 				samples = append(samples, s)
 			}
 		}
@@ -177,31 +201,28 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		}
 		totalAggregated += int64(len(batch))
 
-		// Delete the processed spans by ID so the next batch fetch
-		// doesn't re-read the same rows.
-		ids := make([]int64, len(batch))
-		for i, s := range batch {
-			ids[i] = s.ID
+		maxID := batch[0].ID
+		for _, s := range batch[1:] {
+			if s.ID > maxID {
+				maxID = s.ID
+			}
 		}
-		deleted, err := w.repo.DeleteSpansByIDs(ids)
+		deleted, err := w.repo.DeleteSpansByMaxID(maxID)
 		if err != nil {
 			return err
 		}
 		spansDeleted += deleted
 
-		// If we got fewer than the batch size, we've consumed everything.
 		if len(batch) < defaultBatchSize {
 			break
 		}
 	}
 
-	// Delete old error samples.
 	errorSamplesDeleted, err := w.repo.DeleteErrorSamplesOlderThan(errorCutoff)
 	if err != nil {
 		return err
 	}
 
-	// Delete old aggregates.
 	aggregatesDeleted, err := w.repo.DeleteAggregatesOlderThan(aggCutoff)
 	if err != nil {
 		return err
@@ -211,6 +232,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Int64("spans_aggregated", totalAggregated),
 		attribute.Int64("errors_sampled", totalSampled),
 		attribute.Int64("spans_deleted", spansDeleted),
+		attribute.Int64("boring_dropped", boringDropped),
 		attribute.Int64("error_samples_deleted", errorSamplesDeleted),
 		attribute.Int64("aggregates_deleted", aggregatesDeleted),
 	)
@@ -219,6 +241,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"spans_aggregated", totalAggregated,
 		"errors_sampled", totalSampled,
 		"spans_deleted", spansDeleted,
+		"boring_dropped", boringDropped,
 		"error_samples_deleted", errorSamplesDeleted,
 		"aggregates_deleted", aggregatesDeleted,
 	)

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -71,10 +71,11 @@ func insertTestSpans(t *testing.T, repo *repository.Repository, count int, statu
 
 func TestRunOnceAggregatesOldSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -113,10 +114,11 @@ func TestRunOnceAggregatesOldSpans(t *testing.T) {
 
 func TestRunOnceSamplesErrors(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -144,10 +146,11 @@ func TestRunOnceSamplesErrors(t *testing.T) {
 
 func TestRunOnceSamplesSlowSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        500_000, // 500ms
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           500_000, // 500ms
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -175,10 +178,11 @@ func TestRunOnceSamplesSlowSpans(t *testing.T) {
 
 func TestRunOncePreservesRecentSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -225,10 +229,11 @@ func TestRunOncePreservesRecentSpans(t *testing.T) {
 
 func TestRunOnceDeletesOldErrorSamples(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -266,10 +271,11 @@ func TestRunOnceDeletesOldErrorSamples(t *testing.T) {
 
 func TestRunOnceDeletesOldAggregates(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 
@@ -312,10 +318,11 @@ func TestRunOnceDeletesOldAggregates(t *testing.T) {
 
 func TestRunOnceEmptyDatabase(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, _ := setupTestWorker(t, cfg)
 
@@ -326,10 +333,11 @@ func TestRunOnceEmptyDatabase(t *testing.T) {
 
 func TestRunOnceMultipleBatches(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:     1,
-		ErrorRetentionDays:     30,
-		AggregateRetentionDays: 365,
-		SlowThresholdUS:        1_000_000,
+		FullRetentionHours:        1,
+		InterestingRetentionHours: 1,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
 	}
 	worker, repo := setupTestWorker(t, cfg)
 

--- a/internal/service/query.go
+++ b/internal/service/query.go
@@ -25,6 +25,7 @@ type QueryRepository interface {
 	QuerySpanTimeseries(projectID int64, service, operation string, from, to time.Time, intervalSec int64) ([]repository.SpanBucket, error)
 	QueryPromptRecords(filter repository.PromptFilter) ([]repository.PromptRecord, error)
 	GetSpansBySpanIDs(spanIDs []string) ([]repository.Span, error)
+	StreamSpans(filter repository.SpanFilter, fn func(repository.Span) error) error
 }
 
 // QueryService implements query logic for the dashboard API.

--- a/internal/service/query_service_map.go
+++ b/internal/service/query_service_map.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+func (s *QueryService) GetServiceMap(ctx context.Context, projectID int64, from, to time.Time) (*ServiceMap, error) {
+	_, span := tracer.Start(ctx, "query.service_map")
+	defer span.End()
+
+	sf := repository.SpanFilter{
+		ProjectID: projectID,
+		From:      from,
+		To:        to,
+		Limit:     10000,
+	}
+
+	spans, err := s.repo.QuerySpans(sf)
+	if err != nil {
+		return nil, err
+	}
+
+	type nodeStats struct {
+		count, errorCount int64
+	}
+	nodes := make(map[string]*nodeStats)
+
+	addNode := func(name string, sp repository.Span) {
+		n, ok := nodes[name]
+		if !ok {
+			n = &nodeStats{}
+			nodes[name] = n
+		}
+		n.count++
+		if sp.Status == "error" {
+			n.errorCount++
+		}
+	}
+
+	type edgeKey struct{ source, target, targetType string }
+	type edgeStats struct {
+		count, errorCount int64
+	}
+	edges := make(map[edgeKey]*edgeStats)
+
+	addEdge := func(source, target, targetType string, sp repository.Span) {
+		k := edgeKey{source, target, targetType}
+		e, ok := edges[k]
+		if !ok {
+			e = &edgeStats{}
+			edges[k] = e
+		}
+		e.count++
+		if sp.Status == "error" {
+			e.errorCount++
+		}
+	}
+
+	for _, sp := range spans {
+		if sp.Service != "" {
+			addNode(sp.Service, sp)
+		}
+
+		if sp.Kind == "client" || sp.Kind == "CLIENT" {
+			target, targetType := extractDependencyTarget(sp.Attributes)
+			if target != "" && sp.Service != "" {
+				addEdge(sp.Service, target, targetType, sp)
+				if _, ok := nodes[target]; !ok {
+					nodes[target] = &nodeStats{}
+				}
+			}
+		}
+	}
+
+	spanByID := make(map[string]*repository.Span, len(spans))
+	for i := range spans {
+		spanByID[spans[i].SpanID] = &spans[i]
+	}
+	for _, sp := range spans {
+		if sp.ParentSpanID == "" {
+			continue
+		}
+		parent, ok := spanByID[sp.ParentSpanID]
+		if !ok || parent.Service == "" || sp.Service == "" || parent.Service == sp.Service {
+			continue
+		}
+		addEdge(parent.Service, sp.Service, "service", *parent)
+	}
+
+	result := &ServiceMap{}
+
+	for name, st := range nodes {
+		var errorRate float64
+		if st.count > 0 {
+			errorRate = float64(st.errorCount) / float64(st.count)
+		}
+		result.Nodes = append(result.Nodes, ServiceMapNode{
+			ID:         name,
+			SpanCount:  st.count,
+			ErrorCount: st.errorCount,
+			ErrorRate:  errorRate,
+		})
+	}
+	sort.Slice(result.Nodes, func(i, j int) bool {
+		return result.Nodes[i].SpanCount > result.Nodes[j].SpanCount
+	})
+
+	for k, st := range edges {
+		var errorRate float64
+		if st.count > 0 {
+			errorRate = float64(st.errorCount) / float64(st.count)
+		}
+		result.Edges = append(result.Edges, ServiceMapEdge{
+			Source:     k.source,
+			Target:     k.target,
+			TargetType: k.targetType,
+			CallCount:  st.count,
+			ErrorCount: st.errorCount,
+			ErrorRate:  errorRate,
+		})
+	}
+	sort.Slice(result.Edges, func(i, j int) bool {
+		return result.Edges[i].CallCount > result.Edges[j].CallCount
+	})
+
+	return result, nil
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -72,6 +72,30 @@ type DependencySummary struct {
 	P99Us      int64   `json:"p99Us"`
 }
 
+// ServiceMapNode holds a service in the service map.
+type ServiceMapNode struct {
+	ID         string  `json:"id"`
+	SpanCount  int64   `json:"spanCount"`
+	ErrorCount int64   `json:"errorCount"`
+	ErrorRate  float64 `json:"errorRate"`
+}
+
+// ServiceMapEdge holds a connection between two services.
+type ServiceMapEdge struct {
+	Source     string  `json:"source"`
+	Target     string  `json:"target"`
+	TargetType string  `json:"targetType"`
+	CallCount  int64   `json:"callCount"`
+	ErrorCount int64   `json:"errorCount"`
+	ErrorRate  float64 `json:"errorRate"`
+}
+
+// ServiceMap holds the full service topology.
+type ServiceMap struct {
+	Nodes []ServiceMapNode `json:"nodes"`
+	Edges []ServiceMapEdge `json:"edges"`
+}
+
 // DatabaseQuerySpan is a single span execution of a database query,
 // enriched with caller context from the parent span.
 type DatabaseQuerySpan struct {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -49,10 +50,12 @@ func (m *Metrics) Snapshot() (processed, errors int64, duration time.Duration) {
 
 // Worker reads from the spool and persists records to the repository.
 type Worker struct {
-	spool   *spool.Spool
-	repo    Repository
-	logger  *slog.Logger
-	metrics Metrics
+	spool            *spool.Spool
+	repo             Repository
+	logger           *slog.Logger
+	metrics          Metrics
+	ingestSampleRate float64
+	slowThresholdUS  int64
 }
 
 // NewWorker creates a new background worker.
@@ -61,10 +64,18 @@ func NewWorker(sp *spool.Spool, repo Repository, logger *slog.Logger) *Worker {
 		logger = slog.Default()
 	}
 	return &Worker{
-		spool:  sp,
-		repo:   repo,
-		logger: logger,
+		spool:            sp,
+		repo:             repo,
+		logger:           logger,
+		ingestSampleRate: 1.0,
 	}
+}
+
+// SetIngestSampling configures probabilistic dropping of uneventful spans.
+// rate=1.0 keeps all spans (default). rate=0.5 drops ~50% of non-error, non-slow spans.
+func (w *Worker) SetIngestSampling(rate float64, slowThresholdUS int64) {
+	w.ingestSampleRate = rate
+	w.slowThresholdUS = slowThresholdUS
 }
 
 // Run loops on a 1-second ticker, processing spool batches until ctx is cancelled.
@@ -126,6 +137,11 @@ func (w *Worker) processBatch(ctx context.Context) {
 
 	spans := convertRecords(records)
 
+	if w.ingestSampleRate < 1.0 {
+		spans = w.sampleSpans(spans)
+		span.SetAttributes(attribute.Int("batch.size_after_sampling", len(spans)))
+	}
+
 	_, insertSpan := tracer.Start(ctx, "worker.insert_spans")
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -178,6 +194,22 @@ func (w *Worker) processBatch(ctx context.Context) {
 	w.metrics.mu.Lock()
 	w.metrics.ProcessingDuration += elapsed
 	w.metrics.mu.Unlock()
+}
+
+// sampleSpans keeps all interesting spans (error/slow) and probabilistically
+// drops normal spans based on the configured sample rate.
+func (w *Worker) sampleSpans(spans []repository.Span) []repository.Span {
+	kept := make([]repository.Span, 0, len(spans))
+	for _, s := range spans {
+		if s.Status == "error" || (w.slowThresholdUS > 0 && s.DurationUs > w.slowThresholdUS) {
+			kept = append(kept, s)
+			continue
+		}
+		if rand.Float64() < w.ingestSampleRate {
+			kept = append(kept, s)
+		}
+	}
+	return kept
 }
 
 func convertRecords(records []model.SpanRecord) []repository.Span {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,8 @@ import { OperationDetailPage } from './pages/OperationDetailPage'
 import { TracesPage } from './pages/TracesPage'
 import { TraceDetailPage } from './pages/TraceDetailPage'
 import { DependenciesPage } from './pages/DependenciesPage'
+import { ServiceMapPage } from './pages/ServiceMapPage'
+import { LiveTailPage } from './pages/LiveTailPage'
 import { DatabasePage } from './pages/DatabasePage'
 import { DatabaseQueryDetailPage } from './pages/DatabaseQueryDetailPage'
 import { PromptsPage } from './pages/PromptsPage'
@@ -27,6 +29,8 @@ function App() {
             <Route path="traces" element={<TracesPage />} />
             <Route path="traces/:traceId" element={<TraceDetailPage />} />
             <Route path="dependencies" element={<DependenciesPage />} />
+            <Route path="service-map" element={<ServiceMapPage />} />
+            <Route path="live" element={<LiveTailPage />} />
             <Route path="database" element={<DatabasePage />} />
             <Route path="database/detail" element={<DatabaseQueryDetailPage />} />
             <Route path="prompts" element={<PromptsPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,10 +5,12 @@ import type {
   TraceSummary,
   TraceDetail,
   DependencySummary,
+  ServiceMap,
   DatabaseQuerySummary,
   DatabaseQuerySpan,
   PromptSummary,
   PromptRecord,
+  SavedQuery,
   HealthResponse,
   TraceSearchParams,
 } from './types'
@@ -115,6 +117,9 @@ export const api = {
       `/api/v1/dependencies${qs({ from, to, service })}`,
     ),
 
+  getServiceMap: (from: string, to: string) =>
+    fetchJSON<ServiceMap>(`/api/v1/service-map${qs({ from, to })}`),
+
   getDatabaseQueries: (from: string, to: string, service?: string) =>
     fetchJSON<DatabaseQuerySummary[]>(
       `/api/v1/database${qs({ from, to, service })}`,
@@ -135,5 +140,20 @@ export const api = {
       `/api/v1/prompts/detail${qs({ from, to, name, model, service, status, finish_reason: finishReason })}`,
     ),
 
+  getSavedQueries: (projectId = 1) =>
+    fetchJSON<SavedQuery[]>(`/api/v1/saved-queries${qs({ project_id: projectId })}`),
+
+  createSavedQuery: (query: { name: string; service?: string; operation?: string; status?: string; minDurationUs?: number }) =>
+    fetchJSON<{ id: number }>('/api/v1/saved-queries', {
+      method: 'POST',
+      body: JSON.stringify({ projectId: 1, ...query }),
+    }),
+
+  deleteSavedQuery: (id: number) =>
+    fetchJSON<{ status: string }>(`/api/v1/saved-queries/${id}`, { method: 'DELETE' }),
+
   getHealth: () => fetchJSON<HealthResponse>('/api/v1/health'),
+
+  getExportUrl: (from: string, to: string, service?: string, status?: string, limit?: number) =>
+    `/api/v1/export${qs({ from, to, service, status, limit })}`,
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -167,6 +167,42 @@ export type PromptRecord = {
   ingestedAt: string
 }
 
+/** A node in the service map. */
+export type ServiceMapNode = {
+  id: string
+  spanCount: number
+  errorCount: number
+  errorRate: number
+}
+
+/** An edge in the service map. */
+export type ServiceMapEdge = {
+  source: string
+  target: string
+  targetType: string
+  callCount: number
+  errorCount: number
+  errorRate: number
+}
+
+/** Full service map topology. */
+export type ServiceMap = {
+  nodes: ServiceMapNode[]
+  edges: ServiceMapEdge[]
+}
+
+/** A saved trace query. */
+export type SavedQuery = {
+  id: number
+  projectId: number
+  name: string
+  service: string
+  operation: string
+  status: string
+  minDurationUs: number
+  createdAt: string
+}
+
 /** Health check response. */
 export type HealthResponse = {
   status: string

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement } from 'react'
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
-import { Activity, GitBranch, Search, Database, BrainCircuit, Settings, LogOut } from 'lucide-react'
+import { Activity, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut } from 'lucide-react'
 import { api } from '../api/client'
 import { MobileTabBar } from './MobileTabBar'
 import { PWAInstallBanner } from './PWAInstallBanner'
@@ -9,6 +9,8 @@ const navItems = [
   { to: '/', icon: Activity, label: 'Services' },
   { to: '/traces', icon: Search, label: 'Traces' },
   { to: '/dependencies', icon: GitBranch, label: 'Dependencies' },
+  { to: '/service-map', icon: Network, label: 'Service Map' },
+  { to: '/live', icon: Radio, label: 'Live Tail' },
   { to: '/database', icon: Database, label: 'Database' },
   { to: '/prompts', icon: BrainCircuit, label: 'Prompts' },
   { to: '/settings', icon: Settings, label: 'Settings' },

--- a/web/src/components/SpanDetail.tsx
+++ b/web/src/components/SpanDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import type { Span } from '../api/types'
 import {
   formatDuration,
@@ -12,11 +12,19 @@ import './SpanTimeline.css'
 type Props = {
   span: Span
   traceStartTimeUs: number
+  onNavigateToSpan?: (spanId: string) => void
 }
 
 type Tab = 'overview' | 'attributes' | 'events'
 
-export function SpanDetail({ span, traceStartTimeUs }: Props) {
+const spanLinkStyle: React.CSSProperties = {
+  color: '#60a5fa',
+  cursor: 'pointer',
+  textDecoration: 'underline',
+  textUnderlineOffset: 2,
+}
+
+export function SpanDetail({ span, traceStartTimeUs, onNavigateToSpan }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>('overview')
 
   const attributes = parseAttributes(span.attributes)
@@ -90,7 +98,13 @@ export function SpanDetail({ span, traceStartTimeUs }: Props) {
           {span.parentSpanId && (
             <>
               <span className="span-detail-label">Parent Span ID</span>
-              <span className="span-detail-value">{span.parentSpanId}</span>
+              <span className="span-detail-value">
+                {onNavigateToSpan ? (
+                  <span style={spanLinkStyle} onClick={() => onNavigateToSpan(span.parentSpanId)}>
+                    {span.parentSpanId}
+                  </span>
+                ) : span.parentSpanId}
+              </span>
             </>
           )}
 

--- a/web/src/components/SpanWaterfall.tsx
+++ b/web/src/components/SpanWaterfall.tsx
@@ -35,6 +35,14 @@ export function SpanWaterfall({ spans, totalDurationUs }: Props) {
     setSelectedSpanId(selectedSpanId === spanId ? null : spanId)
   }
 
+  const navigateToSpan = (spanId: string) => {
+    setSelectedSpanId(spanId)
+    const row = document.querySelector(`[data-testid="waterfall-row-${spanId}"]`)
+    if (row) {
+      row.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+  }
+
   const handleMouseMove = (e: React.MouseEvent, span: Span) => {
     setHoveredSpanId(span.spanId)
     setTooltipPos({ x: e.clientX + 12, y: e.clientY + 12 })
@@ -109,6 +117,7 @@ export function SpanWaterfall({ spans, totalDurationUs }: Props) {
               <SpanDetail
                 span={span}
                 traceStartTimeUs={traceStartTimeUs}
+                onNavigateToSpan={navigateToSpan}
               />
             )}
           </React.Fragment>

--- a/web/src/pages/LiveTailPage.tsx
+++ b/web/src/pages/LiveTailPage.tsx
@@ -1,0 +1,215 @@
+import { useState, useEffect, useRef, useCallback, type ReactElement } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ServiceSelect } from '../components/ServiceSelect'
+import { formatDuration } from '../utils/format'
+
+type LiveSpan = {
+  traceId: string
+  spanId: string
+  parentSpanId?: string
+  name: string
+  service: string
+  kind: string
+  status: string
+  durationUs: number
+  start_time_us: number
+}
+
+const MAX_SPANS = 200
+
+export function LiveTailPage(): ReactElement {
+  const navigate = useNavigate()
+  const [spans, setSpans] = useState<LiveSpan[]>([])
+  const [paused, setPaused] = useState(false)
+  const [connected, setConnected] = useState(false)
+  const [serviceFilter, setServiceFilter] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+  const pausedRef = useRef(paused)
+  const bufferRef = useRef<LiveSpan[]>([])
+  const tableRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    pausedRef.current = paused
+    if (!paused && bufferRef.current.length > 0) {
+      setSpans((prev) => [...bufferRef.current, ...prev].slice(0, MAX_SPANS))
+      bufferRef.current = []
+    }
+  }, [paused])
+
+  const connect = useCallback(() => {
+    const params = new URLSearchParams()
+    if (serviceFilter) params.set('service', serviceFilter)
+    if (statusFilter) params.set('status', statusFilter)
+    const qs = params.toString()
+    const url = `/api/v1/spans/live${qs ? '?' + qs : ''}`
+
+    const es = new EventSource(url)
+    es.onopen = () => setConnected(true)
+    es.onerror = () => {
+      setConnected(false)
+      es.close()
+    }
+    es.onmessage = (event) => {
+      try {
+        const span = JSON.parse(event.data) as LiveSpan
+        if (pausedRef.current) {
+          bufferRef.current = [span, ...bufferRef.current].slice(0, MAX_SPANS)
+        } else {
+          setSpans((prev) => [span, ...prev].slice(0, MAX_SPANS))
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return es
+  }, [serviceFilter, statusFilter])
+
+  useEffect(() => {
+    const es = connect()
+    return () => es.close()
+  }, [connect])
+
+  const statusColor = (status: string) => {
+    if (status === 'error' || status === 'ERROR') return '#ef4444'
+    return '#22c55e'
+  }
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '1.5rem',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: 700 }}>Live Tail</h2>
+          <span
+            style={{
+              display: 'inline-block',
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: connected ? '#22c55e' : '#ef4444',
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <ServiceSelect value={serviceFilter} onChange={(v) => { setServiceFilter(v); setSpans([]) }} range="1h" />
+          <select
+            value={statusFilter}
+            onChange={(e) => { setStatusFilter(e.target.value); setSpans([]) }}
+            style={{
+              padding: '0.375rem 0.75rem',
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: 'var(--surface)',
+              color: 'var(--text)',
+              fontSize: '0.8125rem',
+            }}
+          >
+            <option value="">All statuses</option>
+            <option value="error">Error</option>
+            <option value="ok">OK</option>
+          </select>
+          <button
+            onClick={() => setPaused((p) => !p)}
+            style={{
+              padding: '0.375rem 0.75rem',
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: paused ? '#ef4444' : 'var(--accent)',
+              color: '#fff',
+              fontSize: '0.8125rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            {paused ? `Resume (${bufferRef.current.length})` : 'Pause'}
+          </button>
+          <button
+            onClick={() => setSpans([])}
+            style={{
+              padding: '0.375rem 0.75rem',
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: 'transparent',
+              color: 'var(--text-muted)',
+              fontSize: '0.8125rem',
+              cursor: 'pointer',
+            }}
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <div ref={tableRef} style={{ overflowX: 'auto', maxHeight: '70vh', overflowY: 'auto' }}>
+          <table>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left' }}>Time</th>
+                <th style={{ textAlign: 'left' }}>Service</th>
+                <th style={{ textAlign: 'left' }}>Operation</th>
+                <th style={{ textAlign: 'left' }}>Kind</th>
+                <th style={{ textAlign: 'right' }}>Duration</th>
+                <th>Status</th>
+                <th style={{ textAlign: 'left' }}>Trace ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {spans.length === 0 ? (
+                <tr>
+                  <td colSpan={7} style={{ textAlign: 'center', color: 'var(--text-muted)', padding: '3rem' }}>
+                    {connected ? 'Waiting for spans...' : 'Connecting...'}
+                  </td>
+                </tr>
+              ) : (
+                spans.map((s, i) => (
+                  <tr key={`${s.spanId}-${i}`}>
+                    <td className="mono text-muted" style={{ fontSize: '0.8125rem', whiteSpace: 'nowrap' }}>
+                      {new Date(s.start_time_us / 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                    </td>
+                    <td style={{ fontWeight: 600 }}>{s.service}</td>
+                    <td>{s.name}</td>
+                    <td className="text-muted">{s.kind}</td>
+                    <td style={{ textAlign: 'right' }} className="mono">
+                      {formatDuration(s.durationUs)}
+                    </td>
+                    <td style={{ textAlign: 'center' }}>
+                      <span
+                        style={{
+                          display: 'inline-block',
+                          padding: '0.125rem 0.5rem',
+                          borderRadius: '1rem',
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          background: s.status === 'error' || s.status === 'ERROR' ? 'rgba(239,68,68,0.15)' : 'rgba(34,197,94,0.15)',
+                          color: statusColor(s.status),
+                        }}
+                      >
+                        {s.status || 'ok'}
+                      </span>
+                    </td>
+                    <td
+                      className="mono"
+                      style={{ fontSize: '0.8125rem', color: 'var(--accent)', cursor: 'pointer' }}
+                      onClick={() => navigate(`/traces/${s.traceId}`)}
+                    >
+                      {s.traceId.slice(0, 16)}...
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/OperationDetailPage.tsx
+++ b/web/src/pages/OperationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, type ReactElement } from 'react'
+import { useState, useEffect, useCallback, useMemo, type ReactElement } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import { ChevronRight } from 'lucide-react'
 import {
@@ -18,7 +18,7 @@ import {
 import { api } from '../api/client'
 import type { TimeseriesBucket, TraceSummary } from '../api/types'
 import { TimeRangeSelector } from '../components/TimeRangeSelector'
-import { getTimeRange } from '../utils/timeRange'
+import { getTimeRange, RANGES } from '../utils/timeRange'
 import { formatDuration } from '../utils/format'
 import { useTimeRange } from '../contexts/useTimeRange'
 
@@ -27,39 +27,68 @@ export function OperationDetailPage(): ReactElement {
   const navigate = useNavigate()
   const { range, setRange } = useTimeRange()
   const [timeseries, setTimeseries] = useState<TimeseriesBucket[]>([])
+  const [compareTs, setCompareTs] = useState<TimeseriesBucket[]>([])
   const [traces, setTraces] = useState<TraceSummary[]>([])
   const [loading, setLoading] = useState(true)
+  const [compare, setCompare] = useState(false)
+
+  const rangeHours = useMemo(() => {
+    const r = RANGES.find((r) => r.value === range)
+    return r ? r.hours : 1
+  }, [range])
 
   const fetchData = useCallback(async () => {
     if (!service || !operation) return
     const { from, to } = getTimeRange(range)
     try {
-      const [ts, tr] = await Promise.all([
+      const promises: Promise<unknown>[] = [
         api.getTimeseries(service, operation, from, to),
         api.searchTraces({ service, operation, from, to, limit: 20 }),
-      ])
-      setTimeseries(ts ?? [])
-      setTraces(tr ?? [])
+      ]
+
+      if (compare) {
+        const prevTo = new Date(new Date(from).getTime())
+        const prevFrom = new Date(prevTo.getTime() - rangeHours * 3600_000)
+        promises.push(api.getTimeseries(service, operation, prevFrom.toISOString(), prevTo.toISOString()))
+      }
+
+      const results = await Promise.all(promises)
+      setTimeseries((results[0] as TimeseriesBucket[]) ?? [])
+      setTraces((results[1] as TraceSummary[]) ?? [])
+      setCompareTs(compare ? ((results[2] as TimeseriesBucket[]) ?? []) : [])
     } catch {
       // handled by client
     } finally {
       setLoading(false)
     }
-  }, [service, operation, range])
+  }, [service, operation, range, compare, rangeHours])
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetching is a valid effect pattern
     void fetchData()
   }, [fetchData])
 
-  const chartData = timeseries.map((b) => ({
-    time: new Date(b.bucket).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-    p50: b.p50Us / 1000,
-    p95: b.p95Us / 1000,
-    p99: b.p99Us / 1000,
-    count: b.count,
-    errorRate: b.count > 0 ? (b.errorCount / b.count) * 100 : 0,
-  }))
+  const chartData = timeseries.map((b, i) => {
+    const base = {
+      time: new Date(b.bucket).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      p50: b.p50Us / 1000,
+      p95: b.p95Us / 1000,
+      p99: b.p99Us / 1000,
+      count: b.count,
+      errorRate: b.count > 0 ? (b.errorCount / b.count) * 100 : 0,
+    }
+    if (compare && compareTs[i]) {
+      return {
+        ...base,
+        prevP50: compareTs[i].p50Us / 1000,
+        prevP95: compareTs[i].p95Us / 1000,
+        prevP99: compareTs[i].p99Us / 1000,
+        prevCount: compareTs[i].count,
+        prevErrorRate: compareTs[i].count > 0 ? (compareTs[i].errorCount / compareTs[i].count) * 100 : 0,
+      }
+    }
+    return base
+  })
 
   const totalCount = timeseries.reduce((s, b) => s + b.count, 0)
   const avgP50 = totalCount > 0 ? timeseries.reduce((s, b) => s + b.p50Us * b.count, 0) / totalCount : 0
@@ -99,7 +128,24 @@ export function OperationDetailPage(): ReactElement {
         }}
       >
         <h2 style={{ fontSize: '1.25rem', fontWeight: 700 }}>{operation}</h2>
-        <TimeRangeSelector value={range} onChange={setRange} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <button
+            onClick={() => setCompare((c) => !c)}
+            style={{
+              padding: '0.375rem 0.75rem',
+              borderRadius: 6,
+              border: '1px solid var(--border)',
+              background: compare ? 'var(--accent)' : 'transparent',
+              color: compare ? '#fff' : 'var(--text-muted)',
+              fontSize: '0.8125rem',
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            Compare
+          </button>
+          <TimeRangeSelector value={range} onChange={setRange} />
+        </div>
       </div>
 
       {/* Duration stats — only show when we have data */}
@@ -152,6 +198,9 @@ export function OperationDetailPage(): ReactElement {
                   <Line type="monotone" dataKey="p99" name="p99" stroke="#ef4444" dot={false} strokeWidth={2} />
                   <Line type="monotone" dataKey="p95" name="p95" stroke="#eab308" dot={false} strokeWidth={2} />
                   <Line type="monotone" dataKey="p50" name="p50" stroke="#3b82f6" dot={false} strokeWidth={2} />
+                  {compare && <Line type="monotone" dataKey="prevP99" name="prev p99" stroke="#ef4444" dot={false} strokeWidth={1.5} strokeDasharray="4 3" />}
+                  {compare && <Line type="monotone" dataKey="prevP95" name="prev p95" stroke="#eab308" dot={false} strokeWidth={1.5} strokeDasharray="4 3" />}
+                  {compare && <Line type="monotone" dataKey="prevP50" name="prev p50" stroke="#3b82f6" dot={false} strokeWidth={1.5} strokeDasharray="4 3" />}
                 </LineChart>
               </ResponsiveContainer>
             </div>
@@ -175,6 +224,7 @@ export function OperationDetailPage(): ReactElement {
                     }}
                   />
                   <Bar dataKey="count" fill="#3b82f6" radius={[2, 2, 0, 0]} />
+                  {compare && <Bar dataKey="prevCount" name="prev count" fill="#3b82f640" radius={[2, 2, 0, 0]} />}
                 </BarChart>
               </ResponsiveContainer>
             </div>
@@ -199,6 +249,7 @@ export function OperationDetailPage(): ReactElement {
                   }}
                 />
                 <Area type="monotone" dataKey="errorRate" stroke="#ef4444" fill="#ef444440" />
+                {compare && <Area type="monotone" dataKey="prevErrorRate" name="prev error rate" stroke="#ef4444" fill="none" strokeDasharray="4 3" />}
               </AreaChart>
             </ResponsiveContainer>
           </div>

--- a/web/src/pages/ServiceMapPage.tsx
+++ b/web/src/pages/ServiceMapPage.tsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useCallback, useRef, type ReactElement } from 'react'
+import { api } from '../api/client'
+import type { ServiceMap, ServiceMapNode, ServiceMapEdge } from '../api/types'
+import { TimeRangeSelector } from '../components/TimeRangeSelector'
+import { AutoRefresh } from '../components/AutoRefresh'
+import { getTimeRange } from '../utils/timeRange'
+import { useTimeRange } from '../contexts/useTimeRange'
+import { formatCount, formatErrorRate, errorRateColor } from '../utils/format'
+
+type SimNode = ServiceMapNode & { x: number; y: number; vx: number; vy: number }
+
+function useForceLayout(nodes: ServiceMapNode[], edges: ServiceMapEdge[], width: number, height: number) {
+  const [simNodes, setSimNodes] = useState<SimNode[]>([])
+  const frameRef = useRef(0)
+  const iterRef = useRef(0)
+
+  useEffect(() => {
+    if (nodes.length === 0) {
+      setSimNodes([])
+      return
+    }
+
+    const sn: SimNode[] = nodes.map((n, i) => {
+      const angle = (2 * Math.PI * i) / nodes.length
+      const r = Math.min(width, height) * 0.3
+      return {
+        ...n,
+        x: width / 2 + r * Math.cos(angle),
+        y: height / 2 + r * Math.sin(angle),
+        vx: 0,
+        vy: 0,
+      }
+    })
+
+    const nodeIndex = new Map<string, number>()
+    sn.forEach((n, i) => nodeIndex.set(n.id, i))
+
+    iterRef.current = 0
+
+    function tick() {
+      const maxIter = 200
+      if (iterRef.current >= maxIter) return
+
+      const alpha = 1 - iterRef.current / maxIter
+      const repulsion = 8000 * alpha
+      const attraction = 0.005 * alpha
+      const centerForce = 0.01 * alpha
+
+      for (let i = 0; i < sn.length; i++) {
+        for (let j = i + 1; j < sn.length; j++) {
+          const dx = sn[j].x - sn[i].x
+          const dy = sn[j].y - sn[i].y
+          const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1)
+          const force = repulsion / (dist * dist)
+          const fx = (dx / dist) * force
+          const fy = (dy / dist) * force
+          sn[i].vx -= fx
+          sn[i].vy -= fy
+          sn[j].vx += fx
+          sn[j].vy += fy
+        }
+      }
+
+      for (const edge of edges) {
+        const si = nodeIndex.get(edge.source)
+        const ti = nodeIndex.get(edge.target)
+        if (si === undefined || ti === undefined) continue
+        const dx = sn[ti].x - sn[si].x
+        const dy = sn[ti].y - sn[si].y
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        const force = (dist - 200) * attraction
+        const fx = (dx / Math.max(dist, 1)) * force
+        const fy = (dy / Math.max(dist, 1)) * force
+        sn[si].vx += fx
+        sn[si].vy += fy
+        sn[ti].vx -= fx
+        sn[ti].vy -= fy
+      }
+
+      for (const n of sn) {
+        n.vx += (width / 2 - n.x) * centerForce
+        n.vy += (height / 2 - n.y) * centerForce
+        n.vx *= 0.6
+        n.vy *= 0.6
+        n.x += n.vx
+        n.y += n.vy
+        n.x = Math.max(60, Math.min(width - 60, n.x))
+        n.y = Math.max(40, Math.min(height - 40, n.y))
+      }
+
+      iterRef.current++
+      setSimNodes([...sn])
+      frameRef.current = requestAnimationFrame(tick)
+    }
+
+    frameRef.current = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(frameRef.current)
+  }, [nodes, edges, width, height])
+
+  return simNodes
+}
+
+function nodeRadius(node: ServiceMapNode): number {
+  return Math.max(20, Math.min(40, 15 + Math.log2(node.spanCount + 1) * 3))
+}
+
+function nodeColor(node: ServiceMapNode): string {
+  if (node.errorRate > 0.1) return '#ef4444'
+  if (node.errorRate > 0.01) return '#f59e0b'
+  return 'var(--accent)'
+}
+
+function edgeColor(edge: ServiceMapEdge): string {
+  if (edge.errorRate > 0.1) return '#ef4444'
+  if (edge.errorRate > 0.01) return '#f59e0b'
+  return 'var(--border)'
+}
+
+export function ServiceMapPage(): ReactElement {
+  const { range, setRange } = useTimeRange()
+  const [refreshInterval, setRefreshInterval] = useState(0)
+  const [data, setData] = useState<ServiceMap | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [selected, setSelected] = useState<string | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [dims, setDims] = useState({ width: 900, height: 500 })
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const obs = new ResizeObserver((entries) => {
+      const { width, height } = entries[0].contentRect
+      setDims({ width: Math.max(400, width), height: Math.max(300, height) })
+    })
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [])
+
+  const fetchData = useCallback(async () => {
+    const { from, to } = getTimeRange(range)
+    try {
+      const sm = await api.getServiceMap(from, to)
+      setData(sm)
+    } catch {
+      // handled by client
+    } finally {
+      setLoading(false)
+    }
+  }, [range])
+
+  useEffect(() => {
+    void fetchData()
+  }, [fetchData])
+
+  const nodes = data?.nodes ?? []
+  const edges = data?.edges ?? []
+  const simNodes = useForceLayout(nodes, edges, dims.width, dims.height)
+
+  const nodeMap = new Map<string, SimNode>()
+  simNodes.forEach((n) => nodeMap.set(n.id, n))
+
+  const selectedNode = selected ? nodeMap.get(selected) : null
+  const selectedEdges = selected
+    ? edges.filter((e) => e.source === selected || e.target === selected)
+    : []
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '1.5rem',
+          flexWrap: 'wrap',
+          gap: '0.75rem',
+        }}
+      >
+        <h2 style={{ fontSize: '1.25rem', fontWeight: 700 }}>Service Map</h2>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+          <AutoRefresh value={refreshInterval} onChange={setRefreshInterval} onRefresh={fetchData} />
+          <TimeRangeSelector value={range} onChange={setRange} />
+        </div>
+      </div>
+
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <div ref={containerRef} style={{ width: '100%', height: '60vh', minHeight: 300 }}>
+          {loading ? (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--text-muted)' }}>
+              Loading service map...
+            </div>
+          ) : nodes.length === 0 ? (
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: 'var(--text-muted)' }}>
+              No service data found
+            </div>
+          ) : (
+            <svg width={dims.width} height={dims.height} style={{ display: 'block' }}>
+              <defs>
+                <marker id="arrow" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 3 L 0 6 z" fill="var(--text-muted)" />
+                </marker>
+                <marker id="arrow-red" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+                  <path d="M 0 0 L 10 3 L 0 6 z" fill="#ef4444" />
+                </marker>
+              </defs>
+
+              {edges.map((edge, i) => {
+                const s = nodeMap.get(edge.source)
+                const t = nodeMap.get(edge.target)
+                if (!s || !t) return null
+                const dx = t.x - s.x
+                const dy = t.y - s.y
+                const dist = Math.sqrt(dx * dx + dy * dy) || 1
+                const sr = nodeRadius(s)
+                const tr = nodeRadius(t)
+                const x1 = s.x + (dx / dist) * sr
+                const y1 = s.y + (dy / dist) * sr
+                const x2 = t.x - (dx / dist) * (tr + 10)
+                const y2 = t.y - (dy / dist) * (tr + 10)
+                const color = edgeColor(edge)
+                const isHighlighted = selected && (edge.source === selected || edge.target === selected)
+                const opacity = selected ? (isHighlighted ? 1 : 0.15) : 0.6
+                return (
+                  <line
+                    key={i}
+                    x1={x1} y1={y1} x2={x2} y2={y2}
+                    stroke={color}
+                    strokeWidth={Math.max(1, Math.min(4, Math.log2(edge.callCount + 1)))}
+                    opacity={opacity}
+                    markerEnd={edge.errorRate > 0.1 ? 'url(#arrow-red)' : 'url(#arrow)'}
+                  />
+                )
+              })}
+
+              {simNodes.map((node) => {
+                const r = nodeRadius(node)
+                const color = nodeColor(node)
+                const isSelected = selected === node.id
+                const opacity = selected ? (isSelected || edges.some((e) => e.source === selected && e.target === node.id || e.target === selected && e.source === node.id) ? 1 : 0.25) : 1
+                return (
+                  <g
+                    key={node.id}
+                    style={{ cursor: 'pointer', opacity }}
+                    onClick={() => setSelected(isSelected ? null : node.id)}
+                  >
+                    <circle cx={node.x} cy={node.y} r={r} fill={color} opacity={0.15} stroke={color} strokeWidth={isSelected ? 3 : 1.5} />
+                    <text
+                      x={node.x}
+                      y={node.y + r + 14}
+                      textAnchor="middle"
+                      fill="var(--text)"
+                      fontSize={11}
+                      fontWeight={600}
+                    >
+                      {node.id}
+                    </text>
+                    <text
+                      x={node.x}
+                      y={node.y + 4}
+                      textAnchor="middle"
+                      fill={color}
+                      fontSize={10}
+                      fontWeight={700}
+                    >
+                      {formatCount(node.spanCount)}
+                    </text>
+                  </g>
+                )
+              })}
+            </svg>
+          )}
+        </div>
+      </div>
+
+      {selectedNode && (
+        <div className="card" style={{ marginTop: '1rem' }}>
+          <h3 style={{ fontSize: '1rem', fontWeight: 700, marginBottom: '0.75rem' }}>{selectedNode.id}</h3>
+          <div style={{ display: 'flex', gap: '2rem', flexWrap: 'wrap', marginBottom: '1rem' }}>
+            <div>
+              <span style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>Spans</span>
+              <div className="mono" style={{ fontWeight: 600 }}>{formatCount(selectedNode.spanCount)}</div>
+            </div>
+            <div>
+              <span style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>Errors</span>
+              <div className="mono" style={{ fontWeight: 600 }}>{formatCount(selectedNode.errorCount)}</div>
+            </div>
+            <div>
+              <span style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>Error Rate</span>
+              <div className="mono" style={{ fontWeight: 600, color: errorRateColor(selectedNode.errorRate) }}>
+                {formatErrorRate(selectedNode.errorRate)}
+              </div>
+            </div>
+          </div>
+
+          {selectedEdges.length > 0 && (
+            <table>
+              <thead>
+                <tr>
+                  <th style={{ textAlign: 'left' }}>Direction</th>
+                  <th style={{ textAlign: 'left' }}>Service</th>
+                  <th style={{ textAlign: 'left' }}>Type</th>
+                  <th style={{ textAlign: 'right' }}>Calls</th>
+                  <th style={{ textAlign: 'right' }}>Error Rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {selectedEdges.map((e, i) => {
+                  const isOutgoing = e.source === selected
+                  return (
+                    <tr key={i}>
+                      <td>{isOutgoing ? '→ Out' : '← In'}</td>
+                      <td style={{ fontWeight: 600, color: 'var(--accent)' }}>
+                        {isOutgoing ? e.target : e.source}
+                      </td>
+                      <td>
+                        <span style={{
+                          display: 'inline-block',
+                          padding: '0.125rem 0.5rem',
+                          borderRadius: '1rem',
+                          fontSize: '0.75rem',
+                          fontWeight: 600,
+                          background: 'rgba(59,130,246,0.15)',
+                          color: '#3b82f6',
+                        }}>
+                          {e.targetType}
+                        </span>
+                      </td>
+                      <td style={{ textAlign: 'right' }} className="mono">{formatCount(e.callCount)}</td>
+                      <td style={{ textAlign: 'right', color: errorRateColor(e.errorRate) }} className="mono">
+                        {formatErrorRate(e.errorRate)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import type { TraceSummary } from '../api/types'
+import type { SavedQuery, TraceSummary } from '../api/types'
+import { api } from '../api/client'
 import {
   durationColor,
   formatDuration,
@@ -68,8 +69,14 @@ export function TracesPage(): ReactElement {
     const o = searchParams.get('offset')
     return o ? parseInt(o, 10) || 0 : 0
   })
+  const [savedQueries, setSavedQueries] = useState<SavedQuery[]>([])
+  const [savingQuery, setSavingQuery] = useState(false)
 
   const apiBase = '/api/v1'
+
+  useEffect(() => {
+    api.getSavedQueries().then(setSavedQueries).catch(() => {})
+  }, [])
 
   // Fetch services for dropdown
   useEffect(() => {
@@ -137,6 +144,53 @@ export function TracesPage(): ReactElement {
 
   const updateFilter = (key: keyof Filters, value: string) => {
     setFilters((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const saveCurrentQuery = async () => {
+    const hasFilters = filters.service || filters.operation || filters.status || filters.minDurationMs
+    if (!hasFilters) return
+    const parts = [
+      filters.service,
+      filters.operation,
+      filters.status,
+      filters.minDurationMs ? `>${filters.minDurationMs}ms` : '',
+    ].filter(Boolean)
+    const name = parts.join(' / ') || 'Unnamed query'
+    setSavingQuery(true)
+    try {
+      await api.createSavedQuery({
+        name,
+        service: filters.service || undefined,
+        operation: filters.operation || undefined,
+        status: filters.status || undefined,
+        minDurationUs: filters.minDurationMs ? Math.round(parseFloat(filters.minDurationMs) * 1000) : undefined,
+      })
+      const updated = await api.getSavedQueries()
+      setSavedQueries(updated)
+    } catch {
+      // ignore
+    } finally {
+      setSavingQuery(false)
+    }
+  }
+
+  const applySavedQuery = (q: SavedQuery) => {
+    setFilters((prev) => ({
+      ...prev,
+      service: q.service || '',
+      operation: q.operation || '',
+      status: q.status || '',
+      minDurationMs: q.minDurationUs ? String(q.minDurationUs / 1000) : '',
+    }))
+  }
+
+  const deleteSavedQuery = async (id: number) => {
+    try {
+      await api.deleteSavedQuery(id)
+      setSavedQueries((prev) => prev.filter((q) => q.id !== id))
+    } catch {
+      // ignore
+    }
   }
 
   return (
@@ -248,7 +302,72 @@ export function TracesPage(): ReactElement {
         <button onClick={() => search(0)} style={buttonStyle}>
           Search
         </button>
+        <a
+          href={api.getExportUrl(
+            new Date(filters.from).toISOString(),
+            new Date(filters.to).toISOString(),
+            filters.service || undefined,
+            filters.status && filters.status !== 'all' ? filters.status : undefined,
+          )}
+          download="spans.ndjson"
+          style={{
+            ...buttonStyle,
+            background: 'transparent',
+            border: '1px solid #374151',
+            textDecoration: 'none',
+            display: 'inline-flex',
+            alignItems: 'center',
+          }}
+        >
+          Export
+        </a>
+        <button
+          onClick={saveCurrentQuery}
+          disabled={savingQuery || !(filters.service || filters.operation || filters.status || filters.minDurationMs)}
+          style={{
+            ...buttonStyle,
+            background: 'transparent',
+            border: '1px solid #374151',
+            opacity: (filters.service || filters.operation || filters.status || filters.minDurationMs) ? 1 : 0.4,
+            cursor: (filters.service || filters.operation || filters.status || filters.minDurationMs) ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {savingQuery ? 'Saving...' : 'Save Query'}
+        </button>
       </div>
+
+      {/* Saved queries */}
+      {savedQueries.length > 0 && (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+          <span style={{ fontSize: 12, color: '#6b7280', alignSelf: 'center' }}>Saved:</span>
+          {savedQueries.map((q) => (
+            <span
+              key={q.id}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
+                background: '#1f2937',
+                border: '1px solid #374151',
+                borderRadius: 16,
+                padding: '3px 10px',
+                fontSize: 12,
+                color: '#d1d5db',
+                cursor: 'pointer',
+              }}
+            >
+              <span onClick={() => applySavedQuery(q)}>{q.name}</span>
+              <span
+                onClick={() => deleteSavedQuery(q.id)}
+                style={{ color: '#6b7280', fontSize: 14, lineHeight: 1 }}
+                title="Delete"
+              >
+                &times;
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
 
       {/* Error */}
       {error && (


### PR DESCRIPTION
## Summary

- **Performance**: Fix N+1 queries in service/operation stats, batch aggregation upserts, add query timeouts (30s), optimize span deletion, add HTTP cache headers (30s on list endpoints)
- **Tiered retention**: Full span retention (72h default), extended retention for error/slow spans (7d default), configurable ingest-time sampling (keep-all by default)
- **New features**: Service map (force-directed graph), live tail (SSE streaming), comparison overlay on timeseries charts, saved queries on traces page, NDJSON bulk export endpoint
- **Docs**: Fix README config defaults to match actual code values, add new settings

## Test plan
- [x] `go test -race ./...` — all pass
- [x] `npx vitest run` — 59/59 pass
- [x] TypeScript compiles clean
- [ ] CI green
- [ ] Verify on testing (nijmegen) after merge
- [ ] Deploy to production via workflow_dispatch