### PR TITLE
fix(cors): echo request origin for ingest endpoints to support credentialed requests

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -82,15 +82,23 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		// Ingest endpoints always allow wildcard CORS for browser SDKs.
+		// Ingest endpoints allow any origin for browser SDKs.
+		// Echo the request origin instead of '*' so credentialed requests
+		// (credentials: 'include') are also accepted by the browser.
 		if strings.HasPrefix(path, "/api/v1/spans") ||
 			strings.HasPrefix(path, "/v1/traces") ||
 			path == "/api/v1/telemetry" ||
 			path == "/api/v1/client-errors" {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				origin = "*"
+			}
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-SpanBarn-Api-Key, Authorization, traceparent, tracestate")
 			w.Header().Set("Access-Control-Max-Age", "86400")
+			w.Header().Set("Vary", "Origin")
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)
 				return

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -47,8 +47,8 @@ func TestCORSIngestEndpoint(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("expected 204 for OPTIONS, got %d", resp.StatusCode)
 	}
-	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "*" {
-		t.Fatalf("expected CORS allow-origin '*', got %q", acao)
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "https://example.com" {
+		t.Fatalf("expected CORS allow-origin 'https://example.com', got %q", acao)
 	}
 	acah := resp.Header.Get("Access-Control-Allow-Headers")
 	if !strings.Contains(acah, "X-SpanBarn-Api-Key") {
@@ -74,8 +74,8 @@ func TestCORSOTLPEndpoint(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("expected 204 for OPTIONS preflight, got %d", resp.StatusCode)
 	}
-	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "*" {
-		t.Fatalf("expected CORS allow-origin '*', got %q", acao)
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "https://geobarn.test.wiebe.xyz" {
+		t.Fatalf("expected CORS allow-origin 'https://geobarn.test.wiebe.xyz', got %q", acao)
 	}
 	acah := resp.Header.Get("Access-Control-Allow-Headers")
 	for _, h := range []string{"Authorization", "traceparent", "Content-Type"} {


### PR DESCRIPTION
## Summary

- Ingest endpoints (`/v1/traces`, `/api/v1/spans`, etc.) were returning `Access-Control-Allow-Origin: *`, which browsers reject when the request uses `credentials: 'include'`
- Now echoes the request `Origin` header back as the allowed origin, with `Access-Control-Allow-Credentials: true` and `Vary: Origin`
- Any origin is still permitted; credentialed requests now work too

## Test plan

- [ ] Existing CORS tests updated and passing
- [ ] `go test ./internal/api/...` passes