### PR TITLE
chore(secrets): seed spanbarn-testing iambarn OIDC client

### DIFF
--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -20,11 +20,15 @@ stringData:
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:6vKWatS+5c8=,iv:OSZGVOt+AQdRYY0hrnMBnTjL9hSeQkGWX+5U9+fq4Tw=,tag:ZzbxrR8svo/R254Ks3tslA==,type:str]
     SPANBARN_BUGBARN_ENDPOINT: ENC[AES256_GCM,data:IQPsePQT4DrLTd+wS+vBeem0Cuq+Qm6wDVwQvDyC,iv:TCtFFhukVAPDXm0BiHa9S4BcTMTQowyNY158xOfBy+g=,tag:RoGN/wthX0jDvByvD7UdPg==,type:str]
     SPANBARN_OIDC_ISSUER: ENC[AES256_GCM,data:2f77mzZjSncCF1vmanpNZ6/iOYzIFC8F0E0=,iv:CkAu885LHMsD1lODSKGN9OcLZ6F/3MJWtp/RhiBoloY=,tag:E8NKrMKaG0KE3Oi09b5ZXQ==,type:str]
-    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:zyadC2cU+WGHSaJXV+smYuOm,iv:y5pS2w1c3xMjCtMQS7zWv4BwFzL0PRpUkYoKy27Gteg=,tag:1phfavkFF/OYQwF85D8Fnw==,type:str]
-    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:OI5GZs11czFKoebv7krf4Su6dCvzsQpO+ZqTXFOAbodVaLX6Ul7ZK1TDzA==,iv:9O6nvLJpxUqGO/V7UT7B8GGRfVpyapY7yAucJVr+AsA=,tag:Ilj+PgvLHo/QwGjqmi31Zw==,type:str]
+    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:qlbF52h+DJwuQeLjGCTOL3I0,iv:arP5aTLsiCZ9wro9uatI7KwE7DhjTTt/vUIsP44kbvc=,tag:vwbiPIyGtv6SBSqDr5ARFg==,type:str]
+    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:3Cu4i7ooS0dJiApAMOdL1SN+7p7X+gF8rE9p8PFMN+xXDRps9q4VtRnChw==,iv:RQIafYXke2mz3WL43GxxNbXJbiokuMHV/YKS4gc68SU=,tag:YuOdakJ+zwQblcmxp4q+6Q==,type:str]
     SPANBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:MoVQ2ikzkM49+bZTxA141kGdTaQClt7X3XpDvIJ8cxpEuhy4xPndUQnWUpnFYhkEC9cMxA==,iv:VRrqGpSKhND9M/s7dFNj6RTN715SATCFHl572OghbF8=,tag:RMcD+yr1M827/xBJsrN1Rw==,type:str]
     SPANBARN_REDIS_QUEUE_URL: ENC[AES256_GCM,data:XgGvcUxaoA9DvS+RgFZ/EtYfkd4Jkyv+mAAy0Up2m7/6,iv:ajDGO7r7ooHiZL/W6VuwdG5qaqBh9Fr6KcjUH9jzSWs=,tag:tAqwC9w8cDSpiLNOfriBRg==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -35,7 +39,8 @@ sops:
             QmhZck9TZEdTLzNLa0JXR2kxSlBIVUEK7ulhIe1LbASOM3DYo8/N3m3M5+K22bFD
             W4ZfrOTU9W2TFMvtDAkFNLQw6kb6CmPmR6n638+ZT5E5R7WYb61AZQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T13:30:32Z"
-    mac: ENC[AES256_GCM,data:x+kqoFGa6wsweaiNdNffzamOGPQrvB0YrZnS/Os6QQUlYRIeD5y3HFVIJJMNdxT5KCYJ/PLEBKLXwpQwUVRQpCDV9vA28FO2pf3S+XXspO91doCOTzUlvECHkeFpX4ZY8aKhk7QUpj0wnrRz5ZMQySU3awyV36VsfjXiAQrLJjE=,iv:hu1h/NNCVrVQjYaIDPlZZY49CEiUvBu9Faz386j8KpI=,tag:9c9ede7B3QjTFRgWPSWBag==,type:str]
+    lastmodified: "2026-05-20T13:11:42Z"
+    mac: ENC[AES256_GCM,data:M0iSxqb+MwfpRKRXtD35byjGVhVgQTikhrhhDq2wDPg2YZDIB27S0tBe+RXcIW1g9ekJvxqgPrSjiiL9egzTxwbFvRS8Pbs+NIvMq4Q26znNB9UymsqiSDk5dnbxuA/Wy85J87OmeliXwwRYMOGis8/9DcPXSYBhHIi/FFs0F3c=,iv:vgOo8+t6w8v8Ps9sDy/McXBQDxNRqEJRKM6R8Rw5hyg=,tag:YWuC1yjl57kA2z+ipChZMA==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **spanbarn** in **iambarn-testing** and written the credentials into `deploy/k8s/testing/secret.yaml`.

- Client id: `ibc_dlmHNIC4…`
- Redirect URI: `https://spanbarn.test.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_h5yxfpj72k5c7cpa`

Next deploy of spanbarn-testing picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.