### PR TITLE
chore(ci): upgrade upload-artifact to v7, download-artifact to v8

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -140,7 +140,7 @@ jobs:
             --target debs/
 
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: debs-${{ matrix.arch }}
           path: debs/*.deb
@@ -182,7 +182,7 @@ jobs:
           for f in *.tar.gz; do sha256sum "$f" > "${f}.sha256"; done
 
       - name: Upload tarball artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: darwin-${{ matrix.arch }}
           path: dist/*.tar.gz*
@@ -194,7 +194,7 @@ jobs:
     needs: [tag, build-debs, build-darwin-tarballs]
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,7 +76,7 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: go-coverage
           path: coverage.out


### PR DESCRIPTION
## Summary

- Upgrades `actions/upload-artifact@v4` → `v7` in `build-and-test.yml` and `binary-release.yml`
- Upgrades `actions/download-artifact@v4` → `v8` in `binary-release.yml`

Eliminates the Node.js 20 deprecation warnings surfaced in recent CI runs.

## Test plan

- [ ] CI passes without Node.js 20 deprecation warnings on next build