### PR TITLE
fix(e2e): handle admin key, fix multi-statement migration, simplify CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -305,36 +305,10 @@ jobs:
           set -euo pipefail
           STAGING_URL=https://spanbarn.staging.wiebe.xyz
 
-          # Decrypt credentials needed to bootstrap E2E mode.
-          SESSION_SECRET=$(sops -d --extract '["stringData"]["SPANBARN_SESSION_SECRET"]' deploy/k8s/staging/secret.yaml)
-          ADMIN_PASSWORD=$(sops -d --extract '["stringData"]["SPANBARN_ADMIN_PASSWORD"]' deploy/k8s/staging/secret.yaml)
-          echo "::add-mask::$SESSION_SECRET"
-          echo "::add-mask::$ADMIN_PASSWORD"
-
-          # Derive the deterministic ingest API key for the spanbarn project.
-          E2E_API_KEY=$(python3 -c "
-          import hmac, hashlib, sys
-          secret = sys.argv[1].encode()
-          mac = hmac.new(secret, b'setup:spanbarn', hashlib.sha256).hexdigest()
-          print(mac[:40])
-          " "$SESSION_SECRET")
+          # Decrypt the server admin API key (scope=full, projectID=0).
+          # handleE2ESession accepts this key and bypasses the e2e_enabled check.
+          E2E_API_KEY=$(sops -d --extract '["stringData"]["E2E_API_KEY"]' deploy/k8s/staging/secret.yaml)
           echo "::add-mask::$E2E_API_KEY"
-
-          # Login with native admin credentials and enable E2E mode for the project.
-          curl -sf -c /tmp/sb-cookies.txt -X POST "${STAGING_URL}/api/v1/login" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"admin\",\"password\":\"${ADMIN_PASSWORD}\"}" > /dev/null
-          PROJECT_ID=$(curl -sf "${STAGING_URL}/api/v1/projects" \
-            -b /tmp/sb-cookies.txt \
-            | python3 -c "
-          import json, sys
-          for p in json.load(sys.stdin):
-              if p['slug'] == 'spanbarn':
-                  print(p['id']); break
-          ")
-          curl -sf -X POST "${STAGING_URL}/api/v1/projects/${PROJECT_ID}/e2e" \
-            -b /tmp/sb-cookies.txt > /dev/null
-          echo "E2E mode enabled for project ${PROJECT_ID}"
 
           cd "$(git rev-parse --show-toplevel)"
           npm install

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -26,6 +26,7 @@ stringData:
     SPANBARN_REDIS_QUEUE_URL: ENC[AES256_GCM,data:HuJ8W1Coy6+EmvZspcuB1sNxb48Othc/LIVvcVhFTkJd,iv:08O2dZ08VLvVFrdtPElr2/FVQqbhv14aRnmWlYNxZhI=,tag:tpq7pc1BWu22NXWErUAn1Q==,type:str]
     E2E_OIDC_EMAIL: ENC[AES256_GCM,data:/UI46TpWBn8p6szTUHg2,iv:P+SzRUKH8HYlr8VvM/gHu1AM1HtzOM+lFzwnQkh7130=,tag:WDSrGNvRxAclCujobgfrxw==,type:str]
     E2E_OIDC_PASSWORD: ENC[AES256_GCM,data:y+SfTf2g9bk=,iv:wTOSw536bCFvsUCPbk6wvr2TvrMFeCMc//dIxxZRkpI=,tag:oVoNPLarkT8IRGRU7EXpfw==,type:str]
+    E2E_API_KEY: ENC[AES256_GCM,data:MTSxdhJQwkmGfurGwAsZ7V/y1kprlSjcvtG606amWouqYgXytGjh1w==,iv:LXojaGQXWcqjQXE8xpvwo7cBjzoeJfeFWYLtj7KABfE=,tag:KtPHo3Ic17ainRza83nGqA==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
@@ -37,7 +38,7 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T13:15:37Z"
-    mac: ENC[AES256_GCM,data:QYK2zg1c8N4W03dV1diNJlhF0u3NH2W7qPDyrlqUK2fNYWcUqdMsf7t69QMOuBoV04X2X8fK3sPl/MRmS/xDf6C4N7/SlAFMosPCjDg1HyERPAJfsLY2JyOG2zViuZnpU7OOWTYKrX47LVTrX0Amhq1qVALJh55gwFJm4Rk/yhM=,iv:JUJl/TL8thU2k+KwdWOueLaDiQl9ubZ9hweCr7B29I0=,tag:/r6zk1b2ug1OUfuYq21Atg==,type:str]
+    lastmodified: "2026-05-29T14:08:14Z"
+    mac: ENC[AES256_GCM,data:VTQurGBggTp9sOE57ubv1GflT0PV+636RG5lZNtRswdzLSeqtEHsG+UpfMW9vDFo2Drik88NxAVA86kUazOwPMgbXA1YiwahSCVuvIBoP/tixUrf0kGQ68TbhDqxxdBs79rTMiUUbnAmks4R6MyaKB4GueGsMpHcqBixEEapmMY=,iv:tG7qnoX7TAhOBDh/bQbm2zsXDjc4NBCzOnsNhPxoJEM=,tag:73U3FBAu1ikC2TxtSq8MrQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/internal/api/e2e.go
+++ b/internal/api/e2e.go
@@ -10,14 +10,20 @@ import (
 )
 
 // handleE2ESession issues a browser session for an E2E test account without
-// requiring the OIDC flow. The request must be authenticated with a project
-// API key, and the project must have e2e_enabled = true.
+// requiring the OIDC flow.
 //
-// A dedicated user account named "e2e:<project-slug>" is created (or its
-// expiry refreshed) and a normal session cookie is set. The account is
-// automatically deleted after repository.E2EAccountTTL (7 days) by the
-// retention worker, which also invalidates any outstanding sessions because
-// subsequent session renewals would fail to find the user.
+// Two modes of authentication are accepted:
+//
+//  1. Project API key — the project must have e2e_enabled = true. The session
+//     is created for a user named "e2e:<project-slug>".
+//
+//  2. Static admin key (project ID 0 / scope "full") — bypasses the
+//     e2e_enabled flag. The session is created for the user "e2e:admin". This
+//     is intended for CI pipelines that own the server admin key and don't
+//     want to maintain a separate project-scoped key.
+//
+// The E2E account is created (or its expiry refreshed) and expires after
+// repository.E2EAccountTTL (7 days). The retention worker deletes it.
 func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
@@ -29,19 +35,25 @@ func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	projectID := GetProjectID(r.Context())
-	project, err := s.repo.GetProjectByID(projectID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "could not load project", "")
-		return
-	}
-	if !project.E2EEnabled {
-		writeError(w, http.StatusForbidden, "e2e mode is not enabled for this project", "")
-		return
+
+	var username string
+	if projectID == 0 {
+		// Static admin key — no project lookup needed.
+		username = "e2e:admin"
+	} else {
+		project, err := s.repo.GetProjectByID(projectID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "could not load project", "")
+			return
+		}
+		if !project.E2EEnabled {
+			writeError(w, http.StatusForbidden, "e2e mode is not enabled for this project", "")
+			return
+		}
+		username = fmt.Sprintf("e2e:%s", project.Slug)
 	}
 
-	username := fmt.Sprintf("e2e:%s", project.Slug)
 	expiresAt := time.Now().UTC().Add(repository.E2EAccountTTL)
-
 	if _, err := s.repo.UpsertE2EUser(username, expiresAt); err != nil {
 		s.logger.Error("e2e: upsert user", "username", username, "error", err)
 		writeError(w, http.StatusInternalServerError, "could not create e2e account", "")
@@ -77,7 +89,7 @@ func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"username":          username,
+		"username":           username,
 		"account_expires_at": expiresAt.Format(time.RFC3339),
 		"session_expires_at": sessionExpires.Format(time.RFC3339),
 	})

--- a/internal/repository/migrations/019_e2e_accounts.go
+++ b/internal/repository/migrations/019_e2e_accounts.go
@@ -12,17 +12,17 @@ func init() {
 }
 
 func up019(ctx context.Context, tx *sql.Tx) error {
-	_, err := tx.ExecContext(ctx, `
-		ALTER TABLE projects ADD COLUMN e2e_enabled INTEGER NOT NULL DEFAULT 0;
-		ALTER TABLE users    ADD COLUMN e2e_expires_at DATETIME;
-	`)
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN e2e_enabled INTEGER NOT NULL DEFAULT 0`); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `ALTER TABLE users ADD COLUMN e2e_expires_at DATETIME`)
 	return err
 }
 
 func down019(ctx context.Context, tx *sql.Tx) error {
-	_, err := tx.ExecContext(ctx, `
-		ALTER TABLE projects DROP COLUMN e2e_enabled;
-		ALTER TABLE users    DROP COLUMN e2e_expires_at;
-	`)
+	if _, err := tx.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN e2e_enabled`); err != nil {
+		return err
+	}
+	_, err := tx.ExecContext(ctx, `ALTER TABLE users DROP COLUMN e2e_expires_at`)
 	return err
 }

--- a/internal/repository/migrations/020_e2e_expires_at.go
+++ b/internal/repository/migrations/020_e2e_expires_at.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up020, down020)
+}
+
+// up020 ensures users.e2e_expires_at exists. Migration 019 used a single
+// multi-statement ExecContext call; some SQLite driver versions only execute
+// the first statement, leaving e2e_expires_at missing. This migration adds the
+// column idempotently.
+func up020(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `ALTER TABLE users ADD COLUMN e2e_expires_at DATETIME`)
+	if err != nil && strings.Contains(err.Error(), "duplicate column name") {
+		return nil // already present — 019 ran both statements correctly
+	}
+	return err
+}
+
+func down020(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `ALTER TABLE users DROP COLUMN e2e_expires_at`)
+	return err
+}


### PR DESCRIPTION
## Summary

Fixes three issues found while deploying the E2E bypass feature to staging:

- **Migration 019**: The two `ALTER TABLE` statements in a single `ExecContext` call were being silently truncated by the go-sqlite3 driver (which uses `sqlite3_prepare_v2` internally, stopping at the first semicolon). Split into two separate calls.
- **Migration 020**: Idempotent safety net — adds `users.e2e_expires_at` only if it doesn't exist yet, for databases where 019 ran partially.
- **`handleE2ESession`**: Now accepts the static admin key (project ID 0, scope=full) and creates an `e2e:admin` account, bypassing the per-project `e2e_enabled` check. CI pipelines that own the server admin key can call the endpoint without per-project setup.
- **CI workflow**: Simplified — decrypts `E2E_API_KEY` (= server admin key) from SOPS, no admin-login/project-enable bootstrap needed.
- **Staging SOPS secret**: `E2E_API_KEY` stored as the server admin key value.

## Test plan

- [ ] Deploy to staging via CI
- [ ] CI E2E step calls `/api/v1/e2e/session` with admin key → gets session
- [ ] Playwright tests pass with bypass flow