### PR TITLE
feat(secrets): wire SPANBARN_FUNNELBARN_* per environment

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -15,7 +15,14 @@ stringData:
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:jM20n0XqmsQ2wwpmvA==,iv:UcUUl4LWPIvHizGNI7a8QPO/Jtt80k7tML2MCE7gOms=,tag:6lq35hT88H17PhlSDi7Few==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Dbkzv1wqjWC0k8LOAEDQr3fCsGLaZlgfRakaIYNCAJ1WT02iXZb0uA==,iv:n4wv+IPTUOGD7orE1zVlEWnVhd06qWRep9W8lhYKR3E=,tag:HEsYDi6S5mt6LNe5FvY48A==,type:str]
     LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:zliUmcsRrrZosg==,iv:4gYRVpT70/N37pyh0eut9Yj6NkULKzqiKVuCovRj3u4=,tag:S7zVkudg2rjMPz1P5coWWw==,type:str]
+    SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:HwNgHUUYQWDZbOkvf+dIu78u+r/n6QMlDBKoiQ==,iv:4aV+qBP9+080KDePZCcEKC5ibLkRCsEst9jWePASMMc=,tag:LaMg+njHse/LlKLlbFctjg==,type:str]
+    SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:NzfEXAgvLmhu91duv7RNf3yCOWCrO7ZnCTaQHavttue7l6PwEUMA0Q==,iv:1J3oijSev45KGhiyKXUJQ3MFuSAQ8LmUkfI9WublE4M=,tag:OWPTf+RT3SqjzU8R7pyrAg==,type:str]
+    SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:e94Ys2daiPQ=,iv:oeTSIaA2P4XN0ldC7V+6cX0tkYbbucBDqNr3DWLdbh4=,tag:3CvpuWycQ2lw7G6+eb++8w==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -26,7 +33,8 @@ sops:
             elo4cko3b01ZdTViOC9zNk5KZFY4RjgKlc1P892HWbmiCQ1iD+l0LXD4JDjmxJzN
             ppLLPXz3vwKSirpHk5wVQ2NAPKL28G+8Hcz2LaoXXO0akhxqRHxSiw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-11T21:38:52Z"
-    mac: ENC[AES256_GCM,data:jJMLCixoXj5oaPL06usqbGNFaSgpBU9AcOIflBAykXL7RxPnawe/oI4Jq5lh9bQBl+RoRdKQu2MRuqwwDFWrqd+Y7Ytt2A0H8+V6WWtEM25dk/2xcY83hqfVVnSMfyUZuKME1kY+P5i9ltTnrWIZfQYiUG1aoFF1HjuPJCjRDrw=,iv:IpmWX+tz5FuT3hCR310yN+8ZJoG6iFoqImzXu24cRRw=,tag:Ym+CscQSD547F4Q5lFHSmw==,type:str]
+    lastmodified: "2026-05-18T15:09:12Z"
+    mac: ENC[AES256_GCM,data:TSW/gFKEPDPenk36kOHxlks+a+IuomyPxGtDq3cM01uhlYhY/62LZl/R2JYyT6QMFv5tG5n4HNkhLBHmnwhfMtxu1DJ1GNG0h2CoQOK3NwKo4NNjyzafan5uz+oYYAGdcqjK3u37VoaAJJkd2i+IveLSgEvjjfZHJxrO/YD7Zqk=,iv:4oeNGUVgUldzp/+KDqIggpM3swaCsVYcS4qF4WYN85g=,tag:eQNge/1lEoW7z+APXoGH8g==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -15,7 +15,14 @@ stringData:
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:QgWQyliKk7q9E3QtZZTLAw==,iv:4JE/Qbcb5VgGAV4En+LFB6zdyTZ9l2y3FaIlwaZ9Z60=,tag:zYbrY9EHVlRQ9Y+P5B7JYw==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Yv82Wvn+6zdazZNVy7yZ4mRvUh9K4+zI,iv:bKTfd3OIuAxt1+pd2cRbCwzUlHy4YWTRISPi3tm6nYc=,tag:En3M41p9UfT5xzGankUxMA==,type:str]
     LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:SM2F0H7tfQ==,iv:VJxXCOq68za6jsG+t1ynpyqZHXE4rHvgd3YDB+R97XA=,tag:W5ii99UA36kSNcrwSEEvQg==,type:str]
+    SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:h+Mf5+nQ+WhisnE6D48fVC1PKR3A+xnNI7utkTUa5t3PnuPIu1ddeGrKxgwE,iv:a1omGkMAHi+OI4/r+zbMYFJw/WStMaCxReeZ5UhZ0us=,tag:EyGSj3RGWAmZneg2uBITNQ==,type:str]
+    SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:0SobfTf6o8OE7Q1MGufNg1sHeO4aKXTWswTkp06RnKkFkxGKmtHr5A==,iv:mJxgYFc13tu8NBtwHF6dk7oY82fsei/VF0UaaUM4+4c=,tag:EEG4ODxHLWN20LiwavK3wQ==,type:str]
+    SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:5yXWq8p0xYw=,iv:74PfHQBQ2ee7r/6u0HX4Uxxpc3mqPRq9AEXDcVPxxDE=,tag:53fWTWNFnGd2z3ZA9Tdyww==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -26,7 +33,8 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-07T12:15:21Z"
-    mac: ENC[AES256_GCM,data:428KckJmN8nm/1nkAZixWJexCdXK2NGZ0OQDhpLOeGzVKmVbt+oAY7iHrU2f1m+kzJ/cnuvjgialJfe7156ZsGelBCQQpkJVcbwpU31dmhZz9JpgMZIP94vjhEgUWWPdDEEhXUTdOYSIpLRs+d7GEMWKeIxbab3sV441Xr6nxlc=,iv:8VS2gT/2KRPGH4/tp9+juUI5kfVtdTxbw7yXNh3/dyk=,tag:bMBb8Pj85/0HrBU5QBRnqA==,type:str]
+    lastmodified: "2026-05-18T15:09:12Z"
+    mac: ENC[AES256_GCM,data:KM39jFB1LWIVPeeyGjePhlkJ3SO85vkZDNf9j96rrVX3FjDtHkpoD75PzHB1HSjSc8DCEmgGyojoxD8S8p6ONGB3BKfLIFJIyQMPcoF1Grtm0O9EQOTHVb21QAUVlhlPVgUSsyZ6TXWl/NxnAkf6Rd8oZ4Y6kCiUNcx7SpW5F7I=,iv:xhXf6UHvLWFfnG9rXuxe0wpdMyXjxDEc3YIHK4TGpwI=,tag:DEVwQ3J1xQwC1nO9tECeEA==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -15,7 +15,14 @@ stringData:
     LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:9gnsYwXnFHHTrDEdps0HsQ==,iv:q60lde7qQEA9CNLiGdOY3BCoG6U6IyHd3NdTxAKQzUM=,tag:d3xoAhHjmvovVCWXezNJXA==,type:str]
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Tk+BNzSxotPfX2M6gOV0kNWuj5GVOJOi,iv:cm1bcquY9XKguT8cku/sItbXYYETXm0zmrPl6xu19Sc=,tag:9x6o7GONQ1LJhfrVmghZ1A==,type:str]
     LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:4m5vHY2f8A==,iv:zNnHTpuSKo7fQy0T80cA4tldJTZAg0oeZr+gsPLbDrU=,tag:63dm5nCVTQhPeki/ia5x9A==,type:str]
+    SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:S2ly6KrXUhB1zMY4+biiWGUGS4LVGL/VsHhZIqNirZdKgryOeGd6XgYU,iv:JNqvbKDjeY0jgViHYpWw2QZY2KBYP/+eP8PVDP2+HB4=,tag:ydai4XqyPtqOx2k35eqMLw==,type:str]
+    SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:C0W0Ukf7sv8JZwQv45ior5saiVQkWnduhinNcgx2RF3Ffk4I8Orj4g==,iv:TYnG7XLwMZBBOO58ZeV4HHNHJ8jv7HAQO79htuimMoE=,tag:Dzy5y5z+ZVYjNNU/OTbOYw==,type:str]
+    SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:6vKWatS+5c8=,iv:OSZGVOt+AQdRYY0hrnMBnTjL9hSeQkGWX+5U9+fq4Tw=,tag:ZzbxrR8svo/R254Ks3tslA==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -26,7 +33,8 @@ sops:
             QmhZck9TZEdTLzNLa0JXR2kxSlBIVUEK7ulhIe1LbASOM3DYo8/N3m3M5+K22bFD
             W4ZfrOTU9W2TFMvtDAkFNLQw6kb6CmPmR6n638+ZT5E5R7WYb61AZQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-07T12:15:21Z"
-    mac: ENC[AES256_GCM,data:faIRGRWO2T4Y6dFbFP5gymkNxY98pIuqzyRof2N4owT8lUOyUcXMNCI22Dqg4PKkRtuTnQTQM1UPonspGAnSF+A2mnXQ1Q/PAj+LnJvg3djnSXBRvntp3fCp/T3mVdhPeR8PDT0Q6Ppp7aaeS+eM/HfJL8WiyvQSKkucmeaJFQ0=,iv:nczsErovkyyWiM1Xp/gBq36Th7+pSVV6IFSjj3cFa+c=,tag:I9hEaF6AytY+2lOC3gSGRg==,type:str]
+    lastmodified: "2026-05-18T15:09:12Z"
+    mac: ENC[AES256_GCM,data:cz75QDoEDgPT98EzIgWuBGQENkrmFa1+B6DC64Dyr01n4bVkle+nqkoedJX3Z5FZDch+51MRdW1Z9UZMzCEvS3piqYir/pB9+19kv8q2D36WuVaZLSr2UJKh7vqc8pCXzVhTY3oBRNUo7sMgDm/yt63OwWnTCgvbQrMTK2pkTVA=,iv:II416FFMS4cpF4zDsWsT0f2+zruJHp4QlVfajfNzanw=,tag:PZoIcb5RoeysSXuGTlZZag==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

Per-environment FunnelBarn credentials so spanbarn dogfoods the matching funnelbarn:

- testing → \`funnelbarn-test.nijmegen.wiebe.xyz\`
- staging → \`funnelbarn-staging.nijmegen.wiebe.xyz\`
- production → \`funnelbarn.wiebe.xyz\`

Keys generated via \`funnelbarn-{env}.../api/v1/setup/spanbarn\` (deterministic per project slug).

The base deployment already loads secrets with \`envFrom\`, so no manifest change is needed — the new keys are picked up automatically. Pairs with #53 (code) so the SPA's \`/api/v1/client-config\` returns the funnelbarn block on test and staging just like it will on production.

## Test plan

- [ ] CI deploys cleanly
- [ ] \`curl https://spanbarn-test.nijmegen.wiebe.xyz/api/v1/client-config\` returns the test funnelbarn block (not \`{}\`)
- [ ] Same for staging and production
- [ ] Page-view event appears in the per-env funnelbarn dashboard under project \`spanbarn\`