### PR TITLE
chore(secrets): seed spanbarn-staging iambarn OIDC client

### DIFF
--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -20,11 +20,15 @@ stringData:
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:5yXWq8p0xYw=,iv:74PfHQBQ2ee7r/6u0HX4Uxxpc3mqPRq9AEXDcVPxxDE=,tag:53fWTWNFnGd2z3ZA9Tdyww==,type:str]
     SPANBARN_BUGBARN_ENDPOINT: ENC[AES256_GCM,data:eW5XxZjkFos4gLcpXw61SJGpfZXAWLsTnDIQ5jdDqUSY,iv:DEuUL4CB4H8nq0OYyeWJflVlDF4o2R2hPrrTH4cUMh0=,tag:daAltyF/54xmRz3ZQ7AyPg==,type:str]
     SPANBARN_OIDC_ISSUER: ENC[AES256_GCM,data:VOwmmB/Txtns/eU0eP8V8KxGH0YAxqS++nlmu+U=,iv:MKXzbXTa6pm1+AKh5xIz74zF1fwvMihfIQpDy9nBniA=,tag:L+q3wztaMDuz3AWITuWPug==,type:str]
-    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:GdAXPeMrlhqZZBa687mTnnNZ,iv:VuOR1D4IAg9N4jxyaCHQKke/ZZ+aQJ6p3P+d3qTzomE=,tag:iNMMAenO8iPMARQKKqg9RA==,type:str]
-    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:6ig95NQx6Qxw3BQg3RX8HGyU28ZxKha1yw5E2qKzq8VpWyGtDscV+fER7Q==,iv:5zVwDV+9EOMUIqoBlW8b/pOlLPxicWrgVeEsRqKQGRU=,tag:wuygGhIuB4iVg5tgj7M92A==,type:str]
+    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:n1cdiPut0DmHKh/XAnGuAQO6,iv:z5bMOuxW6+P4MUfaHUgGf9mbu1pXWdK0hSH8FwQ+fW8=,tag:i3pXFzkiDEwVsO34yz9EcA==,type:str]
+    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:jGzXjLKAVCkYF9RkZFOh9oSfys3NIX9fLMa69YntVyBTenOwdKCnEsujyQ==,iv:CWL2Vst/+LSSuxxhEXgc4jUMlicBWbuRsTuJESL76OY=,tag:DQ7ahelxgxeUveieBOI22g==,type:str]
     SPANBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:hkd75gdMbhYdkAmGYTO8IZW7XYlkS5bNCx8HlIceLJVmaR6bS/Oh0Adb8KNWTokq0FsjACERmw==,iv:x+sGOR4inIU4dpmK7rwiR/ZG2H5P3a9Ky4vaT2ZXzLE=,tag:O3cbmyyzjGLRruhL36T1xg==,type:str]
     SPANBARN_REDIS_QUEUE_URL: ENC[AES256_GCM,data:HuJ8W1Coy6+EmvZspcuB1sNxb48Othc/LIVvcVhFTkJd,iv:08O2dZ08VLvVFrdtPElr2/FVQqbhv14aRnmWlYNxZhI=,tag:tpq7pc1BWu22NXWErUAn1Q==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -35,7 +39,8 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T12:59:42Z"
-    mac: ENC[AES256_GCM,data:avgYZwEwqWbpBy2v5q7y4rYcOVOO1zzy+GNxyCTHhkBVo7IH4DlbZRkejmpqNGaTMp69VjjE9lH2sAFUSURY5vEI0oEMkuEJMgICiPUpf5u89vMxJdByYgyvmhYWgsN9x+Ltm9+6ow8ZJHP8lsWUoq/JBBB4M8fn46kzPhCS/Gc=,iv:lB3R+mYPkq/PdU4rEVllcKdDsyMVzrJZ9OqtKCyUOmM=,tag:GIP7W4MVP2x89lCEXaTKAQ==,type:str]
+    lastmodified: "2026-05-20T13:11:50Z"
+    mac: ENC[AES256_GCM,data:zdrmEHwP+RlppXx+pkWQinwfXOeT8OHjHv33gRy5FHC9nO05DiF3Byjbx392R3D985Sev0Cx9Ew2vZxrYnpGYovg7dQnnfHuwqSN/uyM9Ui9g1VFmxb07lvW3e7FeOKsvMPFfxe8uxPeqMlV3elMKKnGwGcHCoNHbgHCKutjiNA=,iv:4gFUZgSSFRNKHuvCUP27uJ1OyucQQZ2KlVllJW5iOE4=,tag:0lUZf+ALFUv3ZDKIFhxVWw==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **spanbarn** in **iambarn-staging** and written the credentials into `deploy/k8s/staging/secret.yaml`.

- Client id: `ibc_4rD7tAPc…`
- Redirect URI: `https://spanbarn.staging.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_g4cl3dgbyqcjhgct`

Next deploy of spanbarn-staging picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.