### PR TITLE
fix(ci): use long-lived PAT for cluster GHCR pull secret

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -177,8 +177,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "
@@ -258,8 +258,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=spanbarn-staging \
               --dry-run=client -o yaml | kubectl apply -f -
           "

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -110,8 +110,8 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${K3S_USER}@${K3S_HOST}" "
             kubectl create secret docker-registry ghcr-secret \
               --docker-server=ghcr.io \
-              --docker-username='${{ github.actor }}' \
-              --docker-password='${{ secrets.GITHUB_TOKEN }}' \
+              --docker-username='webwiebe' \
+              --docker-password='${{ secrets.GHCR_PULL_PAT }}' \
               --namespace=${NAMESPACE} \
               --dry-run=client -o yaml | kubectl apply -f -
           "


### PR DESCRIPTION
## Summary
- The cluster's `ghcr-secret` was being created with `secrets.GITHUB_TOKEN`, which is only valid for the workflow's lifetime. After the workflow ended, any pod that needed to pull (HPA scale-up, node reboot, eviction) hit a 403.
- Switch the kubectl-managed `ghcr-secret` to use a long-lived `GHCR_PULL_PAT` repo secret (classic PAT with `write:packages`) under `webwiebe`.
- Other `secrets.GITHUB_TOKEN` uses (docker login at image push, `gh` API in binary-release) are untouched — those only need workflow-duration validity.

Mirrors webwiebe/geobarn#13.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm `ghcr-secret` in the cluster authenticates after the workflow run completes (pod restart pulls cleanly)