### PR TITLE
fix(wal): re-enable app WAL checkpoint alongside Litestream + trace model column

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -148,10 +148,16 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("worker", &wg, func() { w.Run(workerCtx) })
-	if !litestreamActive() {
-		safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
-	} else {
-		logger.Info("litestream detected: WAL checkpointing delegated to litestream")
+	// Always run the app-side checkpoint even when Litestream is active.
+	// Litestream's own PASSIVE checkpoint has no busy_timeout on its connection
+	// and returns SQLITE_BUSY immediately when a write transaction is in flight
+	// (~20 span writes/s means it almost never succeeds). The app's TRUNCATE
+	// checkpoint has busy_timeout(30000) and will wait for a clear window.
+	// WAL-level reader locks ensure Litestream's unstreamed frames are never
+	// truncated before S3 confirms them, so dual checkpointing is safe.
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	if litestreamActive() {
+		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
 	}
 
 	retentionCfg := retention.Config{
@@ -637,10 +643,9 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
-	if !litestreamActive() {
-		safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
-	} else {
-		logger.Info("litestream detected: WAL checkpointing delegated to litestream")
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	if litestreamActive() {
+		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
 	}
 
 	// Retention queries (DELETE/SELECT on the full spans table) can take

--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -9,4 +9,4 @@ dbs:
         access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
         secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
         retention: 24h
-        sync-interval: 1s
+        sync-interval: 1m

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -244,6 +244,8 @@ type TraceSummaryRow struct {
 	RootName     string
 	RootService  string
 	RootDuration int64
+	RootModel    string
+	PromptCount  int
 }
 
 // SearchTraceSummaries returns at most filter.Limit trace summaries matching
@@ -431,10 +433,40 @@ func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSu
 		return nil, err
 	}
 
+	// Step 3: fetch model and prompt count from prompt_records for each trace.
+	type promptInfo struct {
+		model string
+		count int
+	}
+	promptsByTrace := make(map[string]promptInfo, len(order))
+	if len(order) > 0 {
+		prPlaceholders := strings.Repeat("?,", len(order))
+		prPlaceholders = prPlaceholders[:len(prPlaceholders)-1]
+		prArgs := make([]any, len(order))
+		for i, t := range order {
+			prArgs[i] = t
+		}
+		prQ := fmt.Sprintf(`SELECT trace_id, MIN(model), COUNT(*) FROM prompt_records WHERE trace_id IN (%s) GROUP BY trace_id`, prPlaceholders)
+		prCtx, prCancel := r.queryContext()
+		defer prCancel()
+		prRows, err := r.db.QueryContext(prCtx, prQ, prArgs...)
+		if err == nil {
+			for prRows.Next() {
+				var tid, model string
+				var cnt int
+				if err := prRows.Scan(&tid, &model, &cnt); err == nil {
+					promptsByTrace[tid] = promptInfo{model: model, count: cnt}
+				}
+			}
+			prRows.Close()
+		}
+	}
+
 	out := make([]TraceSummaryRow, 0, len(order))
 	for _, traceID := range order {
 		a := accs[traceID]
 		ri := roots[traceID]
+		pi := promptsByTrace[traceID]
 		out = append(out, TraceSummaryRow{
 			TraceID:      traceID,
 			StartTimeUs:  a.startUs,
@@ -443,6 +475,8 @@ func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSu
 			RootName:     ri.name,
 			RootService:  ri.service,
 			RootDuration: ri.duration,
+			RootModel:    pi.model,
+			PromptCount:  pi.count,
 		})
 	}
 	return out, nil

--- a/internal/service/query_traces.go
+++ b/internal/service/query_traces.go
@@ -79,6 +79,8 @@ func (s *QueryService) SearchTraces(ctx context.Context, filter TraceSearchFilte
 			SpanCount:    r.SpanCount,
 			Status:       status,
 			StartTime:    time.UnixMicro(r.StartTimeUs),
+			RootModel:    r.RootModel,
+			PromptCount:  r.PromptCount,
 		})
 	}
 	return result, nil

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -49,6 +49,8 @@ type TraceSummary struct {
 	SpanCount    int       `json:"spanCount"`
 	Status       string    `json:"status"`
 	StartTime    time.Time `json:"startTime"`
+	RootModel    string    `json:"rootModel,omitempty"`
+	PromptCount  int       `json:"promptCount,omitempty"`
 }
 
 // TraceDetail holds a full trace with all its spans.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -41,6 +41,8 @@ export type TraceSummary = {
   spanCount: number
   status: string
   startTime: string
+  rootModel?: string
+  promptCount?: number
 }
 
 /** Aggregated metrics for a group of traces sharing the same root operation. */

--- a/web/src/pages/TracesPage.tsx
+++ b/web/src/pages/TracesPage.tsx
@@ -624,6 +624,7 @@ export function TracesPage(): ReactElement {
                   <th style={thStyle}>Trace ID</th>
                   <th style={thStyle}>Root Span</th>
                   <th style={thStyle}>Service</th>
+                  <th style={thStyle}>Model</th>
                   <th style={thStyle}>Duration</th>
                   <th style={thStyle}>Spans</th>
                   <th style={thStyle}>Status</th>
@@ -633,14 +634,14 @@ export function TracesPage(): ReactElement {
               <tbody>
                 {loading && (
                   <tr>
-                    <td colSpan={7} style={{ ...tdStyle, textAlign: 'center', color: '#9ca3af' }}>
+                    <td colSpan={8} style={{ ...tdStyle, textAlign: 'center', color: '#9ca3af' }}>
                       Loading...
                     </td>
                   </tr>
                 )}
                 {!loading && traces.length === 0 && (
                   <tr>
-                    <td colSpan={7} style={{ ...tdStyle, textAlign: 'center', color: '#6b7280' }}>
+                    <td colSpan={8} style={{ ...tdStyle, textAlign: 'center', color: '#6b7280' }}>
                       No traces found
                     </td>
                   </tr>
@@ -675,6 +676,16 @@ export function TracesPage(): ReactElement {
                       </span>
                     </td>
                     <td style={tdStyle}>{trace.rootService}</td>
+                    <td style={{ ...tdStyle, color: '#d1d5db', fontSize: 12 }}>
+                      {trace.rootModel ? (
+                        <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                          <code style={{ fontSize: 11 }}>{trace.rootModel}</code>
+                          {trace.promptCount != null && trace.promptCount > 1 && (
+                            <span style={{ color: '#6b7280', fontSize: 11 }}>×{trace.promptCount}</span>
+                          )}
+                        </span>
+                      ) : '—'}
+                    </td>
                     <td style={{ ...tdStyle, color: durationColor(trace.durationUs) }}>
                       {formatDuration(trace.durationUs)}
                     </td>


### PR DESCRIPTION
## Summary

- **WAL fix**: Re-enables the app-side `RunPeriodicCheckpoint` (TRUNCATE, `busy_timeout=30s`) even when Litestream is active. Litestream runs as a separate process with no `busy_timeout` on its checkpoint connection — at `sync-interval=1s` it was attempting PASSIVE checkpoints 60×/min but ~20 span writes/s meant it almost always got `SQLITE_BUSY` immediately. The WAL grew to 1.8 GB because nothing was ever successfully checkpointing. Dual checkpointing is safe: SQLite's WAL reader-lock protocol prevents Litestream's unstreamed frames from being truncated before S3 confirms them.
- **Litestream `sync-interval` 1s → 1m**: Batches S3 WAL segment writes and reduces Litestream's own checkpoint attempts to once per minute. RPO increases to ~1 min (acceptable for telemetry).
- **Trace model column**: Adds a Model column to the trace list. Fetches `MIN(model)` and `COUNT(*)` from `prompt_records` per trace in a third SQL query in `SearchTraceSummaries`. Multi-call traces show a ×N badge. Traces without LLM spans show `—`.

## Test plan

- [ ] CI passes (lint, test, build)
- [ ] Deploy to testing — confirm WAL shrinks after restart (check `ls -lh /var/lib/spanbarn/` and logs for `wal checkpoint` success)
- [ ] Trace list shows Model column for LLM Generation traces
- [ ] No new `sync error: checkpoint` spam in production logs after deploy