### PR TITLE
fix(sqlite): run WAL checkpoint on writer pool to fix SPA-27

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -105,15 +105,6 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		repo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 	}
 
-	// Dedicated checkpoint connection — separate from the writer pool so the
-	// periodic WAL checkpoint does not queue behind the worker's aggregate-upsert
-	// transactions (which hold the single writer connection for a full BEGIN…COMMIT).
-	ckptDB, err := repository.NewCheckpointDB(cfg.DBPath)
-	if err != nil {
-		return fmt.Errorf("open checkpoint database: %w", err)
-	}
-	defer ckptDB.Close()
-
 	// Read-only DB — used exclusively by the query service for dashboard reads.
 	// In WAL mode, readers and the single writer don't block each other.
 	roDB, err := repository.NewReadOnlyDB(cfg.DBPath)
@@ -157,7 +148,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("worker", &wg, func() { w.Run(workerCtx) })
-	safeGo("wal-checkpoint", &wg, func() { ckptDB.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
@@ -281,7 +272,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	ingestHandler.Stop()
 	workerCancel()
 	wg.Wait()
-	ckptDB.FinalCheckpoint(logger)
+	db.FinalCheckpoint(logger)
 
 	logger.Info("shutdown complete")
 	return nil
@@ -518,15 +509,6 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		}
 	}
 
-	// Dedicated checkpoint connection — separate from the writer pool so the
-	// periodic WAL checkpoint does not queue behind the worker's aggregate-upsert
-	// transactions (which hold the single writer connection for a full BEGIN…COMMIT).
-	ckptDB, err := repository.NewCheckpointDB(cfg.DBPath)
-	if err != nil {
-		return fmt.Errorf("open checkpoint database: %w", err)
-	}
-	defer ckptDB.Close()
-
 	// Step 3: read-only DB for the query service — reads don't compete with writes.
 	roDB, err := repository.NewReadOnlyDB(cfg.DBPath)
 	if err != nil {
@@ -617,7 +599,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
-	safeGo("wal-checkpoint", &wg, func() { ckptDB.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
@@ -661,7 +643,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionCancel()
 	workerCancel()
 	wg.Wait()
-	ckptDB.FinalCheckpoint(logger)
+	db.FinalCheckpoint(logger)
 
 	logger.Info("writer shutdown complete")
 	return nil

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -93,20 +93,6 @@ func (d *DB) Close() error {
 	return d.DB.Close()
 }
 
-// NewCheckpointDB opens a dedicated write connection to dbPath used exclusively
-// for periodic WAL checkpoints. Keeping it separate from the writer pool means
-// checkpoint queries never queue behind a long aggregate-upsert transaction
-// (which holds the single MaxOpenConns(1) writer connection for the full
-// BEGIN…COMMIT duration).
-func NewCheckpointDB(dbPath string) (*DB, error) {
-	db, err := otelsql.Open("sqlite", buildDSN(dbPath, false), otelOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("open checkpoint sqlite %s: %w", dbPath, err)
-	}
-	db.SetMaxOpenConns(1)
-	return &DB{DB: db}, nil
-}
-
 // RunPeriodicCheckpoint blocks until ctx is cancelled, issuing a WAL TRUNCATE
 // checkpoint on each tick. When a checkpoint returns busy=1 (a reader snapshot
 // blocks full WAL backfill), it retries every retryInterval until the readers
@@ -117,8 +103,19 @@ func NewCheckpointDB(dbPath string) (*DB, error) {
 // only applies to write-lock conflicts between concurrent writers. Application-level
 // retry (done here) is required to eventually drain the WAL under read load.
 //
-// Call from a dedicated goroutine using a connection opened by NewCheckpointDB,
-// not the main writer DB, so checkpoint queries do not queue behind write transactions.
+// Call on the same writer *DB as every other writer. An earlier version used a
+// dedicated second connection to avoid queueing behind worker transactions, but
+// SQLite still only allows one writer at a time at the file level — a second
+// connection just moves the contention from Go's pool into SQLite's lock
+// machinery, where a deferred-tx upgrade against this connection's RESERVED
+// lock returns SQLITE_BUSY immediately and bypasses busy_timeout (root cause of
+// SPA-27). In-process serialisation via MaxOpenConns(1) is cheap because the
+// write transactions are tiny (small aggregate upserts, short CRUD txs).
+//
+// Long-horizon plan: hand off WAL maintenance to Litestream, the same way
+// BugBarn and FunnelBarn do. Once Litestream is doing the periodic checkpoint
+// as part of its replication loop, this goroutine can go away entirely and
+// "snapshots are not the writer's problem" becomes literally true.
 func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, log *slog.Logger) {
 	retryInterval := 5 * time.Second
 	t := time.NewTicker(interval)


### PR DESCRIPTION
## Summary
- Deletes `NewCheckpointDB` and runs the periodic WAL checkpoint on the same writer `*DB` as everything else.
- Fixes [SPA-27](https://bugbarn) — `redis worker: inline aggregate persist failed` / `database is locked (5) (SQLITE_BUSY)` every few minutes in prod.

## Why
The dedicated checkpoint connection added in `e86bcd8` reintroduced the exact failure mode `MaxOpenConns(1)` was meant to prevent. With two writer connections to the same file:

1. Redis-worker opens a deferred `BEGIN` for `UpsertAggregates` (takes SHARED).
2. Checkpoint connection grabs RESERVED for `PRAGMA wal_checkpoint(TRUNCATE)`.
3. Redis-worker's first write tries to upgrade SHARED → RESERVED.
4. SQLite returns `SQLITE_BUSY` **immediately**, before `busy_timeout` can help, because waiting would deadlock both sides.

Single writer connection means there is no second writer to race against; the upgrade path is impossible. All writers — redis-worker, retention, alerts, API CRUD, **and** checkpoint — serialize through one connection. Write transactions are tiny (aggregate batches are ~10–20 rows, CRUD txs are single statements), so queueing the checkpoint behind them is cheap.

## Long-term
Comment on `RunPeriodicCheckpoint` records the plan: hand WAL maintenance off to Litestream the way BugBarn and FunnelBarn already do. Once that's in place this goroutine goes away entirely.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/repository/... ./internal/aggregation/... ./internal/worker/... ./internal/retention/...`
- [ ] Watch SPA-27 in BugBarn after staging deploys — should stop accumulating events
- [ ] Confirm no growth in WAL file size in prod (checkpoint still running, just on the writer pool)