### PR TITLE
feat(secrets): dogfood per-env bugbarn from spanbarn

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -7,7 +7,7 @@ type: ENC[AES256_GCM,data:ylHD6MWV,iv:M0fmwRPjfjavNFGwMMvWMpdcmGJYRkiFEZIR4yrjbY
 stringData:
     SPANBARN_API_KEY: ENC[AES256_GCM,data:z9VR0O3UGGy1kGI36yBv3V1Pxo8+76fJhYamXYFr5253t4ep4rj2PQ==,iv:sRRTWpAcmon9Ynf4thJDwj8LsA3yAB+NDLHUburJg+M=,tag:qxzgIFbqs9jOT7LL9n9KTg==,type:str]
     SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:66ZeTJrS1oUmO6a/J/+NH5U8TVxAcmKnq8fcK0bvfUT0W9JWroyWY8qMwR2x/xp8QVj4h2y61Z/2zKOGtI0dpA==,iv:CDHecYFAIWbWv0+3gK3n4UeJvi85t7ewBbRRtur2jFQ=,tag:L4PGqaFexYlIXLMRoen1fA==,type:str]
-    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:OlVVuhbwE5RL5Y5E6n57dGGHZz0JicSA7jMIX9x/sZWxvEwSDzMKjA==,iv:DgNdVPeSd7f/JYugO0o6d3U9HChagc2EelgL3dE63nc=,tag:CnMaQosIOUvrQ/DfcFbqLg==,type:str]
+    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:z39HVpW805obWghsUeaeF1WtHUwCHNOpW2mUpW3d1JH/y5v+LH/UyQ==,iv:eAQoKeIr54Jw6JdzZemKQb3+wPdh/qidasYiI/vQ9y8=,tag:uSRLkcM0qh92+DNOl8OXqw==,type:str]
     SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:+aX1cEUA4g==,iv:yrxwbZrD/gkKN2AalFApYV7IH9dwKAGZYkFtRHACSxY=,tag:/oLHc2EnxWH7F4w/2crbKQ==,type:str]
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:SVBfM9c=,iv:DW3O9ltZxf2XvKthwam7DeTjDHR5jwRZs/i6P2ZPonQ=,tag:T2/wHfGJTL3/MNcpEy9psA==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:Vacvyi6PUmk=,iv:EmdHo9MT+yecjJ9OKi+V+/7QQVjdLd5Wv7hAbjr/avc=,tag:056ciKnaBPhW2+DMPcj2RA==,type:str]
@@ -18,6 +18,7 @@ stringData:
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:h+Mf5+nQ+WhisnE6D48fVC1PKR3A+xnNI7utkTUa5t3PnuPIu1ddeGrKxgwE,iv:a1omGkMAHi+OI4/r+zbMYFJw/WStMaCxReeZ5UhZ0us=,tag:EyGSj3RGWAmZneg2uBITNQ==,type:str]
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:0SobfTf6o8OE7Q1MGufNg1sHeO4aKXTWswTkp06RnKkFkxGKmtHr5A==,iv:mJxgYFc13tu8NBtwHF6dk7oY82fsei/VF0UaaUM4+4c=,tag:EEG4ODxHLWN20LiwavK3wQ==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:5yXWq8p0xYw=,iv:74PfHQBQ2ee7r/6u0HX4Uxxpc3mqPRq9AEXDcVPxxDE=,tag:53fWTWNFnGd2z3ZA9Tdyww==,type:str]
+    SPANBARN_BUGBARN_ENDPOINT: ENC[AES256_GCM,data:eW5XxZjkFos4gLcpXw61SJGpfZXAWLsTnDIQ5jdDqUSY,iv:DEuUL4CB4H8nq0OYyeWJflVlDF4o2R2hPrrTH4cUMh0=,tag:daAltyF/54xmRz3ZQ7AyPg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -33,8 +34,8 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T15:09:12Z"
-    mac: ENC[AES256_GCM,data:KM39jFB1LWIVPeeyGjePhlkJ3SO85vkZDNf9j96rrVX3FjDtHkpoD75PzHB1HSjSc8DCEmgGyojoxD8S8p6ONGB3BKfLIFJIyQMPcoF1Grtm0O9EQOTHVb21QAUVlhlPVgUSsyZ6TXWl/NxnAkf6Rd8oZ4Y6kCiUNcx7SpW5F7I=,iv:xhXf6UHvLWFfnG9rXuxe0wpdMyXjxDEc3YIHK4TGpwI=,tag:DEVwQ3J1xQwC1nO9tECeEA==,type:str]
+    lastmodified: "2026-05-18T15:49:00Z"
+    mac: ENC[AES256_GCM,data:NVqvhnpDtQwFxvBcvgwiyHJVMRIWufZHlBEnsF6XN/5Hy9J25aM5scVlncoJl1vp1pF8zJjTVQe8bllsfq2dj1uNxPH7qLyW/c6X7+8UYq7tKccdyCGNDxa4dvW82MY2y9fAV9l2yr0VOhT6PUBzL5C/Y7tdH9Fe8b2+EfyIHY8=,iv:rMzOs5/9FQIIDGC+esZbTO/Qvg32I4Cvt/4Xsl1zAII=,tag:hb1+XGWHlHlEFZPo6ldTjg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -7,7 +7,7 @@ type: ENC[AES256_GCM,data:PBas/Z4a,iv:dMjKHW6dxHxnw/8sYYkYT5G/gRRaGCtOcsyQze1jS3
 stringData:
     SPANBARN_API_KEY: ENC[AES256_GCM,data:eQdyEszm1jhAXh91iwogkR/gbA75u8xuNEsH83jRicO2xEs+YN4/YQ==,iv:D/DpOulBTN4IIxzpKlRGb62e8GOPCuPaP/wf1jI1k38=,tag:G7vBAzUJpz+iuIeKLRDKPA==,type:str]
     SPANBARN_SESSION_SECRET: ENC[AES256_GCM,data:keeAJg8IMC3WhlT+/YtcRyQwCBv4s3M+4mffGNXyyP/JnkF7N0aZJC5qM1+8H+NeRm9ezlZs9xNFMJiRJbBRKw==,iv:pq36d+CvLcoQsKY1e8X1u8tdrD/HayiAwCSLFP+ZUh4=,tag:081u7Q+XZcXqIr9E4X8+Ew==,type:str]
-    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:jkSdXzqBy6ywcVvYbTE/XGDpsJQFED35RmMWnr9XoQmuyWaqERR8Ew==,iv:mmm4xK/8qS1xS7L0rJGIaNLKCkqw4uUl/2C1qPnfiG0=,tag:gvlhlamHnWyxUV+cvN5ijQ==,type:str]
+    SPANBARN_BUGBARN_API_KEY: ENC[AES256_GCM,data:QlmcnUH+grgt1EqUg1dZoQTWBiFzEbQaYQalqrOlgT5rjGDfdVCGug==,iv:Q7xeDLdZrBd6dP8djslhY3k9m6BdC79UyTJ5Lrs8J+0=,tag:0tjPEWDD3VIEs5pryFfwRA==,type:str]
     SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:Igaljcb7wQ==,iv:zfSJDfcb1WfJX1f8xIS7ZbZ8izhfrpFrCMGhgYidUCQ=,tag:LojB6lGvcSFRq8duFch7eQ==,type:str]
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:Cw7nl4Q=,iv:/0I/VhPUOLDWjDXiqR755iYVHjbKYmPCWseZxrbxWjo=,tag:1y28Eg6b8G7waGnqOFwkAw==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:d0OmilQE928=,iv:g86zTfLw2h9vw+S1lr8egOvaZImZO4rrYF5OQcKvXMY=,tag:V3JDOx0BLdhyALs3sFh8Fw==,type:str]
@@ -18,6 +18,7 @@ stringData:
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:S2ly6KrXUhB1zMY4+biiWGUGS4LVGL/VsHhZIqNirZdKgryOeGd6XgYU,iv:JNqvbKDjeY0jgViHYpWw2QZY2KBYP/+eP8PVDP2+HB4=,tag:ydai4XqyPtqOx2k35eqMLw==,type:str]
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:C0W0Ukf7sv8JZwQv45ior5saiVQkWnduhinNcgx2RF3Ffk4I8Orj4g==,iv:TYnG7XLwMZBBOO58ZeV4HHNHJ8jv7HAQO79htuimMoE=,tag:Dzy5y5z+ZVYjNNU/OTbOYw==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:6vKWatS+5c8=,iv:OSZGVOt+AQdRYY0hrnMBnTjL9hSeQkGWX+5U9+fq4Tw=,tag:ZzbxrR8svo/R254Ks3tslA==,type:str]
+    SPANBARN_BUGBARN_ENDPOINT: ENC[AES256_GCM,data:IQPsePQT4DrLTd+wS+vBeem0Cuq+Qm6wDVwQvDyC,iv:TCtFFhukVAPDXm0BiHa9S4BcTMTQowyNY158xOfBy+g=,tag:RoGN/wthX0jDvByvD7UdPg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -33,8 +34,8 @@ sops:
             QmhZck9TZEdTLzNLa0JXR2kxSlBIVUEK7ulhIe1LbASOM3DYo8/N3m3M5+K22bFD
             W4ZfrOTU9W2TFMvtDAkFNLQw6kb6CmPmR6n638+ZT5E5R7WYb61AZQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T15:09:12Z"
-    mac: ENC[AES256_GCM,data:cz75QDoEDgPT98EzIgWuBGQENkrmFa1+B6DC64Dyr01n4bVkle+nqkoedJX3Z5FZDch+51MRdW1Z9UZMzCEvS3piqYir/pB9+19kv8q2D36WuVaZLSr2UJKh7vqc8pCXzVhTY3oBRNUo7sMgDm/yt63OwWnTCgvbQrMTK2pkTVA=,iv:II416FFMS4cpF4zDsWsT0f2+zruJHp4QlVfajfNzanw=,tag:PZoIcb5RoeysSXuGTlZZag==,type:str]
+    lastmodified: "2026-05-18T15:49:00Z"
+    mac: ENC[AES256_GCM,data:uTXZbLhkVpW/r893WNFF24OLaWZTas181S5b3fvjSQqkDySkcIAf+Q78faA0krtbGbNzStTyQal/umdn7BhYYxo8kLhNKW+G+/vc4TFaonERlZVPmhavLqlZ/pYyDNCYWQptpWREKxw+gfs/pd6CO8jINtHkARlYlmNipKrIZEQ=,iv:gGdgAwOM/JmeD2c6RdG9jQJsfSxb0mG9V1kW2cctaA0=,tag:u0TIPBcA+Dz/VM/kJ/oejw==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

The base configmap hardcodes \`SPANBARN_BUGBARN_ENDPOINT\` to the prod URL for every env, and the secret's \`SPANBARN_BUGBARN_API_KEY\` was the prod key too. Add per-env overrides in the testing/staging secrets — \`envFrom: secretRef\` takes precedence over \`configMapRef\` so the secret wins.

- testing → \`bugbarn.test.wiebe.xyz\` + per-env spanbarn project key
- staging → \`bugbarn.staging.wiebe.xyz\` + per-env spanbarn project key
- production → unchanged (configmap default + matching secret key already point at prod)

## Test plan

- [ ] CI green
- [ ] An error in spanbarn-test appears in bugbarn.test.wiebe.xyz (not prod)