### PR TITLE
fix(sqlite): cap writer pool at 1 to fix SPA-27 SQLITE_BUSY

### DIFF
--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -43,6 +43,11 @@ func NewDB(dbPath string) (*DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite %s: %w", dbPath, err)
 	}
+	// SQLite allows only one writer at a time. Capping the pool to a single
+	// connection serializes writes in Go instead of letting two deferred
+	// transactions race to upgrade their locks — that race returns SQLITE_BUSY
+	// immediately and bypasses busy_timeout.
+	db.SetMaxOpenConns(1)
 	return &DB{DB: db}, nil
 }
 


### PR DESCRIPTION
## Summary
- Caps the writer `*sql.DB` pool at one connection so all writes serialize through a single SQLite connection.
- Fixes [SPA-27](https://bugbarn) `redis worker: inline aggregate persist failed` — recurring `database is locked (5) (SQLITE_BUSY)` on the inline aggregate upsert (every few minutes in prod).

## Why
The recent `8bae9a4` fix made `busy_timeout=30000` apply to every pool connection, but the errors continued. Root cause: `UpsertAggregates` (and others) use `db.Begin()`, which starts a **deferred** transaction. Deferred txs only take a SHARED lock at BEGIN and upgrade to RESERVED on the first write. When two pool connections both hold deferred txs and both try to upgrade, SQLite returns `SQLITE_BUSY` **immediately** — `busy_timeout` deliberately does not retry because both waiters would deadlock.

Capping `SetMaxOpenConns(1)` on the writer is the canonical Go+SQLite pattern: writes serialize in Go, the upgrade race can't happen, and `busy_timeout` still handles contention with external processes (Litestream). The read-only pool (`NewReadOnlyDB`) is untouched, so reads stay concurrent.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/repository/... ./internal/aggregation/... ./internal/worker/...`
- [ ] Watch SPA-27 in BugBarn after staging deploys
- [ ] Confirm no regression on inline aggregation latency in prod