### PR TITLE
fix(ingest): wire FunnelBarn config into ingest-mode ServerConfig

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -432,15 +432,18 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 	}
 
 	serverCfg := api.ServerConfig{
-		APIKey:         cfg.APIKey,
-		MaxBodyBytes:   cfg.MaxBodyBytes,
-		AllowedOrigins: cfg.AllowedOrigins,
-		Version:        Version,
-		LoginRate:      cfg.LoginRatePerMinute,
-		IngestRate:     cfg.IngestRatePerMinute,
-		APIRate:        cfg.APIRatePerMinute,
-		SessionSecret:  cfg.SessionSecret,
-		PublicURL:      cfg.PublicURL,
+		APIKey:             cfg.APIKey,
+		MaxBodyBytes:       cfg.MaxBodyBytes,
+		AllowedOrigins:     cfg.AllowedOrigins,
+		Version:            Version,
+		LoginRate:          cfg.LoginRatePerMinute,
+		IngestRate:         cfg.IngestRatePerMinute,
+		APIRate:            cfg.APIRatePerMinute,
+		SessionSecret:      cfg.SessionSecret,
+		PublicURL:          cfg.PublicURL,
+		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
+		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
+		FunnelBarnProject:  cfg.FunnelBarnProject,
 	}
 	opts := []api.ServerOption{api.WithAuthorizer(authorizer)}
 	if roRepo != nil {


### PR DESCRIPTION
## Summary

After #53 and #55 the spanbarn writer pod has \`SPANBARN_FUNNELBARN_*\` env vars wired through to the API, but \`/api/v1/client-config\` still returned \`{}\` on \`spanbarn-test\`.

Root cause: the dashboard read path (\`/api\` GETs incl. \`client-config\`) is routed to the spanbarn-ingest pod via the \`spanbarn-reads\` Service — it owns the read-only DB so reads survive writer rollouts. The ingest pod builds its own \`api.ServerConfig\` in \`runIngestMode()\` and that construction was missing the three FunnelBarn fields, so the \`Server.funnelBarn\` struct stayed empty regardless of what was in the secret.

Add them next to the existing \`PublicURL\`/\`SessionSecret\` plumbing. Writer mode already had them in the main \`NewServerWithQuery\` call site.

## Test plan

- [ ] CI green
- [ ] After deploy, \`curl https://spanbarn-test.nijmegen.wiebe.xyz/api/v1/client-config\` returns the funnelbarn block (not \`{}\`)
- [ ] Same on staging once the staging pipeline rolls a new image