### PR TITLE
feat: FunnelBarn analytics integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,18 @@ SPANBARN_SELF_ENDPOINT=https://spanbarn.wiebe.xyz
 # SPANBARN_SELF_API_KEY=<set via SOPS secret>
 SPANBARN_ENVIRONMENT=production
 
+# -- BugBarn error tracking (optional) -----------------------------------------
+# SPANBARN_BUGBARN_ENDPOINT=https://bugbarn.wiebe.xyz
+# SPANBARN_BUGBARN_API_KEY=<set via SOPS secret>
+
+# -- FunnelBarn analytics (optional) ------------------------------------------
+# When set, the SPA fetches these via /api/v1/client-config at boot and sends
+# page_view + custom events to FunnelBarn. Get a project key from:
+#   https://funnelbarn.wiebe.xyz/api/v1/setup/spanbarn
+# SPANBARN_FUNNELBARN_ENDPOINT=https://funnelbarn.wiebe.xyz
+# SPANBARN_FUNNELBARN_API_KEY=<set via SOPS secret>
+# SPANBARN_FUNNELBARN_PROJECT=spanbarn
+
 # -- Rate limiting -------------------------------------------------------------
 
 # SPANBARN_LOGIN_RATE_PER_MINUTE=20

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -171,16 +171,19 @@ func run() error {
 	}
 
 	serverCfg := api.ServerConfig{
-		APIKey:         cfg.APIKey,
-		MaxBodyBytes:   cfg.MaxBodyBytes,
-		AllowedOrigins: cfg.AllowedOrigins,
-		Version:        Version,
-		MetricsToken:   cfg.MetricsToken,
-		LoginRate:      cfg.LoginRatePerMinute,
-		IngestRate:     cfg.IngestRatePerMinute,
-		APIRate:        cfg.APIRatePerMinute,
-		SessionSecret:  cfg.SessionSecret,
-		PublicURL:      cfg.PublicURL,
+		APIKey:             cfg.APIKey,
+		MaxBodyBytes:       cfg.MaxBodyBytes,
+		AllowedOrigins:     cfg.AllowedOrigins,
+		Version:            Version,
+		MetricsToken:       cfg.MetricsToken,
+		LoginRate:          cfg.LoginRatePerMinute,
+		IngestRate:         cfg.IngestRatePerMinute,
+		APIRate:            cfg.APIRatePerMinute,
+		SessionSecret:      cfg.SessionSecret,
+		PublicURL:          cfg.PublicURL,
+		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
+		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
+		FunnelBarnProject:  cfg.FunnelBarnProject,
 	}
 	apiServer := api.NewServerWithQuery(serverCfg, ingestHandler, querySvc, sessionMgr, logger, api.WithRepository(repo), api.WithAuthorizer(authorizer), api.WithPaths(cfg.DBPath, cfg.SpoolDir), api.WithCache(querySvc.Cache()))
 

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -13,3 +13,21 @@ func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		Version: s.version,
 	})
 }
+
+// handleClientConfig returns the public runtime config the SPA needs at boot.
+// Only non-secret values that the browser is expected to send back upstream are
+// included. When an integration is not configured server-side, its block is
+// omitted so the SPA can no-op cleanly.
+func (s *Server) handleClientConfig(w http.ResponseWriter, _ *http.Request) {
+	resp := map[string]any{}
+	if s.funnelBarn.Endpoint != "" {
+		resp["funnelbarn"] = map[string]string{
+			"endpoint": s.funnelBarn.Endpoint,
+			"api_key":  s.funnelBarn.APIKey,
+			"project":  s.funnelBarn.Project,
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -11,6 +11,10 @@ func (s *Server) registerRoutes() {
 	// Health endpoint — no auth required.
 	s.mux.HandleFunc("/api/v1/health", s.handleHealth)
 
+	// Client-config endpoint — public, no auth. Exposes only non-secret values
+	// (e.g. funnelbarn project + ingest API key) that the SPA needs at boot.
+	s.mux.HandleFunc("/api/v1/client-config", s.handleClientConfig)
+
 	// Internal ingest endpoint — used by ingest pods to forward spans to writer.
 	// Uses raw API key auth (pod-to-pod, no need for SHA256/DB lookup).
 	if s.ingest != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -16,16 +16,19 @@ import (
 
 // ServerConfig holds configuration for the HTTP server.
 type ServerConfig struct {
-	APIKey         string
-	MaxBodyBytes   int64
-	AllowedOrigins []string
-	Version        string
-	MetricsToken   string // Bearer token for /metrics; empty = no auth
-	LoginRate      int    // per-minute rate limit for login; 0 = default (10)
-	IngestRate     int    // per-minute rate limit for ingest; 0 = default (600)
-	APIRate        int    // per-minute rate limit for API queries; 0 = default (120)
-	SessionSecret  string
-	PublicURL      string
+	APIKey             string
+	MaxBodyBytes       int64
+	AllowedOrigins     []string
+	Version            string
+	MetricsToken       string // Bearer token for /metrics; empty = no auth
+	LoginRate          int    // per-minute rate limit for login; 0 = default (10)
+	IngestRate         int    // per-minute rate limit for ingest; 0 = default (600)
+	APIRate            int    // per-minute rate limit for API queries; 0 = default (120)
+	SessionSecret      string
+	PublicURL          string
+	FunnelBarnEndpoint string
+	FunnelBarnAPIKey   string
+	FunnelBarnProject  string
 }
 
 // Server is the HTTP server for SpanBarn.
@@ -39,6 +42,7 @@ type Server struct {
 	metricsToken   string
 	sessionSecret  string
 	publicURL      string
+	funnelBarn     funnelBarnConfig
 	rateLimiter    *RateLimiter
 	metrics        *Metrics
 	ingest         *ingest.Handler
@@ -50,6 +54,14 @@ type Server struct {
 	spoolDir       string
 	cache          *cache.Cache
 	logger         *slog.Logger
+}
+
+// funnelBarnConfig captures the public bits of the FunnelBarn integration
+// that the SPA needs at boot. Empty Endpoint disables analytics.
+type funnelBarnConfig struct {
+	Endpoint string
+	APIKey   string
+	Project  string
 }
 
 // ServerOption configures optional Server dependencies.
@@ -107,6 +119,11 @@ func NewServerWithQuery(cfg ServerConfig, ingestHandler *ingest.Handler, querySv
 		metricsToken:   cfg.MetricsToken,
 		sessionSecret:  cfg.SessionSecret,
 		publicURL:      cfg.PublicURL,
+		funnelBarn: funnelBarnConfig{
+			Endpoint: cfg.FunnelBarnEndpoint,
+			APIKey:   cfg.FunnelBarnAPIKey,
+			Project:  cfg.FunnelBarnProject,
+		},
 		rateLimiter:    NewRateLimiter(defaultRate(cfg.LoginRate, 10), defaultRate(cfg.IngestRate, 600), defaultRate(cfg.APIRate, 120)),
 		metrics:        NewMetrics(),
 		ingest:         ingestHandler,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	SelfAPIKey             string
 	BugBarnEndpoint        string
 	BugBarnAPIKey          string
+	FunnelBarnEndpoint     string
+	FunnelBarnAPIKey       string
+	FunnelBarnProject      string
 	Environment            string
 	LoginRatePerMinute     int
 	IngestRatePerMinute    int
@@ -72,6 +75,9 @@ func Load() Config {
 		SelfAPIKey:              os.Getenv("SPANBARN_SELF_API_KEY"),
 		BugBarnEndpoint:         os.Getenv("SPANBARN_BUGBARN_ENDPOINT"),
 		BugBarnAPIKey:           os.Getenv("SPANBARN_BUGBARN_API_KEY"),
+		FunnelBarnEndpoint:      os.Getenv("SPANBARN_FUNNELBARN_ENDPOINT"),
+		FunnelBarnAPIKey:        os.Getenv("SPANBARN_FUNNELBARN_API_KEY"),
+		FunnelBarnProject:       getenv("SPANBARN_FUNNELBARN_PROJECT", "spanbarn"),
 		Environment:             getenv("SPANBARN_ENVIRONMENT", "development"),
 		LoginRatePerMinute:      getenvInt("SPANBARN_LOGIN_RATE_PER_MINUTE", 10),
 		IngestRatePerMinute:     getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),

--- a/web/src/funnelbarn.ts
+++ b/web/src/funnelbarn.ts
@@ -1,0 +1,95 @@
+// FunnelBarn analytics integration. Config is fetched from
+// /api/v1/client-config at boot — when the server has no FunnelBarn env vars
+// set, the response omits the funnelbarn block and all tracking calls no-op.
+
+let endpoint = ''
+let apiKey = ''
+let project = ''
+let configured = false
+
+const SESSION_KEY = 'fb_sid'
+const SESSION_EXP_KEY = 'fb_sid_exp'
+const SESSION_TTL = 30 * 60 * 1000 // 30 min idle
+
+interface FBEvent {
+  name: string
+  session_id: string
+  timestamp: string
+  url?: string
+  properties?: Record<string, unknown>
+}
+
+interface ClientConfig {
+  funnelbarn?: { endpoint?: string; api_key?: string; project?: string }
+}
+
+function sessionId(): string {
+  try {
+    const now = Date.now()
+    const exp = Number(localStorage.getItem(SESSION_EXP_KEY) ?? 0)
+    let sid = localStorage.getItem(SESSION_KEY)
+    if (!sid || now > exp) {
+      sid = crypto.randomUUID()
+      localStorage.setItem(SESSION_KEY, sid)
+    }
+    localStorage.setItem(SESSION_EXP_KEY, String(now + SESSION_TTL))
+    return sid
+  } catch {
+    return 'unknown'
+  }
+}
+
+function makeEvent(name: string, properties?: Record<string, unknown>): FBEvent {
+  return {
+    name,
+    session_id: sessionId(),
+    timestamp: new Date().toISOString(),
+    url: location.href,
+    properties,
+  }
+}
+
+async function send(ev: FBEvent): Promise<void> {
+  if (!configured) return
+  try {
+    await fetch(`${endpoint}/api/v1/events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-funnelbarn-api-key': apiKey,
+        'x-funnelbarn-project': project,
+      },
+      body: JSON.stringify(ev),
+      keepalive: true,
+    })
+  } catch { /* fire-and-forget */ }
+}
+
+export async function initFunnelBarn(): Promise<void> {
+  if (typeof window === 'undefined') return
+  try {
+    const r = await fetch('/api/v1/client-config', { credentials: 'same-origin' })
+    if (!r.ok) return
+    const cfg: ClientConfig = await r.json()
+    const fb = cfg.funnelbarn
+    if (!fb || !fb.endpoint || !fb.api_key) return
+    endpoint = fb.endpoint.replace(/\/+$/, '')
+    apiKey = fb.api_key
+    project = fb.project || 'spanbarn'
+    configured = true
+    fbPage()
+  } catch { /* leave unconfigured; tracking calls no-op */ }
+}
+
+export function fbPage(properties?: Record<string, unknown>): void {
+  void send(makeEvent('page_view', {
+    path: location.pathname,
+    referrer: document.referrer || undefined,
+    ...properties,
+  }))
+}
+
+export function fbTrack(name: string, properties?: Record<string, unknown>): void {
+  if (!name) return
+  void send(makeEvent(name, properties))
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,8 +3,10 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { initInstrumentation } from './instrumentation'
+import { initFunnelBarn } from './funnelbarn'
 
 initInstrumentation()
+void initFunnelBarn()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

Spanbarn previously had no way to report SPA page views or custom analytics events to FunnelBarn. This PR mirrors the bugbarn-side pattern:

- Server reads \`SPANBARN_FUNNELBARN_{ENDPOINT,API_KEY,PROJECT}\` from env
- Exposes them via a new public \`GET /api/v1/client-config\` endpoint
- SPA fetches that config on boot and sends fire-and-forget \`page_view\` + custom events

When env vars are unset, \`/api/v1/client-config\` returns \`{}\` and the SPA no-ops cleanly — preserving the zero-config single-user default.

### Changes

- \`internal/config/config.go\` — add \`SPANBARN_FUNNELBARN_*\` (project defaults to \`\"spanbarn\"\`)
- \`internal/api/server.go\` — thread FunnelBarn config through \`ServerConfig\` + \`Server\`
- \`internal/api/health.go\` — new \`handleClientConfig\`
- \`internal/api/routes.go\` — register \`GET /api/v1/client-config\` (public, no auth)
- \`web/src/funnelbarn.ts\` (new) — \`initFunnelBarn\`/\`fbPage\`/\`fbTrack\` module
- \`web/src/main.tsx\` — bootstrap \`initFunnelBarn\` alongside instrumentation
- \`.env.example\` — document the FunnelBarn + existing BugBarn env vars
- \`cmd/spanbarn/main.go\` — pass new config into \`ServerConfig\`

## Test plan

- [ ] CI green (go build, go test, lint, vitest, frontend build)
- [ ] Post-deploy with \`SPANBARN_FUNNELBARN_*\` set: \`curl https://spanbarn-test.nijmegen.wiebe.xyz/api/v1/client-config\` returns the \`funnelbarn\` block
- [ ] Without env set: same endpoint returns \`{}\`
- [ ] After visiting the dashboard, a \`page_view\` shows up in the funnelbarn dashboard under the \`spanbarn\` project slug