### PR TITLE
feat: serve /.well-known/iambarn-theme.json

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -15,6 +15,11 @@ func (s *Server) registerRoutes() {
 	// (e.g. funnelbarn project + ingest API key) that the SPA needs at boot.
 	s.mux.HandleFunc("/api/v1/client-config", s.handleClientConfig)
 
+	// IAMBarn theme manifest — public, no auth, no redirects. Served at the
+	// well-known path so IAMBarn can adopt SpanBarn's brand on its login page
+	// when users arrive via an OAuth authorize redirect from this host.
+	s.mux.HandleFunc("/.well-known/iambarn-theme.json", s.handleThemeManifest)
+
 	// OIDC login flow — public, no auth required. Returns 404 when OIDC is not
 	// configured server-side, so the SPA can fall through to local login.
 	s.mux.HandleFunc("/api/v1/oidc/login", s.handleOIDCLogin)

--- a/internal/api/theme.go
+++ b/internal/api/theme.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// themeManifest is the schema served at /.well-known/iambarn-theme.json.
+// IAMBarn fetches this file when a user lands on its login page via an OAuth
+// authorize redirect originating from a SpanBarn host, so the login screen can
+// adopt SpanBarn's brand colours, name, and logo. Field names and shape match
+// the contract in iambarn/internal/theme.
+type themeManifest struct {
+	Name            string `json:"name"`
+	LogoURL         string `json:"logo_url"`
+	PrimaryColor    string `json:"primary_color"`
+	BackgroundColor string `json:"background_color"`
+	CardColor       string `json:"card_color"`
+	BodyTextColor   string `json:"body_text_color"`
+	SupportURL      string `json:"support_url"`
+	Locale          string `json:"locale"`
+}
+
+// spanBarnThemeManifest holds the values served at /.well-known/iambarn-theme.json.
+// Colours mirror the CSS variables in web/src/index.css so the IAMBarn login
+// page stays visually consistent with the SpanBarn UI. URLs are absolute and
+// point at the canonical production host.
+var spanBarnThemeManifest = themeManifest{
+	Name:            "SpanBarn",
+	LogoURL:         "https://spanbarn.wiebe.xyz/favicon.svg",
+	PrimaryColor:    "#3b82f6", // --accent
+	BackgroundColor: "#0f1117", // --bg
+	CardColor:       "#1a1d27", // --surface
+	BodyTextColor:   "#e2e8f0", // --text
+	SupportURL:      "https://spanbarn.wiebe.xyz",
+	Locale:          "en",
+}
+
+// handleThemeManifest serves the public IAMBarn theme manifest. The endpoint
+// is unauthenticated, returns application/json, and must not redirect — the
+// IAMBarn cache uses CheckRedirect=ErrUseLastResponse and treats any 3xx as a
+// failure.
+func (s *Server) handleThemeManifest(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(spanBarnThemeManifest)
+}

--- a/internal/api/theme_test.go
+++ b/internal/api/theme_test.go
@@ -1,0 +1,63 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Manifest mirrors the iambarn theme.Manifest contract the endpoint must
+// satisfy. Duplicated here (rather than imported) so this test fails loudly if
+// the on-the-wire shape ever drifts from what IAMBarn's fetcher decodes into.
+type themeManifest struct {
+	Name            string `json:"name"`
+	LogoURL         string `json:"logo_url"`
+	PrimaryColor    string `json:"primary_color"`
+	BackgroundColor string `json:"background_color"`
+	CardColor       string `json:"card_color"`
+	BodyTextColor   string `json:"body_text_color"`
+	SupportURL      string `json:"support_url"`
+	Locale          string `json:"locale"`
+}
+
+func TestIAMBarnThemeManifestEndpoint(t *testing.T) {
+	srv := newServer(t, "1.0.0")
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	// Use a client that does not follow redirects — IAMBarn fetches this
+	// resource with the same constraint and treats any 3xx as a hard failure.
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/.well-known/iambarn-theme.json", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected Content-Type to contain application/json, got %q", ct)
+	}
+
+	var m themeManifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if m.Name == "" {
+		t.Fatalf("expected name to be populated, got empty manifest: %+v", m)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a public, unauthenticated `GET /.well-known/iambarn-theme.json` endpoint that returns SpanBarn's brand manifest in the schema IAMBarn's relying-party theme fetcher expects.
- Colours are pulled straight from `web/src/index.css` CSS variables so the IAMBarn login page stays visually consistent with the SpanBarn UI.
- Endpoint sets `Content-Type: application/json`, returns HTTP 200, and never redirects — IAMBarn rejects any 3xx for the well-known path.

## Theme values
| Field | Value | Source |
|---|---|---|
| `name` | `SpanBarn` | brand |
| `logo_url` | `https://spanbarn.wiebe.xyz/favicon.svg` | `web/public/favicon.svg` |
| `primary_color` | `#3b82f6` | CSS `--accent` |
| `background_color` | `#0f1117` | CSS `--bg` (also PWA `theme_color`) |
| `card_color` | `#1a1d27` | CSS `--surface` |
| `body_text_color` | `#e2e8f0` | CSS `--text` |
| `support_url` | `https://spanbarn.wiebe.xyz` | production host |
| `locale` | `en` | UI is English-only today |

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] New `TestIAMBarnThemeManifestEndpoint` asserts 200, `Content-Type: application/json`, no redirects (client uses `ErrUseLastResponse`), decodes into the manifest shape, and has `name` populated.
- [ ] After deploy, `curl -sH 'Accept: application/json' https://spanbarn.wiebe.xyz/.well-known/iambarn-theme.json` returns the manifest with HTTP 200 and no redirect.