### PR TITLE
feat(secrets): wire SPANBARN_OIDC_* for staging

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -19,6 +19,10 @@ stringData:
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:0SobfTf6o8OE7Q1MGufNg1sHeO4aKXTWswTkp06RnKkFkxGKmtHr5A==,iv:mJxgYFc13tu8NBtwHF6dk7oY82fsei/VF0UaaUM4+4c=,tag:EEG4ODxHLWN20LiwavK3wQ==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:5yXWq8p0xYw=,iv:74PfHQBQ2ee7r/6u0HX4Uxxpc3mqPRq9AEXDcVPxxDE=,tag:53fWTWNFnGd2z3ZA9Tdyww==,type:str]
     SPANBARN_BUGBARN_ENDPOINT: ENC[AES256_GCM,data:eW5XxZjkFos4gLcpXw61SJGpfZXAWLsTnDIQ5jdDqUSY,iv:DEuUL4CB4H8nq0OYyeWJflVlDF4o2R2hPrrTH4cUMh0=,tag:daAltyF/54xmRz3ZQ7AyPg==,type:str]
+    SPANBARN_OIDC_ISSUER: ENC[AES256_GCM,data:VOwmmB/Txtns/eU0eP8V8KxGH0YAxqS++nlmu+U=,iv:MKXzbXTa6pm1+AKh5xIz74zF1fwvMihfIQpDy9nBniA=,tag:L+q3wztaMDuz3AWITuWPug==,type:str]
+    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:GdAXPeMrlhqZZBa687mTnnNZ,iv:VuOR1D4IAg9N4jxyaCHQKke/ZZ+aQJ6p3P+d3qTzomE=,tag:iNMMAenO8iPMARQKKqg9RA==,type:str]
+    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:6ig95NQx6Qxw3BQg3RX8HGyU28ZxKha1yw5E2qKzq8VpWyGtDscV+fER7Q==,iv:5zVwDV+9EOMUIqoBlW8b/pOlLPxicWrgVeEsRqKQGRU=,tag:wuygGhIuB4iVg5tgj7M92A==,type:str]
+    SPANBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:hkd75gdMbhYdkAmGYTO8IZW7XYlkS5bNCx8HlIceLJVmaR6bS/Oh0Adb8KNWTokq0FsjACERmw==,iv:x+sGOR4inIU4dpmK7rwiR/ZG2H5P3a9Ky4vaT2ZXzLE=,tag:O3cbmyyzjGLRruhL36T1xg==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -34,8 +38,8 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-18T16:32:54Z"
-    mac: ENC[AES256_GCM,data:QX5FwhNBmZ931ROZEzoXKkBxbC5GC6CiHmyDSNLreYTUO4+pd2/D03IYheddOLw0aNi0B7+Tgu5VvF5n3MwaW4Muqc1uoDnnIgiPKOvKbxvp8US4bIUoLncVN2HP39IRpNBc/6ndVxuGX//CVcmcnFRyuYA1MOAlL9Li1Hwr28I=,iv:W9sVPVZPYaFCaK9srHxHbS5djTvfBHacldGfKj1ldQQ=,tag:7v/WV5G+YhceBiQqtPMaPA==,type:str]
+    lastmodified: "2026-05-19T09:56:46Z"
+    mac: ENC[AES256_GCM,data:UjEjI2hoozvlEM1mqTKVTeB37lfgY9nJa0CA+hJHTLSAfYLiGVqRwDbFlxSHV0cds4+7/MOJbqr4H8H9Lq5RmnU9on5uhu/pxOFT3P/Daf7gzhJ0az0m0tRfmlINkO1Tbpf4h0q5eyHtEGIsi8xWSXmvMIg+0Hmq81oZ7G2pyhA=,iv:m/hJ4FG6DvG2Nl/b8EmNWssmbKiPvtXC0SKL0Qxlcis=,tag:BnxQ+U7FN0Kke2HZ49YFrQ==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Adds the iambarn OIDC credentials to spanbarn-staging's SOPS secret. Client minted via `iamctl client create --confidential` on iambarn-staging.