### PR TITLE
feat(ingress): serve testing+staging at spanbarn.{test,staging}.wiebe.xyz

### DIFF
--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -6,28 +6,28 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/v1/traces`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/v1/traces`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/spans`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/spans`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/telemetry`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/telemetry`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/client-errors`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/client-errors`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
 
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
       kind: Rule
       priority: 100
       services:
@@ -35,25 +35,25 @@ spec:
           port: 8080
 
     # Setup is GET-but-writes (creates pending project + setup API key) — route to writer.
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/setup`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/setup`)
       kind: Rule
       priority: 100
       services:
         - name: spanbarn
           port: 8080
 
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/api`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`)
       kind: Rule
       services:
         - name: spanbarn-reads
           port: 8080
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`) && PathPrefix(`/v1`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/v1`)
       kind: Rule
       services:
         - name: spanbarn-reads
           port: 8080
 
-    - match: Host(`spanbarn-staging.nijmegen.wiebe.xyz`)
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`))
       kind: Rule
       services:
         - name: spanbarn-web

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -6,28 +6,28 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/v1/traces`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/v1/traces`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/spans`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/spans`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/telemetry`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/telemetry`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/client-errors`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/client-errors`)
       kind: Rule
       services:
         - name: spanbarn-ingest
           port: 8080
 
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
       kind: Rule
       priority: 100
       services:
@@ -35,25 +35,25 @@ spec:
           port: 8080
 
     # Setup is GET-but-writes (creates pending project + setup API key) — route to writer.
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api/v1/setup`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/setup`)
       kind: Rule
       priority: 100
       services:
         - name: spanbarn
           port: 8080
 
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/api`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`)
       kind: Rule
       services:
         - name: spanbarn-reads
           port: 8080
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`) && PathPrefix(`/v1`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/v1`)
       kind: Rule
       services:
         - name: spanbarn-reads
           port: 8080
 
-    - match: Host(`spanbarn-test.nijmegen.wiebe.xyz`)
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`))
       kind: Rule
       services:
         - name: spanbarn-web


### PR DESCRIPTION
## Summary

Move spanbarn's non-prod hostnames onto the canonical \`*.{test,staging}.wiebe.xyz\` wildcard the rest of the barns already use. Legacy \`spanbarn-{test,staging}.nijmegen.wiebe.xyz\` hosts stay in the route match so consumers keep working during the migration; a follow-up will drop them.

### Changes

Each route was wrapped from
\`\`\`
Host(\`spanbarn-{env}.nijmegen.wiebe.xyz\`) && PathPrefix(...)
\`\`\`
to
\`\`\`
(Host(\`spanbarn.{env}.wiebe.xyz\`) || Host(\`spanbarn-{env}.nijmegen.wiebe.xyz\`)) && PathPrefix(...)
\`\`\`
so the writer/ingest/reads/web split keeps routing correctly under either hostname. Traefik's Let's Encrypt resolver issues a cert per host it sees in the rules.

## Test plan

- [ ] Deploy applies cleanly
- [ ] \`curl https://spanbarn.test.wiebe.xyz/api/v1/health\` returns 200
- [ ] \`curl https://spanbarn-test.nijmegen.wiebe.xyz/api/v1/health\` still returns 200 (legacy alias)