### PR TITLE
fix(iambarn-profile): only show link for sessions actually opened via OIDC

### DIFF
--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -35,7 +35,7 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, _ *http.Request) {
 		}
 		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
 			resp["iambarn"] = map[string]string{
-				"profile_url": issuer + "/admin",
+				"profile_url": issuer + "/admin#profile",
 			}
 		}
 	}

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -112,7 +112,7 @@ func TestClientConfigIAMBarnProfileURL(t *testing.T) {
 	if body.OIDC == nil {
 		t.Fatalf("oidc block should be present")
 	}
-	if body.IAMBarn.ProfileURL != "https://iam.example.com/admin" {
+	if body.IAMBarn.ProfileURL != "https://iam.example.com/admin#profile" {
 		t.Fatalf("unexpected profile_url: %q", body.IAMBarn.ProfileURL)
 	}
 }

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -76,6 +76,15 @@ func HandleLogout() http.HandlerFunc {
 			HttpOnly: true,
 			SameSite: http.SameSiteLaxMode,
 		})
+		// Clear the auth-method hint set by the OIDC callback so a
+		// subsequent local login does not inherit the OIDC marker.
+		http.SetCookie(w, &http.Cookie{
+			Name:     "spanbarn_auth_method",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			SameSite: http.SameSiteLaxMode,
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -84,12 +84,24 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	secure := r.TLS != nil
+	expires := time.Now().Add(s.sessionMgr.TTL())
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",
 		Value:    token,
 		Path:     "/",
-		Expires:  time.Now().Add(s.sessionMgr.TTL()),
+		Expires:  expires,
 		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	// Non-HttpOnly hint so the SPA can show OIDC-specific UI (e.g. the
+	// IAMBarn profile link) only for sessions that actually came from
+	// iambarn. Same expiry as the session.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "spanbarn_auth_method",
+		Value:    "oidc",
+		Path:     "/",
+		Expires:  expires,
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})

--- a/web/src/api/clientConfig.ts
+++ b/web/src/api/clientConfig.ts
@@ -28,3 +28,12 @@ export function fetchClientConfig(): Promise<ClientConfig> {
 export function _resetClientConfigCache(): void {
   cached = null
 }
+
+// True only when the current session was established via the iambarn OIDC
+// callback. Local password sessions don't have a remote profile to link to.
+export function isOIDCSession(): boolean {
+  if (typeof document === 'undefined') return false
+  return document.cookie
+    .split('; ')
+    .some((c) => c.startsWith('spanbarn_auth_method=oidc'))
+}

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, useEffect, useState } from 'react'
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { Activity, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe, UserCog } from 'lucide-react'
 import { api } from '../api/client'
-import { fetchClientConfig } from '../api/clientConfig'
+import { fetchClientConfig, isOIDCSession } from '../api/clientConfig'
 import { MobileTabBar } from './MobileTabBar'
 import { PWAInstallBanner } from './PWAInstallBanner'
 
@@ -34,6 +34,10 @@ export function DashboardLayout(): ReactElement {
   }, [location.pathname])
 
   useEffect(() => {
+    // Only sessions actually opened via the iambarn OIDC callback should
+    // see the profile link — local password sessions don't have a remote
+    // profile to manage.
+    if (!isOIDCSession()) return
     let cancelled = false
     void fetchClientConfig().then((cfg) => {
       if (!cancelled && cfg.iambarn?.profile_url) {

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactElement } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { Activity, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut, UserCog } from 'lucide-react'
 import { api } from '../api/client'
-import { fetchClientConfig } from '../api/clientConfig'
+import { fetchClientConfig, isOIDCSession } from '../api/clientConfig'
 
 const tabs = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -17,6 +17,10 @@ export function MobileTabBar(): ReactElement {
   const navigate = useNavigate()
 
   useEffect(() => {
+    // Only sessions actually opened via the iambarn OIDC callback should
+    // see the profile link — local password sessions don't have a remote
+    // profile to manage.
+    if (!isOIDCSession()) return
     let cancelled = false
     void fetchClientConfig().then((cfg) => {
       if (!cancelled && cfg.iambarn?.profile_url) {


### PR DESCRIPTION
## Summary
- OIDC callback sets a non-HttpOnly `spanbarn_auth_method=oidc` cookie at session-mint time (same expiry as session); logout clears it.
- `client-config` now emits `iambarn.profile_url = {issuer}/admin#profile` so iambarn's admin SPA opens directly on the profile section.
- Sidebar (`DashboardLayout`) and `MobileTabBar` gate the "Edit IAMBarn profile" link on the new cookie via a shared `isOIDCSession()` helper, so local password sessions no longer see a link to a profile page they don't have.

Mirrors bugbarn PR #90.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `npm --prefix web run build`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web test -- --run`
- [ ] CI green