### PR TITLE
chore: clear deprecation warnings from CI output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   spec:
     runs-on: [self-hosted, build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Spec checks
         shell: bash
         run: make spec-check
@@ -19,7 +19,7 @@ jobs:
   code:
     runs-on: [self-hosted, build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Detect manifests
         id: detect
         shell: bash
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up Go
         if: steps.detect.outputs.go_mods != '0'
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
           cache: false
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set up Node
         if: steps.detect.outputs.node_manifests != '0'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: ''

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -8,11 +8,10 @@ version = "0.1.0"
 description = "SpanBarn telemetry SDK for Python"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = "MIT"
 authors = [{name = "Wiebe Zweers", email = "wiebe@webwiebe.nl"}]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4 → v6`, `actions/setup-go@v5 → v6`, `actions/setup-node@v4 → v6` in `ci.yml`.
- Switches `sdks/python/pyproject.toml` to PEP 639 SPDX license form (`license = "MIT"`) and bumps build requirement to `setuptools>=77.0`.
- Drops the redundant `License :: OSI Approved :: MIT License` classifier (deprecated under PEP 639).

## Why
Two deprecation streams were appearing on every CI run:
1. `##[warning]Node.js 20 actions are deprecated` — bumping action majors to versions that target Node.js 24 natively is the actual fix (the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var only changed the wording).
2. `SetuptoolsDeprecationWarning: project.license as a TOML table is deprecated` (deadline 2027-02-18) and `License classifiers are deprecated`. PEP 639 is the modern path; setuptools 77+ supports it.

Verified locally: `uv build --sdist` on the SDK now produces no deprecation warnings.

## Test plan
- [ ] CI green on this PR.
- [ ] No `Node.js 20 actions are deprecated` lines in CI output.
- [ ] No `SetuptoolsDeprecationWarning` lines in the Python-checks step.