### PR TITLE
chore(secrets): seed spanbarn-production iambarn OIDC client

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -19,11 +19,15 @@ stringData:
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:NzfEXAgvLmhu91duv7RNf3yCOWCrO7ZnCTaQHavttue7l6PwEUMA0Q==,iv:1J3oijSev45KGhiyKXUJQ3MFuSAQ8LmUkfI9WublE4M=,tag:OWPTf+RT3SqjzU8R7pyrAg==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:e94Ys2daiPQ=,iv:oeTSIaA2P4XN0ldC7V+6cX0tkYbbucBDqNr3DWLdbh4=,tag:3CvpuWycQ2lw7G6+eb++8w==,type:str]
     SPANBARN_OIDC_ISSUER: ENC[AES256_GCM,data:CJrFydOcxHwon5ZPOoZ0w4QJ0X3s,iv:b9482PXP8m1xUQ8m0plhNnPtLuGMu0N84KHAW1jI6Rk=,tag:R7iDmlMlajdE/0G5LWI1bQ==,type:str]
-    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:cVsc/tLYw3K5BISJh4DCfzeZ,iv:P6Bwo06t4bqHfjbSOQf4h+apyBtcRWxBbOJkaisnSXg=,tag:L+HqhFL74A9cN/y7dKx5xA==,type:str]
-    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:/El0hzdmtGxz4I/nOWU0ndLGvDlhTrSrqoxkL+n36I2vCgWANDOGEPA/TQ==,iv:RjjUy4tRt6KVUvBGVbh9p56jv8Rxq2QatncWfuTlXyc=,tag:oZID0V0DPp9AE2CRZzEzHA==,type:str]
+    SPANBARN_OIDC_CLIENT_ID: ENC[AES256_GCM,data:X1lNzKkgOQ/xQQJsphfxu/V7,iv:/0SjEHdOBp2t1sPwndvlSCW9nf+4BP18gRchwblCp2c=,tag:GlbciaFuqHXT8BkoyWp/pw==,type:str]
+    SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:zGrHxFz94L8OL/3a3apwG/H6+3yE8UUArh6SCzBN+7KxVqDleNTyoAYZbA==,iv:GBJj2iL6E8W+69kq6fiVtJ0HmmYV+d/pUIYepzB6L9g=,tag:4fzgfrvSj9H5hzMTcGmiyw==,type:str]
     SPANBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:8TyCIBS9VFYtjaD1mAXcC3qflHGU5CUeoUoxdZQAIjhpjMc+SHAcVaUIyCyMe+Y=,iv:VZJP0rOJmHarCHfg+BPopb4GHq2Kz/r3HtOjOJeI9Hw=,tag:t/TilM42DuKoJofulaW6Lg==,type:str]
     SPANBARN_REDIS_QUEUE_URL: ENC[AES256_GCM,data:/FRYzQ2Fs4Iq21hqIKuFwyllTS1qcXOAbTXD3di+tp6r,iv:X0iTq2SAYpDrbzpHEu+Gqhr9YqqqvWKBCpWjBnrjwNk=,tag:KSWzuGK8bHBnTfS79qLEow==,type:str]
 sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
           enc: |
@@ -34,7 +38,8 @@ sops:
             elo4cko3b01ZdTViOC9zNk5KZFY4RjgKlc1P892HWbmiCQ1iD+l0LXD4JDjmxJzN
             ppLLPXz3vwKSirpHk5wVQ2NAPKL28G+8Hcz2LaoXXO0akhxqRHxSiw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-19T12:59:38Z"
-    mac: ENC[AES256_GCM,data:3VgrmNH6zbNs/PWBXZ217t1hik5NdltnQBdgPxqdMhHTg1SGo31jSF3NxmlnhNHzXn1GvtXodFVWCyTUQPdu1LcT4ojVlG8lkS3+ZxJaerBsqNzXhrPzBwwUItzXsLDRlIy7ZTOh9oi3U3pCBmbEHV6abfyZl9Owqng9KGk9lVk=,iv:PDhC/PuKlyKoc7gvtzSHBff+/V+mQyt5v0o/9A9Huzo=,tag:daB5BRvTYtpSFrFZG6fyjQ==,type:str]
+    lastmodified: "2026-05-20T13:11:57Z"
+    mac: ENC[AES256_GCM,data:VpiqU7PpKzk6Am8kZnUQ+0JvggKb3BcRaEAlQYOMl4lDCuDnOmSX7GqbWXqQnQ7vd9CmXV+wk74WUDarmyBW6nKkUdRZrpbD5nz+N8f57MjxWnWDRFl/bRaJh6q5QFHK55D5HFlOcpE3Lvu6ODyUxlkbX+UTEToJ9d2npuP2Hec=,iv:Wukg4cvKsgJD4oT07nfPstmQ0sD7FjZOcRHrMxj5lHo=,tag:WIvCG+kcnhOi3tOiJh/xPA==,type:str]
+    pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Provisioned a confidential OIDC client for **spanbarn** in **iambarn-production** and written the credentials into `deploy/k8s/production/secret.yaml`.

- Client id: `ibc_4jMnJabC…`
- Redirect URI: `https://spanbarn.wiebe.xyz/api/v1/oidc/callback`
- Organization id: `org_qbwyqure4p2lm2hg`

Next deploy of spanbarn-production picks up the new credentials.

Provisioned via `/srv/projects/seed-iambarn-clients.sh`.