### PR TITLE
fix(e2e): prevent read-only pods from registering write-only E2E endpoint

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -333,7 +333,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 			logger.Warn("read-only DB unavailable, dashboard reads disabled", "error", dbErr)
 		} else {
 			defer db.Close()
-			roRepo = repository.NewRepository(db.DB)
+			roRepo = repository.NewReadOnlyRepository(db.DB)
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}
@@ -841,7 +841,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 			logger.Warn("read-only DB unavailable, API key validation limited to static key", "error", dbErr)
 		} else {
 			defer db.Close()
-			roRepo = repository.NewRepository(db.DB)
+			roRepo = repository.NewReadOnlyRepository(db.DB)
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}

--- a/internal/api/e2e.go
+++ b/internal/api/e2e.go
@@ -56,7 +56,7 @@ func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 	expiresAt := time.Now().UTC().Add(repository.E2EAccountTTL)
 	if _, err := s.repo.UpsertE2EUser(username, expiresAt); err != nil {
 		s.logger.Error("e2e: upsert user", "username", username, "error", err)
-		writeError(w, http.StatusInternalServerError, "could not create e2e account", err.Error())
+		writeError(w, http.StatusInternalServerError, "could not create e2e account", "")
 		return
 	}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -140,7 +140,8 @@ func (s *Server) registerRoutes() {
 	}
 
 	// E2E session endpoint — API key auth required; only works when e2e_enabled.
-	if s.repo != nil && s.sessionMgr != nil && s.authorizer != nil {
+	// Not registered on read-only pods (reader mode) to prevent write errors.
+	if s.repo != nil && !s.repo.ReadOnly() && s.sessionMgr != nil && s.authorizer != nil {
 		s.mux.Handle("/api/v1/e2e/session", ingestRL(ingestAuth(http.HandlerFunc(s.handleE2ESession))))
 	}
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -19,12 +19,23 @@ const DefaultQueryTimeout = 30 * time.Second
 type Repository struct {
 	db           *sql.DB
 	queryTimeout time.Duration
+	readOnly     bool
 }
 
 // NewRepository creates a Repository backed by the given database connection.
 func NewRepository(db *sql.DB) *Repository {
 	return &Repository{db: db, queryTimeout: DefaultQueryTimeout}
 }
+
+// NewReadOnlyRepository creates a Repository that is flagged as read-only.
+// Write operations will fail at the SQLite level; this flag lets callers skip
+// registering write-only endpoints on pods that open read-only connections.
+func NewReadOnlyRepository(db *sql.DB) *Repository {
+	return &Repository{db: db, queryTimeout: DefaultQueryTimeout, readOnly: true}
+}
+
+// ReadOnly reports whether this repository was opened against a read-only DB.
+func (r *Repository) ReadOnly() bool { return r.readOnly }
 
 // SetQueryTimeout overrides the default query timeout.
 func (r *Repository) SetQueryTimeout(d time.Duration) {


### PR DESCRIPTION
Reader pod had all three conditions (repo, sessionMgr, authorizer) satisfied, so the E2E session endpoint was being registered there with a read-only DB. Adds ReadOnly() flag to Repository and gates endpoint registration on it.