### PR TITLE
fix(ingress): route /.well-known/iambarn-theme.json to API backend

### DIFF
--- a/deploy/k8s/production/ingress.yaml
+++ b/deploy/k8s/production/ingress.yaml
@@ -53,6 +53,16 @@ spec:
         - name: spanbarn
           port: 8080
 
+    # Well-known theme manifest served by the Go backend, not the SPA.
+    # priority: 101 beats the static frontend catch-all so it doesn't fall
+    # through to index.html.
+    - match: Host(`spanbarn.wiebe.xyz`) && Path(`/.well-known/iambarn-theme.json`)
+      kind: Rule
+      priority: 101
+      services:
+        - name: spanbarn-reads
+          port: 8080
+
     # Reads — load-balanced across writer + ingest pods (both carry
     # spanbarn.io/serves-reads). When the writer is unready during a deploy,
     # k8s drops it from this Service's endpoints and the ingest pod (read-only

--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -42,6 +42,15 @@ spec:
         - name: spanbarn
           port: 8080
 
+    # Well-known theme manifest served by the Go backend, not the SPA.
+    # priority: 101 beats the static frontend catch-all.
+    - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && Path(`/.well-known/iambarn-theme.json`)
+      kind: Rule
+      priority: 101
+      services:
+        - name: spanbarn-reads
+          port: 8080
+
     - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`)
       kind: Rule
       services:

--- a/deploy/k8s/testing/ingress.yaml
+++ b/deploy/k8s/testing/ingress.yaml
@@ -42,6 +42,15 @@ spec:
         - name: spanbarn
           port: 8080
 
+    # Well-known theme manifest served by the Go backend, not the SPA.
+    # priority: 101 beats the static frontend catch-all.
+    - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && Path(`/.well-known/iambarn-theme.json`)
+      kind: Rule
+      priority: 101
+      services:
+        - name: spanbarn-reads
+          port: 8080
+
     - match: (Host(`spanbarn.test.wiebe.xyz`) || Host(`spanbarn-test.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`)
       kind: Rule
       services:


### PR DESCRIPTION
## Summary

`https://spanbarn.wiebe.xyz/.well-known/iambarn-theme.json` was falling through to the SPA catch-all and returning `index.html` instead of the JSON manifest the Go handler from #68 serves.

The Traefik `IngressRoute` has no priority on the static frontend rule, and no other rule matched `/.well-known/*`, so the SPA won.

## Fix

Add an explicit route in each environment's ingress:

- `Host(...) && Path('/.well-known/iambarn-theme.json')` (exact match)
- `priority: 101` (same precedence tier used by the ingest overrides, comfortably above the catch-all)
- Service: `spanbarn-reads` (the existing load-balanced read service across writer + ingest pods — the same target other GET `/api` reads use, and both binaries register the theme handler)

Applied to `testing`, `staging`, and `production` ingress YAMLs. No Go changes — `internal/api/theme.go` and `internal/api/routes.go` are already correct.

## Test plan

- [ ] CI green
- [ ] After deploy to testing: `curl -sS https://spanbarn.test.wiebe.xyz/.well-known/iambarn-theme.json` returns JSON with `Content-Type: application/json`, not HTML
- [ ] After deploy to production: same check against `spanbarn.wiebe.xyz`
- [ ] SPA routes (`/`, `/projects/...`) still serve the dashboard