### PR TITLE
fix(sqlite): eliminate SQLITE_BUSY in EnsureProjectPending and WAL checkpoint contention

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -148,7 +149,11 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("worker", &wg, func() { w.Run(workerCtx) })
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	if !litestreamActive() {
+		safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	} else {
+		logger.Info("litestream detected: WAL checkpointing delegated to litestream")
+	}
 
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
@@ -599,7 +604,11 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	if !litestreamActive() {
+		safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	} else {
+		logger.Info("litestream detected: WAL checkpointing delegated to litestream")
+	}
 
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
@@ -703,6 +712,23 @@ func safeGo(name string, wg *sync.WaitGroup, fn func()) {
 		}()
 		fn()
 	}()
+}
+
+// litestreamActive returns true when this process is running as the -exec child
+// of Litestream. In that case Litestream owns WAL checkpointing as part of its
+// replication cycle; spanbarn must not run a competing checkpoint goroutine.
+// Detection mirrors the entrypoint.sh placeholder check.
+func litestreamActive() bool {
+	key := os.Getenv("LITESTREAM_ACCESS_KEY_ID")
+	if key == "" {
+		return false
+	}
+	for _, prefix := range []string{"REPLACE", "CHANGEME", "TODO", "PLACEHOLDER"} {
+		if strings.HasPrefix(key, prefix) {
+			return false
+		}
+	}
+	return true
 }
 
 func parseAggregationInterval(s string) time.Duration {

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -717,18 +716,8 @@ func safeGo(name string, wg *sync.WaitGroup, fn func()) {
 // litestreamActive returns true when this process is running as the -exec child
 // of Litestream. In that case Litestream owns WAL checkpointing as part of its
 // replication cycle; spanbarn must not run a competing checkpoint goroutine.
-// Detection mirrors the entrypoint.sh placeholder check.
 func litestreamActive() bool {
-	key := os.Getenv("LITESTREAM_ACCESS_KEY_ID")
-	if key == "" {
-		return false
-	}
-	for _, prefix := range []string{"REPLACE", "CHANGEME", "TODO", "PLACEHOLDER"} {
-		if strings.HasPrefix(key, prefix) {
-			return false
-		}
-	}
-	return true
+	return os.Getenv("LITESTREAM_ACCESS_KEY_ID") != ""
 }
 
 func parseAggregationInterval(s string) time.Duration {

--- a/internal/repository/repo_projects.go
+++ b/internal/repository/repo_projects.go
@@ -3,6 +3,8 @@ package repository
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"time"
 )
 
 func (r *Repository) CreateProject(slug, name string) (Project, error) {
@@ -63,19 +65,23 @@ func (r *Repository) ListProjectIDs() ([]int64, error) {
 }
 
 func (r *Repository) EnsureProjectPending(slug, name string) (Project, error) {
-	p, err := r.GetProjectBySlug(slug)
-	if err == nil {
-		return p, nil
+	for attempt := range 3 {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt) * 200 * time.Millisecond)
+		}
+		_, err := r.db.Exec(
+			"INSERT OR IGNORE INTO projects (slug, name, status) VALUES (?, ?, 'pending')",
+			slug, name,
+		)
+		if err != nil {
+			if strings.Contains(err.Error(), "SQLITE_BUSY") && attempt < 2 {
+				continue
+			}
+			return Project{}, err
+		}
+		return r.GetProjectBySlug(slug)
 	}
-	if err != sql.ErrNoRows {
-		return Project{}, err
-	}
-	res, err := r.db.Exec("INSERT INTO projects (slug, name, status) VALUES (?, ?, 'pending')", slug, name)
-	if err != nil {
-		return Project{}, err
-	}
-	id, _ := res.LastInsertId()
-	return r.getProjectByID(id)
+	return Project{}, fmt.Errorf("ensure project pending: exhausted retries")
 }
 
 func (r *Repository) ApproveProject(id int64) (Project, error) {


### PR DESCRIPTION
## Summary

- **`EnsureProjectPending` made atomic** — replaces the non-atomic `SELECT` + conditional `INSERT` with `INSERT OR IGNORE` + `SELECT`, matching the existing `EnsureSetupAPIKey` pattern. Adds a 3-attempt retry loop with backoff for transient `SQLITE_BUSY` errors (SPA-20).
- **WAL checkpoint delegated to Litestream** — when `LITESTREAM_ACCESS_KEY_ID` is set (i.e. spanbarn runs as Litestream's `-exec` child), spanbarn no longer starts its own `wal-checkpoint` goroutine. Two processes competing for the SQLite checkpoint lock was a source of write contention; Litestream owns the WAL in that deployment topology.

## Test plan

- [ ] All existing tests pass (`go test ./...`)
- [ ] `EnsureProjectPending` called twice with the same slug returns the same project ID (idempotency covered by `TestEnsureProjectPendingAndApprove`)
- [ ] Deploy to staging and verify log line `"litestream detected: WAL checkpointing delegated to litestream"` appears on writer pod startup
- [ ] Confirm no `SQLITE_BUSY` errors in BugBarn after deploy