### PR TITLE
fix(e2e): register E2E endpoint unconditionally, raise ingress priority

### DIFF
--- a/deploy/k8s/staging/ingress.yaml
+++ b/deploy/k8s/staging/ingress.yaml
@@ -29,7 +29,7 @@ spec:
 
     - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api`) && (Method(`POST`) || Method(`PUT`) || Method(`PATCH`) || Method(`DELETE`))
       kind: Rule
-      priority: 100
+      priority: 200
       services:
         - name: spanbarn
           port: 8080
@@ -37,7 +37,7 @@ spec:
     # Setup is GET-but-writes (creates pending project + setup API key) — route to writer.
     - match: (Host(`spanbarn.staging.wiebe.xyz`) || Host(`spanbarn-staging.nijmegen.wiebe.xyz`)) && PathPrefix(`/api/v1/setup`)
       kind: Rule
-      priority: 100
+      priority: 200
       services:
         - name: spanbarn
           port: 8080

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -140,8 +140,7 @@ func (s *Server) registerRoutes() {
 	}
 
 	// E2E session endpoint — API key auth required; only works when e2e_enabled.
-	// Not registered on read-only pods (reader mode) to prevent write errors.
-	if s.repo != nil && !s.repo.ReadOnly() && s.sessionMgr != nil && s.authorizer != nil {
+	if s.repo != nil && s.sessionMgr != nil && s.authorizer != nil {
 		s.mux.Handle("/api/v1/e2e/session", ingestRL(ingestAuth(http.HandlerFunc(s.handleE2ESession))))
 	}
 


### PR DESCRIPTION
Two fixes: routes.go drops the ReadOnly guard that was blocking registration; ingress raises write-method rule priority from 100→200 to beat the default length-based priority (~105) of the catch-all /api rule.