### PR TITLE
debug: expose upsert SQL error in e2e session response

### DIFF
--- a/internal/api/e2e.go
+++ b/internal/api/e2e.go
@@ -56,7 +56,7 @@ func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().UTC().Add(repository.E2EAccountTTL)
 	if _, err := s.repo.UpsertE2EUser(username, expiresAt); err != nil {
 		s.logger.Error("e2e: upsert user", "username", username, "error", err)
-		writeError(w, http.StatusInternalServerError, "could not create e2e account", "")
+		writeError(w, http.StatusInternalServerError, "could not create e2e account", err.Error())
 		return
 	}
 


### PR DESCRIPTION
Temporary debug: expose the actual SQL error so we can diagnose the staging failure.