### PR TITLE
feat(ui): add iambarn profile link to user menu

### DIFF
--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
@@ -31,6 +32,11 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, _ *http.Request) {
 		resp["oidc"] = map[string]any{
 			"enabled":  true,
 			"loginURL": "/api/v1/oidc/login",
+		}
+		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
+			resp["iambarn"] = map[string]string{
+				"profile_url": issuer + "/admin",
+			}
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/wiebe-xyz/spanbarn/internal/api"
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
 	"github.com/wiebe-xyz/spanbarn/internal/ingest"
 	"github.com/wiebe-xyz/spanbarn/internal/spool"
 )
@@ -52,4 +53,82 @@ func TestHealthEndpoint(t *testing.T) {
 	if result.Version != "1.2.3" {
 		t.Fatalf("expected version '1.2.3', got %q", result.Version)
 	}
+}
+
+func TestClientConfigOIDCNotSet(t *testing.T) {
+	srv := newServer(t, "1.0.0")
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v1/client-config")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var body map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := body["oidc"]; ok {
+		t.Fatalf("oidc block should be omitted when not configured: %v", body)
+	}
+	if _, ok := body["iambarn"]; ok {
+		t.Fatalf("iambarn block should be omitted when oidc is not configured: %v", body)
+	}
+}
+
+func TestClientConfigIAMBarnProfileURL(t *testing.T) {
+	srv := newServer(t, "1.0.0")
+	srv.SetOIDCClient(auth.NewOIDCClient(auth.OIDCConfig{
+		Issuer:       "https://iam.example.com/",
+		ClientID:     "spanbarn",
+		ClientSecret: "secret",
+		RedirectURL:  "https://spanbarn.example.com/api/v1/oidc/callback",
+	}))
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v1/client-config")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OIDC    map[string]any `json:"oidc"`
+		IAMBarn struct {
+			ProfileURL string `json:"profile_url"`
+		} `json:"iambarn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.OIDC == nil {
+		t.Fatalf("oidc block should be present")
+	}
+	if body.IAMBarn.ProfileURL != "https://iam.example.com/admin" {
+		t.Fatalf("unexpected profile_url: %q", body.IAMBarn.ProfileURL)
+	}
+}
+
+func newServer(t *testing.T, version string) *api.Server {
+	t.Helper()
+	q := ingest.NewQueue(1024)
+	sp, err := spool.NewSpool(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("spool: %v", err)
+	}
+	t.Cleanup(func() { sp.Close() })
+
+	h := ingest.NewHandler(q, sp, 0, slog.Default())
+	h.Start(t.Context())
+	t.Cleanup(func() { h.Stop() })
+
+	return api.NewServer(api.ServerConfig{APIKey: testAPIKey, Version: version}, h, slog.Default())
 }

--- a/web/src/api/clientConfig.ts
+++ b/web/src/api/clientConfig.ts
@@ -1,0 +1,30 @@
+// Public runtime config served by /api/v1/client-config. Blocks for
+// integrations that are not configured server-side are simply omitted, so the
+// SPA can render UI conditionally without leaking secrets.
+
+export interface ClientConfig {
+  funnelbarn?: { endpoint?: string; api_key?: string; project?: string }
+  oidc?: { enabled?: boolean; loginURL?: string }
+  iambarn?: { profile_url?: string }
+}
+
+let cached: Promise<ClientConfig> | null = null
+
+export function fetchClientConfig(): Promise<ClientConfig> {
+  if (cached) return cached
+  cached = (async () => {
+    try {
+      const res = await fetch('/api/v1/client-config', { credentials: 'same-origin' })
+      if (!res.ok) return {}
+      return (await res.json()) as ClientConfig
+    } catch {
+      return {}
+    }
+  })()
+  return cached
+}
+
+// Reset is exported for tests; production code does not need it.
+export function _resetClientConfigCache(): void {
+  cached = null
+}

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -1,7 +1,8 @@
-import { type ReactElement, useEffect } from 'react'
+import { type ReactElement, useEffect, useState } from 'react'
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { Activity, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe } from 'lucide-react'
+import { Activity, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe, UserCog } from 'lucide-react'
 import { api } from '../api/client'
+import { fetchClientConfig } from '../api/clientConfig'
 import { MobileTabBar } from './MobileTabBar'
 import { PWAInstallBanner } from './PWAInstallBanner'
 
@@ -21,6 +22,7 @@ const navItems = [
 export function DashboardLayout(): ReactElement {
   const navigate = useNavigate()
   const location = useLocation()
+  const [iambarnProfileURL, setIambarnProfileURL] = useState<string | null>(null)
 
   useEffect(() => {
     if (navigator.serviceWorker?.controller) {
@@ -30,6 +32,18 @@ export function DashboardLayout(): ReactElement {
       })
     }
   }, [location.pathname])
+
+  useEffect(() => {
+    let cancelled = false
+    void fetchClientConfig().then((cfg) => {
+      if (!cancelled && cfg.iambarn?.profile_url) {
+        setIambarnProfileURL(cfg.iambarn.profile_url)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleLogout = async () => {
     try {
@@ -98,8 +112,28 @@ export function DashboardLayout(): ReactElement {
           ))}
         </nav>
 
-        {/* Logout */}
+        {/* User actions */}
         <div style={{ padding: '0.75rem 0.5rem', borderTop: '1px solid var(--border)' }}>
+          {iambarnProfileURL && (
+            <a
+              href={iambarnProfileURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="btn"
+              style={{
+                width: '100%',
+                justifyContent: 'center',
+                background: 'transparent',
+                border: 'none',
+                color: 'var(--text-muted)',
+                marginBottom: '0.25rem',
+                textDecoration: 'none',
+              }}
+            >
+              <UserCog size={16} />
+              Edit IAMBarn profile
+            </a>
+          )}
           <button
             onClick={handleLogout}
             className="btn"

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -1,7 +1,8 @@
-import { useState, type ReactElement } from 'react'
+import { useEffect, useState, type ReactElement } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { Activity, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut } from 'lucide-react'
+import { Activity, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut, UserCog } from 'lucide-react'
 import { api } from '../api/client'
+import { fetchClientConfig } from '../api/clientConfig'
 
 const tabs = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -12,7 +13,20 @@ const tabs = [
 
 export function MobileTabBar(): ReactElement {
   const [moreOpen, setMoreOpen] = useState(false)
+  const [iambarnProfileURL, setIambarnProfileURL] = useState<string | null>(null)
   const navigate = useNavigate()
+
+  useEffect(() => {
+    let cancelled = false
+    void fetchClientConfig().then((cfg) => {
+      if (!cancelled && cfg.iambarn?.profile_url) {
+        setIambarnProfileURL(cfg.iambarn.profile_url)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const handleLogout = async () => {
     try {
@@ -169,6 +183,29 @@ export function MobileTabBar(): ReactElement {
             <Settings size={18} />
             Settings
           </NavLink>
+          {iambarnProfileURL && (
+            <a
+              href={iambarnProfileURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setMoreOpen(false)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.625rem',
+                width: '100%',
+                padding: '0.625rem 0.75rem',
+                borderRadius: '0.5rem',
+                fontSize: '0.875rem',
+                fontWeight: 500,
+                color: 'var(--text-muted)',
+                textDecoration: 'none',
+              }}
+            >
+              <UserCog size={18} />
+              Edit IAMBarn profile
+            </a>
+          )}
           <button
             onClick={() => {
               setMoreOpen(false)


### PR DESCRIPTION
## Summary
- Backend: `/api/v1/client-config` now returns `iambarn.profile_url` (= `${OIDC_ISSUER}/admin`) whenever the OIDC client is configured. Trailing slashes on the issuer are normalized.
- Frontend: `DashboardLayout` (desktop sidebar) and `MobileTabBar` (PWA overflow menu) fetch the client-config on mount and render an "Edit IAMBarn profile" entry above the existing Logout button when `iambarn.profile_url` is present. The link opens in a new tab with `rel="noopener noreferrer"`. A shared `web/src/api/clientConfig.ts` memoizes the fetch so multiple consumers do not re-hit the endpoint.
- When OIDC is not configured server-side, the menu falls back to logout only — no UI changes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (new `TestClientConfigOIDCNotSet` + `TestClientConfigIAMBarnProfileURL`)
- [x] `npm --prefix web run build`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web test -- --run`
- [ ] Manual: with `SPANBARN_OIDC_ISSUER=https://iam.staging.wiebe.xyz` set, click "Edit IAMBarn profile" on desktop and mobile menus and confirm it opens `https://iam.staging.wiebe.xyz/admin` in a new tab.