### PR TITLE
feat(ingest): in-memory aggregates, boring span bypass, priority write queue

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -628,7 +628,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	var wg sync.WaitGroup
 
 	aggInterval := parseAggregationInterval(cfg.AggregationInterval)
-	aggregator := aggregation.NewAggregator(repo, aggInterval, logger)
+	accumulator := aggregation.NewAccumulator(repo, aggInterval, 30*time.Second, logger)
 
 	// writeMu serialises all SQLite writes between the span worker and the
 	// retention worker. Without this they compete for the write connection:
@@ -638,11 +638,13 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	writeMu := &sync.Mutex{}
 
 	rw := worker.NewRedisWorker(writeQueue, &workerRepoAdapter{repo: repo}, logger)
-	rw.SetAggregator(aggregator)
+	rw.SetAccumulator(accumulator)
+	rw.SetConfig(worker.WorkerConfig{SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000})
 	rw.SetWriteMutex(writeMu)
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
+	safeGo("accumulator", &wg, func() { accumulator.Run(workerCtx) })
 	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
@@ -663,7 +665,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
 	}
-	retentionWorker := retention.NewRetentionWorker(retentionRepo, aggregator, retentionCfg, logger)
+	retentionWorker := retention.NewRetentionWorker(retentionRepo, accumulator, retentionCfg, logger)
 	retentionWorker.SetWriteMutex(writeMu)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)
 	defer retentionCancel()
@@ -676,6 +678,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	defer alertCancel()
 	safeGo("alert-runner", &wg, func() { alertRunner.Run(alertCtx) })
 
+	querySvc.SetAccumulator(accumulator)
 	api.WarmCaches(ctx, queryRepo, querySvc.Cache(), logger)
 
 	select {

--- a/internal/aggregation/accumulator.go
+++ b/internal/aggregation/accumulator.go
@@ -1,0 +1,273 @@
+package aggregation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// Accumulator is an in-memory aggregate store fed span-by-span from the worker
+// hot path. Every Add call is O(1) amortised. A background flush loop (Run)
+// periodically writes accumulated slots to SQLite and resets them.
+// QueryRecent lets the query service read current slots as synthetic aggregate
+// rows, replacing the raw-span fallback in query_services.go.
+//
+// Accumulator also implements the AggregateSpans + Persist contract expected by
+// the retention worker, so it can replace *Aggregator at the call site in
+// main.go without changing retention internals.
+type Accumulator struct {
+	mu            sync.Mutex
+	slots         map[accKey]*accSlot
+	interval      time.Duration
+	flushInterval time.Duration
+	repo          AggregateWriter
+	logger        *slog.Logger
+}
+
+type accKey struct {
+	projectID int64
+	service   string
+	operation string
+	resource  string
+	kind      string
+	bucket    time.Time
+}
+
+type accSlot struct {
+	count      int64
+	errorCount int64
+	durations  []int64
+}
+
+// NewAccumulator creates an Accumulator.
+// interval is the bucket granularity (e.g. time.Minute).
+// flushInterval controls how often accumulated slots are written to SQLite (e.g. 30s).
+func NewAccumulator(repo AggregateWriter, interval, flushInterval time.Duration, logger *slog.Logger) *Accumulator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Accumulator{
+		slots:         make(map[accKey]*accSlot),
+		interval:      interval,
+		flushInterval: flushInterval,
+		repo:          repo,
+		logger:        logger,
+	}
+}
+
+// Add records a single span into its in-memory slot. Thread-safe; O(1) amortised.
+func (a *Accumulator) Add(s repository.Span) {
+	bucket := TruncateToBucket(time.UnixMicro(s.StartTimeUs), a.interval)
+	k := accKey{
+		projectID: s.ProjectID,
+		service:   s.Service,
+		operation: s.Name,
+		resource:  s.Resource,
+		kind:      s.Kind,
+		bucket:    bucket,
+	}
+	a.mu.Lock()
+	sl := a.slots[k]
+	if sl == nil {
+		sl = &accSlot{}
+		a.slots[k] = sl
+	}
+	sl.count++
+	if s.Status == "error" {
+		sl.errorCount++
+	}
+	sl.durations = append(sl.durations, s.DurationUs)
+	a.mu.Unlock()
+}
+
+// QueryRecent returns synthetic aggregate rows from the current in-memory slots
+// that match f. Used by the query service to cover the recent tail window
+// without scanning the spans table.
+func (a *Accumulator) QueryRecent(f repository.AggregateFilter) []repository.Aggregate {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	var result []repository.Aggregate
+	for k, sl := range a.slots {
+		if f.ProjectID != 0 && k.projectID != f.ProjectID {
+			continue
+		}
+		if f.Service != "" && k.service != f.Service {
+			continue
+		}
+		if f.Operation != "" && k.operation != f.Operation {
+			continue
+		}
+		if f.Kind != "" && k.kind != f.Kind {
+			continue
+		}
+		if !f.From.IsZero() && k.bucket.Before(f.From) {
+			continue
+		}
+		if !f.To.IsZero() && k.bucket.After(f.To) {
+			continue
+		}
+		durations := make([]int64, len(sl.durations))
+		copy(durations, sl.durations)
+		result = append(result, repository.Aggregate{
+			ProjectID:  k.projectID,
+			Service:    k.service,
+			Operation:  k.operation,
+			Resource:   k.resource,
+			Kind:       k.kind,
+			Bucket:     k.bucket,
+			Count:      sl.count,
+			ErrorCount: sl.errorCount,
+			P50Us:      P50(durations),
+			P95Us:      P95(durations),
+			P99Us:      P99(durations),
+		})
+	}
+	return result
+}
+
+// Flush drains all accumulated slots, computes final aggregates, and upserts
+// them into SQLite. Slots are swapped out atomically so Add calls during Flush
+// land in the next cycle without blocking.
+func (a *Accumulator) Flush(ctx context.Context) error {
+	a.mu.Lock()
+	slots := a.slots
+	a.slots = make(map[accKey]*accSlot)
+	a.mu.Unlock()
+
+	if len(slots) == 0 {
+		return nil
+	}
+
+	aggs := make([]repository.Aggregate, 0, len(slots))
+	for k, sl := range slots {
+		var maxUs, sumUs int64
+		for _, d := range sl.durations {
+			sumUs += d
+			if d > maxUs {
+				maxUs = d
+			}
+		}
+		aggs = append(aggs, repository.Aggregate{
+			ProjectID:     k.projectID,
+			Service:       k.service,
+			Operation:     k.operation,
+			Resource:      k.resource,
+			Kind:          k.kind,
+			Bucket:        k.bucket,
+			Count:         sl.count,
+			ErrorCount:    sl.errorCount,
+			P50Us:         P50(sl.durations),
+			P95Us:         P95(sl.durations),
+			P99Us:         P99(sl.durations),
+			MaxUs:         maxUs,
+			SumDurationUs: sumUs,
+		})
+	}
+
+	if err := a.repo.UpsertAggregates(aggs); err != nil {
+		return fmt.Errorf("accumulator flush: %w", err)
+	}
+	a.logger.Info("persisted aggregates", "count", len(aggs))
+	return nil
+}
+
+// Run starts a periodic flush loop. Blocks until ctx is cancelled.
+func (a *Accumulator) Run(ctx context.Context) {
+	ticker := time.NewTicker(a.flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.Flush(ctx); err != nil {
+				a.logger.Warn("accumulator flush failed", "error", err)
+			}
+		}
+	}
+}
+
+// AggregateSpans satisfies the retention.Aggregator interface. It computes
+// aggregates from an arbitrary span batch without touching the in-memory slots —
+// the retention worker uses this when aggregating spans it is about to delete.
+func (a *Accumulator) AggregateSpans(ctx context.Context, spans []repository.Span) ([]repository.Aggregate, error) {
+	if len(spans) == 0 {
+		return nil, nil
+	}
+
+	_, otelSpan := tracer.Start(ctx, "accumulator.aggregate_spans")
+	otelSpan.SetAttributes(attribute.Int("input_span_count", len(spans)))
+	defer otelSpan.End()
+
+	type batchKey struct {
+		projectID int64
+		service   string
+		operation string
+		resource  string
+		kind      string
+		bucket    time.Time
+	}
+	groups := make(map[batchKey][]repository.Span)
+	for _, s := range spans {
+		bucket := TruncateToBucket(time.UnixMicro(s.StartTimeUs), a.interval)
+		k := batchKey{s.ProjectID, s.Service, s.Name, s.Resource, s.Kind, bucket}
+		groups[k] = append(groups[k], s)
+	}
+
+	otelSpan.SetAttributes(attribute.Int("bucket_count", len(groups)))
+
+	out := make([]repository.Aggregate, 0, len(groups))
+	for k, batch := range groups {
+		durations := make([]int64, len(batch))
+		var errorCount, sumDuration, maxDuration int64
+		for i, s := range batch {
+			durations[i] = s.DurationUs
+			sumDuration += s.DurationUs
+			if s.DurationUs > maxDuration {
+				maxDuration = s.DurationUs
+			}
+			if s.Status == "error" {
+				errorCount++
+			}
+		}
+		out = append(out, repository.Aggregate{
+			ProjectID:     k.projectID,
+			Service:       k.service,
+			Operation:     k.operation,
+			Resource:      k.resource,
+			Kind:          k.kind,
+			Bucket:        k.bucket,
+			Count:         int64(len(batch)),
+			ErrorCount:    errorCount,
+			P50Us:         P50(durations),
+			P95Us:         P95(durations),
+			P99Us:         P99(durations),
+			MaxUs:         maxDuration,
+			SumDurationUs: sumDuration,
+		})
+	}
+	return out, nil
+}
+
+// Persist satisfies the retention.Aggregator interface.
+func (a *Accumulator) Persist(ctx context.Context, aggregates []repository.Aggregate) error {
+	_, otelSpan := tracer.Start(ctx, "accumulator.persist")
+	otelSpan.SetAttributes(attribute.Int("aggregate_count", len(aggregates)))
+	defer otelSpan.End()
+
+	if err := a.repo.UpsertAggregates(aggregates); err != nil {
+		otelSpan.RecordError(err)
+		otelSpan.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("persist %d aggregates: %w", len(aggregates), err)
+	}
+	a.logger.Info("persisted aggregates", "count", len(aggregates))
+	return nil
+}

--- a/internal/aggregation/accumulator_test.go
+++ b/internal/aggregation/accumulator_test.go
@@ -1,0 +1,160 @@
+package aggregation
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// mockAccWriter implements AggregateWriter and captures upserted aggregates.
+type mockAccWriter struct {
+	mu   sync.Mutex
+	aggs []repository.Aggregate
+}
+
+func (m *mockAccWriter) UpsertAggregate(agg repository.Aggregate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.aggs = append(m.aggs, agg)
+	return nil
+}
+
+func (m *mockAccWriter) UpsertAggregates(aggs []repository.Aggregate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.aggs = append(m.aggs, aggs...)
+	return nil
+}
+
+func (m *mockAccWriter) get() []repository.Aggregate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]repository.Aggregate, len(m.aggs))
+	copy(cp, m.aggs)
+	return cp
+}
+
+func TestAccumulatorAdd(t *testing.T) {
+	w := &mockAccWriter{}
+	acc := NewAccumulator(w, time.Minute, time.Hour, nil)
+
+	now := time.Now().UTC()
+	acc.Add(repository.Span{ProjectID: 1, Service: "svc", Name: "op", Kind: "server", StartTimeUs: now.UnixMicro(), DurationUs: 100})
+	acc.Add(repository.Span{ProjectID: 1, Service: "svc", Name: "op", Kind: "server", StartTimeUs: now.UnixMicro(), DurationUs: 200, Status: "error"})
+
+	acc.mu.Lock()
+	if len(acc.slots) != 1 {
+		t.Fatalf("expected 1 slot, got %d", len(acc.slots))
+	}
+	for _, sl := range acc.slots {
+		if sl.count != 2 {
+			t.Errorf("count = %d, want 2", sl.count)
+		}
+		if sl.errorCount != 1 {
+			t.Errorf("errorCount = %d, want 1", sl.errorCount)
+		}
+		if len(sl.durations) != 2 {
+			t.Errorf("len(durations) = %d, want 2", len(sl.durations))
+		}
+	}
+	acc.mu.Unlock()
+}
+
+func TestAccumulatorFlush(t *testing.T) {
+	w := &mockAccWriter{}
+	acc := NewAccumulator(w, time.Minute, time.Hour, nil)
+
+	now := time.Now().UTC()
+	for i := 0; i < 5; i++ {
+		acc.Add(repository.Span{
+			ProjectID:   1,
+			Service:     "svc",
+			Name:        "op",
+			Kind:        "server",
+			StartTimeUs: now.UnixMicro(),
+			DurationUs:  int64(100 * (i + 1)),
+		})
+	}
+
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	aggs := w.get()
+	if len(aggs) != 1 {
+		t.Fatalf("expected 1 aggregate, got %d", len(aggs))
+	}
+	if aggs[0].Count != 5 {
+		t.Errorf("Count = %d, want 5", aggs[0].Count)
+	}
+	if aggs[0].P50Us == 0 {
+		t.Error("P50Us should be non-zero")
+	}
+
+	// Slots should be reset after flush.
+	acc.mu.Lock()
+	if len(acc.slots) != 0 {
+		t.Errorf("slots not reset after flush, got %d", len(acc.slots))
+	}
+	acc.mu.Unlock()
+}
+
+func TestAccumulatorQueryRecent(t *testing.T) {
+	w := &mockAccWriter{}
+	acc := NewAccumulator(w, time.Minute, time.Hour, nil)
+
+	now := time.Now().UTC()
+	acc.Add(repository.Span{ProjectID: 1, Service: "alpha", Name: "get", Kind: "server", StartTimeUs: now.UnixMicro(), DurationUs: 50})
+	acc.Add(repository.Span{ProjectID: 1, Service: "beta", Name: "post", Kind: "server", StartTimeUs: now.UnixMicro(), DurationUs: 100, Status: "error"})
+
+	// No filter — returns all.
+	all := acc.QueryRecent(repository.AggregateFilter{ProjectID: 1})
+	if len(all) != 2 {
+		t.Fatalf("QueryRecent (no filter) = %d rows, want 2", len(all))
+	}
+
+	// Service filter.
+	only := acc.QueryRecent(repository.AggregateFilter{ProjectID: 1, Service: "alpha"})
+	if len(only) != 1 || only[0].Service != "alpha" {
+		t.Fatalf("QueryRecent (service=alpha) = %v, want 1 alpha row", only)
+	}
+
+	// ProjectID filter excludes all.
+	none := acc.QueryRecent(repository.AggregateFilter{ProjectID: 99})
+	if len(none) != 0 {
+		t.Fatalf("QueryRecent (projectID=99) = %d rows, want 0", len(none))
+	}
+}
+
+func TestAccumulatorAggregateSpansMatchesAggregator(t *testing.T) {
+	w := &mockAccWriter{}
+	acc := NewAccumulator(w, time.Minute, time.Hour, nil)
+	agg := NewAggregator(w, time.Minute, nil)
+
+	spans := []repository.Span{
+		{ProjectID: 1, Service: "svc", Name: "op", Kind: "server", StartTimeUs: time.Now().UnixMicro(), DurationUs: 100},
+		{ProjectID: 1, Service: "svc", Name: "op", Kind: "server", StartTimeUs: time.Now().UnixMicro(), DurationUs: 200, Status: "error"},
+	}
+
+	accAggs, err := acc.AggregateSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("acc.AggregateSpans: %v", err)
+	}
+	aggAggs, err := agg.AggregateSpans(context.Background(), spans)
+	if err != nil {
+		t.Fatalf("agg.AggregateSpans: %v", err)
+	}
+
+	if len(accAggs) != len(aggAggs) {
+		t.Fatalf("len(accAggs)=%d, len(aggAggs)=%d", len(accAggs), len(aggAggs))
+	}
+	if accAggs[0].Count != aggAggs[0].Count {
+		t.Errorf("Count mismatch: acc=%d agg=%d", accAggs[0].Count, aggAggs[0].Count)
+	}
+	if accAggs[0].ErrorCount != aggAggs[0].ErrorCount {
+		t.Errorf("ErrorCount mismatch: acc=%d agg=%d", accAggs[0].ErrorCount, aggAggs[0].ErrorCount)
+	}
+}

--- a/internal/queue/redis_queue.go
+++ b/internal/queue/redis_queue.go
@@ -12,9 +12,20 @@ import (
 )
 
 const (
-	WriteQueueKey     = "spanbarn:write-queue"
+	// WriteQueueRecentKey holds batches whose spans have start_time_us within
+	// RecentThreshold. The consumer drains this before the backlog queue.
+	WriteQueueRecentKey = "spanbarn:write-queue:recent"
+	// WriteQueueBacklogKey is the legacy key and now serves as the backlog queue
+	// for spans older than RecentThreshold.
+	WriteQueueBacklogKey = "spanbarn:write-queue"
+	// WriteQueueKey is kept as an alias of WriteQueueBacklogKey so that any
+	// external tooling referencing it still works.
+	WriteQueueKey     = WriteQueueBacklogKey
 	maxRecordsPerItem = 500
 	brpopTimeout      = 5 * time.Second
+	// RecentThreshold is the max age of start_time_us for a batch to be routed
+	// to the recent (high-priority) queue.
+	RecentThreshold = 5 * time.Minute
 )
 
 // RedisQueue is a durable write queue backed by a Redis list.
@@ -72,30 +83,46 @@ func NewRedisQueueWithRetry(ctx context.Context, redisURL string) (*RedisQueue, 
 	}
 }
 
-// Publish serialises records as JSON and LPUSHes them to the queue in batches
-// of up to maxRecordsPerItem. Called by the RedisForwarder in reader mode.
+// Publish serialises records as JSON and LPUSHes them to the appropriate queue
+// in batches of up to maxRecordsPerItem. Batches whose spans have a max
+// start_time_us within RecentThreshold go to the recent (high-priority) queue;
+// older batches go to the backlog queue. The consumer drains recent first.
 func (q *RedisQueue) Publish(ctx context.Context, records []model.SpanRecord) error {
 	for i := 0; i < len(records); i += maxRecordsPerItem {
 		end := i + maxRecordsPerItem
 		if end > len(records) {
 			end = len(records)
 		}
-		data, err := json.Marshal(records[i:end])
+		chunk := records[i:end]
+
+		var maxStart int64
+		for _, r := range chunk {
+			if r.StartTimeUs > maxStart {
+				maxStart = r.StartTimeUs
+			}
+		}
+		key := WriteQueueBacklogKey
+		if maxStart > 0 && time.Since(time.UnixMicro(maxStart)) < RecentThreshold {
+			key = WriteQueueRecentKey
+		}
+
+		data, err := json.Marshal(chunk)
 		if err != nil {
 			return fmt.Errorf("queue: marshal: %w", err)
 		}
-		if err := q.client.LPush(ctx, WriteQueueKey, data).Err(); err != nil {
+		if err := q.client.LPush(ctx, key, data).Err(); err != nil {
 			return fmt.Errorf("queue: lpush: %w", err)
 		}
 	}
 	return nil
 }
 
-// Consume blocks for up to brpopTimeout waiting for a batch, then returns it.
-// Returns nil, nil when the timeout expires with no items — callers should loop.
+// Consume blocks for up to brpopTimeout waiting for a batch from either queue.
+// The recent (high-priority) queue is checked first; if empty, the backlog queue
+// is checked. Returns nil, nil when both queues are empty.
 // Called by the RedisWorker in writer mode.
 func (q *RedisQueue) Consume(ctx context.Context) ([]model.SpanRecord, error) {
-	result, err := q.client.BRPop(ctx, brpopTimeout, WriteQueueKey).Result()
+	result, err := q.client.BRPop(ctx, brpopTimeout, WriteQueueRecentKey, WriteQueueBacklogKey).Result()
 	if err == redis.Nil {
 		return nil, nil
 	}
@@ -110,13 +137,17 @@ func (q *RedisQueue) Consume(ctx context.Context) ([]model.SpanRecord, error) {
 	return records, nil
 }
 
-// Len returns the current depth of the write queue. Used for health metrics.
+// Len returns the total depth of both write queues. Used for health metrics.
 func (q *RedisQueue) Len(ctx context.Context) (int64, error) {
-	n, err := q.client.LLen(ctx, WriteQueueKey).Result()
+	recent, err := q.client.LLen(ctx, WriteQueueRecentKey).Result()
 	if err != nil {
-		return 0, fmt.Errorf("queue: llen: %w", err)
+		return 0, fmt.Errorf("queue: llen recent: %w", err)
 	}
-	return n, nil
+	backlog, err := q.client.LLen(ctx, WriteQueueBacklogKey).Result()
+	if err != nil {
+		return 0, fmt.Errorf("queue: llen backlog: %w", err)
+	}
+	return recent + backlog, nil
 }
 
 // Close releases the underlying Redis connection.

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -184,8 +184,10 @@ func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
 }
 
 func (r *Repository) CountSpansOlderThan(cutoff time.Time) (int64, error) {
+	ctx, cancel := r.queryContext()
+	defer cancel()
 	var n int64
-	err := r.db.QueryRow("SELECT COUNT(*) FROM spans WHERE ingested_at <= ?", cutoff).Scan(&n)
+	err := r.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM spans WHERE ingested_at <= ?", cutoff).Scan(&n)
 	return n, err
 }
 
@@ -196,40 +198,6 @@ func (r *Repository) GetSpansForAggregation(cutoff time.Time, limit int) ([]Span
 	return r.scanSpans(
 		"SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at FROM spans WHERE ingested_at <= ? ORDER BY ingested_at LIMIT ?",
 		cutoff, limit,
-	)
-}
-
-// GetBoringTraceSpans returns spans from traces that are entirely boring
-// (no error spans, no slow spans) with ingested_at older than cutoff.
-// Used to aggregate-then-delete boring traces on a shorter TTL than error traces.
-//
-// The query uses two NOT EXISTS clauses instead of GROUP BY so SQLite can stop
-// scanning as soon as it finds enough rows via idx_spans_ingested, and each
-// trace-membership check is a keyed lookup on idx_spans_trace / the partial
-// idx_spans_error_trace index rather than a full-table aggregate.
-func (r *Repository) GetBoringTraceSpans(cutoff time.Time, slowThresholdUS int64, limit int) ([]Span, error) {
-	if limit <= 0 {
-		limit = 1000
-	}
-	return r.scanSpans(`
-		SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at
-		FROM spans s
-		WHERE s.ingested_at < ?
-		  AND s.status NOT IN ('error','ERROR','Error')
-		  AND s.duration_us <= ?
-		  AND NOT EXISTS (
-		    SELECT 1 FROM spans e
-		    WHERE e.trace_id = s.trace_id
-		      AND e.status IN ('error','ERROR','Error')
-		  )
-		  AND NOT EXISTS (
-		    SELECT 1 FROM spans e2
-		    WHERE e2.trace_id = s.trace_id
-		      AND e2.duration_us > ?
-		  )
-		ORDER BY s.ingested_at
-		LIMIT ?`,
-		cutoff, slowThresholdUS, slowThresholdUS, limit,
 	)
 }
 

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -11,18 +11,20 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
-	"github.com/wiebe-xyz/spanbarn/internal/aggregation"
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
+
+// Aggregator groups raw spans into aggregates and persists them.
+// Satisfied by both *aggregation.Aggregator and *aggregation.Accumulator.
+type Aggregator interface {
+	AggregateSpans(ctx context.Context, spans []repository.Span) ([]repository.Aggregate, error)
+	Persist(ctx context.Context, aggregates []repository.Aggregate) error
+}
 
 var tracer = otel.Tracer("spanbarn/retention")
 
 const (
 	defaultBatchSize = 5000
-	// boringBatchSize is the number of boring-trace spans deleted per boring
-	// phase run. Kept small so the write lock is held briefly and the writer
-	// can drain the Redis queue between runs.
-	boringBatchSize = 1000
 	// maxSpansPerCycle caps how many spans each RunOnce call will aggregate and
 	// delete. Keeping cycles short prevents long write-lock holds that starve
 	// the span-insert path. Any backlog beyond this cap is picked up on the
@@ -37,8 +39,6 @@ const (
 type Repository interface {
 	CountSpansOlderThan(cutoff time.Time) (int64, error)
 	GetSpansForAggregation(cutoff time.Time, limit int) ([]repository.Span, error)
-	GetBoringTraceSpans(cutoff time.Time, slowThresholdUS int64, limit int) ([]repository.Span, error)
-	DeleteSpansByIDs(ids []int64) (int64, error)
 	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
@@ -51,7 +51,6 @@ type Repository interface {
 // Config controls the retention worker's behaviour.
 type Config struct {
 	FullRetentionHours        int           // hours to keep ALL spans (default 4)
-	BoringTraceHours          int           // hours to keep boring (non-error, non-slow) traces (default 4)
 	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 168 = 7d)
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
@@ -61,18 +60,11 @@ type Config struct {
 	// between deletion batches so the span-insert worker can drain the Redis
 	// queue. 0 disables yielding (old behaviour). Default 30s.
 	BatchYield time.Duration
-	// BoringInterval is the minimum time between boring-trace deletion runs.
-	// Boring spans are deleted in small batches (boringBatchSize) and only
-	// when this interval has elapsed since the last run. Default 10m.
-	BoringInterval time.Duration
 }
 
 func (c Config) withDefaults() Config {
 	if c.FullRetentionHours <= 0 {
 		c.FullRetentionHours = 4
-	}
-	if c.BoringTraceHours <= 0 {
-		c.BoringTraceHours = 4
 	}
 	if c.InterestingRetentionHours <= 0 {
 		c.InterestingRetentionHours = 168
@@ -92,25 +84,21 @@ func (c Config) withDefaults() Config {
 	if c.BatchYield == 0 {
 		c.BatchYield = 30 * time.Second
 	}
-	if c.BoringInterval == 0 {
-		c.BoringInterval = 10 * time.Minute
-	}
 	return c
 }
 
 // RetentionWorker manages span lifecycle: aggregate old spans, sample
 // errors/slow spans, and delete data past its retention window.
 type RetentionWorker struct {
-	repo          Repository
-	aggregator    *aggregation.Aggregator
-	cfg           Config
-	logger        *slog.Logger
-	writeMu       *sync.Mutex
-	lastBoringRun time.Time
+	repo       Repository
+	aggregator Aggregator
+	cfg        Config
+	logger     *slog.Logger
+	writeMu    *sync.Mutex
 }
 
 // NewRetentionWorker creates a new retention worker.
-func NewRetentionWorker(repo Repository, aggregator *aggregation.Aggregator, cfg Config, logger *slog.Logger) *RetentionWorker {
+func NewRetentionWorker(repo Repository, aggregator Aggregator, cfg Config, logger *slog.Logger) *RetentionWorker {
 	return &RetentionWorker{
 		repo:       repo,
 		aggregator: aggregator,
@@ -170,9 +158,6 @@ func (w *RetentionWorker) effectiveConfig() Config {
 	if n, ok := readInt("retention_full_hours"); ok {
 		cfg.FullRetentionHours = n
 	}
-	if n, ok := readInt("boring_trace_hours"); ok {
-		cfg.BoringTraceHours = n
-	}
 	if n, ok := readInt("retention_interesting_hours"); ok {
 		cfg.InterestingRetentionHours = n
 	}
@@ -186,9 +171,8 @@ func (w *RetentionWorker) effectiveConfig() Config {
 }
 
 // RunOnce executes a single retention cycle:
-//  1. Aggregate-and-delete boring traces (non-error, non-slow) older than boring_trace_hours
-//  2. Fetch spans older than full_retention_hours in batches, sample errors, aggregate, delete
-//  3. Delete old error_samples and aggregates
+//  1. Fetch spans older than full_retention_hours in batches, sample errors, aggregate, delete
+//  2. Delete old error_samples and aggregates
 //
 // Each cycle is capped at maxSpansPerCycle deletions to keep write-lock hold
 // times short. If the cap is reached, backlog_remains is logged so operators
@@ -220,7 +204,6 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	cfg := w.effectiveConfig()
 
 	now := time.Now().UTC()
-	boringCutoff := now.Add(-time.Duration(cfg.BoringTraceHours) * time.Hour)
 	interestingCutoff := now.Add(-time.Duration(cfg.InterestingRetentionHours) * time.Hour)
 	errorCutoff := now.Add(-time.Duration(cfg.ErrorRetentionDays) * 24 * time.Hour)
 	aggCutoff := now.Add(-time.Duration(cfg.AggregateRetentionDays) * 24 * time.Hour)
@@ -236,23 +219,11 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		}
 	}
 
-	// Phase 1: aggregate-then-delete boring traces — throttled to BoringInterval
-	// (default 10m) so it doesn't compete with Phase 2 on every cycle.
-	var boringDeleted int64
-	if time.Since(w.lastBoringRun) >= cfg.BoringInterval {
-		var berr error
-		boringDeleted, berr = w.processBoring(ctx, boringCutoff, cfg.SlowThresholdUS, cfg.BatchYield)
-		if berr != nil {
-			return berr
-		}
-		w.lastBoringRun = time.Now()
-	}
-
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	// Phase 2: aggregate-then-delete all remaining old spans (error/slow included),
+	// Aggregate-then-delete all old spans (error/slow included),
 	// capped at maxSpansPerCycle total to bound write-lock hold time.
 	// The write mutex is held only for the duration of one batch, then released
 	// for cfg.BatchYield so the span-insert worker can drain the Redis queue.
@@ -341,7 +312,6 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	}
 
 	span.SetAttributes(
-		attribute.Int64("boring_spans_deleted", boringDeleted),
 		attribute.Int64("spans_aggregated", totalAggregated),
 		attribute.Int64("errors_sampled", totalSampled),
 		attribute.Int64("spans_deleted", spansDeleted),
@@ -351,7 +321,6 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Bool("backlog_remains", backlogRemains),
 	)
 	w.logger.Info("retention cycle complete",
-		"boring_spans_deleted", boringDeleted,
 		"spans_aggregated", totalAggregated,
 		"errors_sampled", totalSampled,
 		"spans_deleted", spansDeleted,
@@ -361,58 +330,4 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"backlog_remains", backlogRemains,
 	)
 	return nil
-}
-
-// processBoring aggregates then deletes one batch of boring traces older than
-// boringCutoff. A single run deletes at most boringBatchSize spans so the
-// write lock is held only briefly. The caller throttles how often this runs
-// via BoringInterval (default 10m).
-func (w *RetentionWorker) processBoring(ctx context.Context, boringCutoff time.Time, slowThresholdUS int64, yield time.Duration) (int64, error) {
-	if ctx.Err() != nil {
-		return 0, ctx.Err()
-	}
-
-	batch, err := w.repo.GetBoringTraceSpans(boringCutoff, slowThresholdUS, boringBatchSize)
-	if err != nil {
-		return 0, err
-	}
-	if len(batch) == 0 {
-		return 0, nil
-	}
-
-	var total int64
-	var batchErr error
-	w.lockBatch(ctx, yield, func() {
-		aggs, err := w.aggregator.AggregateSpans(ctx, batch)
-		if err != nil {
-			batchErr = err
-			return
-		}
-		if len(aggs) > 0 {
-			if err := w.aggregator.Persist(ctx, aggs); err != nil {
-				batchErr = err
-				return
-			}
-		}
-
-		ids := make([]int64, len(batch))
-		for i, s := range batch {
-			ids[i] = s.ID
-		}
-		for len(ids) > 0 {
-			chunk := ids
-			if len(chunk) > 500 {
-				chunk = ids[:500]
-			}
-			ids = ids[len(chunk):]
-			n, err := w.repo.DeleteSpansByIDs(chunk)
-			if err != nil {
-				batchErr = err
-				return
-			}
-			total += n
-		}
-		w.logger.Info("retention: boring batch deleted", "deleted", total)
-	})
-	return total, batchErr
 }

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -337,66 +337,6 @@ func TestRunOnceEmptyDatabase(t *testing.T) {
 	}
 }
 
-func TestBoringTraceAggregationAndDeletion(t *testing.T) {
-	cfg := Config{
-		BoringTraceHours:          1,   // boring traces older than 1h are processed
-		FullRetentionHours:        168, // error traces kept for 7d
-		InterestingRetentionHours: 168,
-		ErrorRetentionDays:        30,
-		AggregateRetentionDays:    365,
-		SlowThresholdUS:           1_000_000,
-	}
-	worker, repo := setupTestWorker(t, cfg)
-	if _, err := repo.CreateProject("test", "Test"); err != nil {
-		t.Fatalf("CreateProject: %v", err)
-	}
-
-	old := time.Now().UTC().Add(-2 * time.Hour)
-
-	// 5 boring spans (single trace, no errors, fast) — should be aggregated + deleted
-	insertTestSpans(t, repo, 5, "ok", 500, old)
-
-	// 3 error spans in a separate trace — must NOT be touched by boring purge
-	insertTestSpans(t, repo, 3, "error", 500, old)
-
-	// 2 recent boring spans — must NOT be touched (within boring TTL)
-	insertTestSpans(t, repo, 2, "ok", 500, time.Now().UTC())
-
-	if err := worker.RunOnce(context.Background()); err != nil {
-		t.Fatalf("RunOnce: %v", err)
-	}
-
-	remaining, err := repo.QuerySpans(repository.SpanFilter{ProjectID: 1, Limit: 100})
-	if err != nil {
-		t.Fatalf("QuerySpans: %v", err)
-	}
-	// Only the 3 error spans + 2 recent boring spans should remain.
-	if len(remaining) != 5 {
-		t.Fatalf("expected 5 spans remaining, got %d", len(remaining))
-	}
-	for _, s := range remaining {
-		if s.Status == "ok" && s.DurationUs == 500 {
-			// If it's ok+fast it must be one of the recent ones.
-			continue
-		}
-		if s.Status != "error" {
-			t.Errorf("unexpected span remaining: %+v", s)
-		}
-	}
-
-	// Boring spans must have been aggregated.
-	aggs, err := repo.QueryAggregates(repository.AggregateFilter{ProjectID: 1, Limit: 100})
-	if err != nil {
-		t.Fatalf("QueryAggregates: %v", err)
-	}
-	var total int64
-	for _, a := range aggs {
-		total += a.Count
-	}
-	if total < 5 {
-		t.Fatalf("expected at least 5 spans in aggregates, got %d", total)
-	}
-}
 
 func TestRunOnceMultipleBatches(t *testing.T) {
 	cfg := Config{

--- a/internal/service/query.go
+++ b/internal/service/query.go
@@ -41,6 +41,12 @@ type SampleRatioLookup interface {
 	Ratio(ctx context.Context, projectID int64, operation string) int
 }
 
+// RecentAggregateQuerier returns synthetic aggregate rows from an in-memory
+// accumulator for the recent tail window. Satisfied by *aggregation.Accumulator.
+type RecentAggregateQuerier interface {
+	QueryRecent(f repository.AggregateFilter) []repository.Aggregate
+}
+
 // QueryService implements query logic for the dashboard API.
 // Methods are organized into focused files:
 //   - query_services.go      — ListServices, ListOperations, GetTimeseries
@@ -51,6 +57,7 @@ type QueryService struct {
 	cache       *cache.Cache
 	logger      *slog.Logger
 	ratioLookup SampleRatioLookup
+	accumulator RecentAggregateQuerier // may be nil on reader/standalone pods
 }
 
 // NewQueryService creates a new QueryService. ratioLookup is used to read the
@@ -90,6 +97,11 @@ func inflateCount(count, errorCount int64, sampleRate float64) int64 {
 
 func (s *QueryService) SetCache(c *cache.Cache) {
 	s.cache = c
+}
+
+// SetAccumulator wires in the in-memory accumulator for recent tail queries.
+func (s *QueryService) SetAccumulator(a RecentAggregateQuerier) {
+	s.accumulator = a
 }
 
 // Cache exposes the underlying cache instance for handlers outside the service.

--- a/internal/service/query_services.go
+++ b/internal/service/query_services.go
@@ -101,21 +101,10 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 		st.buckets += a.Count
 	}
 
-	var spanStats []repository.ServiceStats
-	if fbFrom, ok := narrowFallback(from, to); ok {
-		var err error
-		spanStats, err = s.repo.QueryServiceStatsFromSpans(projectID, fbFrom, to, kind)
-		if err != nil {
-			s.logger.Warn("failed to query service stats from spans", "error", err)
-		}
-	}
-
 	type mergedStats struct {
-		count, errorCount              int64
+		count, errorCount               int64
 		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                       int64
-		spanP50, spanP95, spanP99      int64
-		hasSpanPercentiles             bool
+		aggCount                        int64
 	}
 	merged := make(map[string]*mergedStats)
 
@@ -130,19 +119,45 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 		}
 	}
 
-	for _, ss := range spanStats {
-		ms, ok := merged[ss.Service]
-		if !ok {
-			ms = &mergedStats{}
-			merged[ss.Service] = ms
-		}
-		ms.count += ss.Count
-		ms.errorCount += ss.ErrorCount
-		if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
-			ms.spanP50 = ss.P50Us
-			ms.spanP95 = ss.P95Us
-			ms.spanP99 = ss.P99Us
-			ms.hasSpanPercentiles = true
+	// Merge recent in-memory aggregates (or fall back to raw spans when no
+	// accumulator is wired — reader pods and standalone mode).
+	if fbFrom, ok := narrowFallback(from, to); ok {
+		if s.accumulator != nil {
+			for _, a := range s.accumulator.QueryRecent(repository.AggregateFilter{
+				ProjectID: projectID, Kind: kind, From: fbFrom, To: to,
+			}) {
+				ms := merged[a.Service]
+				if ms == nil {
+					ms = &mergedStats{}
+					merged[a.Service] = ms
+				}
+				ms.count += a.Count
+				ms.errorCount += a.ErrorCount
+				ms.aggP50Sum += a.P50Us * a.Count
+				ms.aggP95Sum += a.P95Us * a.Count
+				ms.aggP99Sum += a.P99Us * a.Count
+				ms.aggCount += a.Count
+			}
+		} else {
+			spanStats, err := s.repo.QueryServiceStatsFromSpans(projectID, fbFrom, to, kind)
+			if err != nil {
+				s.logger.Warn("failed to query service stats from spans", "error", err)
+			}
+			for _, ss := range spanStats {
+				ms := merged[ss.Service]
+				if ms == nil {
+					ms = &mergedStats{}
+					merged[ss.Service] = ms
+				}
+				ms.count += ss.Count
+				ms.errorCount += ss.ErrorCount
+				if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
+					ms.aggP50Sum += ss.P50Us * ss.Count
+					ms.aggP95Sum += ss.P95Us * ss.Count
+					ms.aggP99Sum += ss.P99Us * ss.Count
+					ms.aggCount += ss.Count
+				}
+			}
 		}
 	}
 
@@ -160,10 +175,6 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 			p50 = ms.aggP50Sum / ms.aggCount
 			p95 = ms.aggP95Sum / ms.aggCount
 			p99 = ms.aggP99Sum / ms.aggCount
-		} else if ms.hasSpanPercentiles {
-			p50 = ms.spanP50
-			p95 = ms.spanP95
-			p99 = ms.spanP99
 		}
 
 		result = append(result, ServiceSummary{
@@ -212,11 +223,9 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 		operation, resource, kind string
 	}
 	type opStats struct {
-		count, errorCount              int64
+		count, errorCount               int64
 		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                       int64
-		spanP50, spanP95, spanP99      int64
-		hasSpanPercentiles             bool
+		aggCount                        int64
 	}
 	byOp := make(map[opKey]*opStats)
 	for _, a := range aggs {
@@ -234,28 +243,45 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 		st.aggCount += a.Count
 	}
 
-	var spanStats []repository.OperationStats
 	if fbFrom, ok := narrowFallback(from, to); ok {
-		var err error
-		spanStats, err = s.repo.QueryOperationStatsFromSpans(projectID, service, fbFrom, to, kind)
-		if err != nil {
-			s.logger.Warn("failed to query operation stats from spans", "error", err)
-		}
-	}
-	for _, ss := range spanStats {
-		k := opKey{ss.Operation, ss.Resource, ss.Kind}
-		st, ok := byOp[k]
-		if !ok {
-			st = &opStats{}
-			byOp[k] = st
-		}
-		st.count += ss.Count
-		st.errorCount += ss.ErrorCount
-		if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
-			st.spanP50 = ss.P50Us
-			st.spanP95 = ss.P95Us
-			st.spanP99 = ss.P99Us
-			st.hasSpanPercentiles = true
+		if s.accumulator != nil {
+			for _, a := range s.accumulator.QueryRecent(repository.AggregateFilter{
+				ProjectID: projectID, Service: service, Kind: kind, From: fbFrom, To: to,
+			}) {
+				k := opKey{a.Operation, a.Resource, a.Kind}
+				st := byOp[k]
+				if st == nil {
+					st = &opStats{}
+					byOp[k] = st
+				}
+				st.count += a.Count
+				st.errorCount += a.ErrorCount
+				st.aggP50Sum += a.P50Us * a.Count
+				st.aggP95Sum += a.P95Us * a.Count
+				st.aggP99Sum += a.P99Us * a.Count
+				st.aggCount += a.Count
+			}
+		} else {
+			spanStats, err := s.repo.QueryOperationStatsFromSpans(projectID, service, fbFrom, to, kind)
+			if err != nil {
+				s.logger.Warn("failed to query operation stats from spans", "error", err)
+			}
+			for _, ss := range spanStats {
+				k := opKey{ss.Operation, ss.Resource, ss.Kind}
+				st := byOp[k]
+				if st == nil {
+					st = &opStats{}
+					byOp[k] = st
+				}
+				st.count += ss.Count
+				st.errorCount += ss.ErrorCount
+				if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
+					st.aggP50Sum += ss.P50Us * ss.Count
+					st.aggP95Sum += ss.P95Us * ss.Count
+					st.aggP99Sum += ss.P99Us * ss.Count
+					st.aggCount += ss.Count
+				}
+			}
 		}
 	}
 
@@ -272,10 +298,6 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 			p50 = st.aggP50Sum / st.aggCount
 			p95 = st.aggP95Sum / st.aggCount
 			p99 = st.aggP99Sum / st.aggCount
-		} else if st.hasSpanPercentiles {
-			p50 = st.spanP50
-			p95 = st.spanP95
-			p99 = st.spanP99
 		}
 		result = append(result, OperationSummary{
 			Operation:  k.operation,
@@ -325,11 +347,9 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 	}
 
 	type bucketStats struct {
-		count, errorCount              int64
+		count, errorCount               int64
 		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                       int64
-		spanP50, spanP95, spanP99      int64
-		hasSpanPercentiles             bool
+		aggCount                        int64
 	}
 	byBucket := make(map[time.Time]*bucketStats)
 	for _, a := range aggs {
@@ -347,28 +367,45 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 		st.aggCount += a.Count
 	}
 
-	var spanBuckets []repository.SpanBucket
 	if fbFrom, ok := narrowFallback(from, to); ok {
-		var err error
-		spanBuckets, err = s.repo.QuerySpanTimeseries(projectID, svcName, operation, fbFrom, to, int64(interval.Seconds()))
-		if err != nil {
-			s.logger.Warn("failed to query span timeseries", "error", err)
-		}
-	}
-	for _, sb := range spanBuckets {
-		b := sb.Bucket.Truncate(interval)
-		st, ok := byBucket[b]
-		if !ok {
-			st = &bucketStats{}
-			byBucket[b] = st
-		}
-		st.count += sb.Count
-		st.errorCount += sb.ErrorCount
-		if sb.P50Us > 0 || sb.P95Us > 0 || sb.P99Us > 0 {
-			st.spanP50 = sb.P50Us
-			st.spanP95 = sb.P95Us
-			st.spanP99 = sb.P99Us
-			st.hasSpanPercentiles = true
+		if s.accumulator != nil {
+			for _, a := range s.accumulator.QueryRecent(repository.AggregateFilter{
+				ProjectID: projectID, Service: svcName, Operation: operation, From: fbFrom, To: to,
+			}) {
+				b := a.Bucket.Truncate(interval)
+				st := byBucket[b]
+				if st == nil {
+					st = &bucketStats{}
+					byBucket[b] = st
+				}
+				st.count += a.Count
+				st.errorCount += a.ErrorCount
+				st.aggP50Sum += a.P50Us * a.Count
+				st.aggP95Sum += a.P95Us * a.Count
+				st.aggP99Sum += a.P99Us * a.Count
+				st.aggCount += a.Count
+			}
+		} else {
+			spanBuckets, err := s.repo.QuerySpanTimeseries(projectID, svcName, operation, fbFrom, to, int64(interval.Seconds()))
+			if err != nil {
+				s.logger.Warn("failed to query span timeseries", "error", err)
+			}
+			for _, sb := range spanBuckets {
+				b := sb.Bucket.Truncate(interval)
+				st := byBucket[b]
+				if st == nil {
+					st = &bucketStats{}
+					byBucket[b] = st
+				}
+				st.count += sb.Count
+				st.errorCount += sb.ErrorCount
+				if sb.P50Us > 0 || sb.P95Us > 0 || sb.P99Us > 0 {
+					st.aggP50Sum += sb.P50Us * sb.Count
+					st.aggP95Sum += sb.P95Us * sb.Count
+					st.aggP99Sum += sb.P99Us * sb.Count
+					st.aggCount += sb.Count
+				}
+			}
 		}
 	}
 
@@ -379,10 +416,6 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 			p50 = st.aggP50Sum / st.aggCount
 			p95 = st.aggP95Sum / st.aggCount
 			p99 = st.aggP99Sum / st.aggCount
-		} else if st.hasSpanPercentiles {
-			p50 = st.spanP50
-			p95 = st.spanP95
-			p99 = st.spanP99
 		}
 		result = append(result, TimeseriesBucket{
 			Bucket:     b,

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -55,11 +55,11 @@ func (m *Metrics) Snapshot() (processed, errors int64, duration time.Duration) {
 
 // Worker reads from the spool and persists records to the repository.
 type Worker struct {
-	spool      *spool.Spool
-	repo       Repository
-	aggregator Aggregator
-	logger     *slog.Logger
-	metrics    Metrics
+	spool          *spool.Spool
+	repo           Repository
+	aggregator     Aggregator
+	logger         *slog.Logger
+	metrics        Metrics
 	retryBaseDelay time.Duration
 }
 
@@ -213,23 +213,33 @@ func (w *Worker) aggregateInline(ctx context.Context, spans []repository.Span) {
 	}
 }
 
-// inlineAggInterval is how often the RedisWorker runs inline aggregation.
-// Running after every batch causes too many write transactions under high ingest
-// rates, which starves span inserts and backs up the Redis queue. Retention
-// catches up on any spans skipped here within its own cycle.
-const inlineAggInterval = 30 * time.Second
+// SpanAccumulator receives every span for in-memory aggregation.
+// Satisfied by *aggregation.Accumulator.
+type SpanAccumulator interface {
+	Add(s repository.Span)
+}
 
-// RedisWorker consumes span batches from a Redis write queue and persists them
-// to the repository. It reuses the same retry and inline-aggregation logic as
-// the file-spool Worker.
+// WorkerConfig holds tunable parameters for RedisWorker.
+type WorkerConfig struct {
+	// SlowThresholdUs is the duration above which a span is considered "slow"
+	// and therefore interesting (must be stored in SQLite). Spans below this
+	// threshold with no errors are boring and skipped. 0 disables the filter
+	// (all spans are written).
+	SlowThresholdUs int64
+}
+
+// RedisWorker consumes span batches from a Redis write queue and persists
+// interesting spans to the repository. Boring spans (no error, below the slow
+// threshold) are fed only to the in-memory accumulator and never written to
+// SQLite, keeping the spans table small and fast.
 type RedisWorker struct {
-	queue         *queue.RedisQueue
-	repo          Repository
-	aggregator    Aggregator
-	logger        *slog.Logger
-	metrics       Metrics
-	lastInlineAgg time.Time
-	writeMu       *sync.Mutex
+	queue       *queue.RedisQueue
+	repo        Repository
+	accumulator SpanAccumulator
+	logger      *slog.Logger
+	metrics     Metrics
+	writeMu     *sync.Mutex
+	cfg         WorkerConfig
 }
 
 // NewRedisWorker creates a worker that drains the Redis write queue.
@@ -240,9 +250,15 @@ func NewRedisWorker(q *queue.RedisQueue, repo Repository, logger *slog.Logger) *
 	return &RedisWorker{queue: q, repo: repo, logger: logger}
 }
 
-// SetAggregator wires in an aggregator for inline aggregation after each batch.
-func (w *RedisWorker) SetAggregator(a Aggregator) {
-	w.aggregator = a
+// SetAccumulator wires in the in-memory accumulator. Every span in each batch
+// (boring and interesting alike) is fed to Add before SQLite classification.
+func (w *RedisWorker) SetAccumulator(a SpanAccumulator) {
+	w.accumulator = a
+}
+
+// SetConfig applies worker tuning parameters.
+func (w *RedisWorker) SetConfig(cfg WorkerConfig) {
+	w.cfg = cfg
 }
 
 // SetWriteMutex wires in the shared write serializer. When set, the worker
@@ -291,9 +307,31 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 
 	spans := convertRecords(records)
 
-	// Acquire the shared write lock before touching the DB. This serialises
-	// all writes with the retention worker so neither starves the other out
-	// competing for the SQLite write connection.
+	// Feed every span to the accumulator for in-memory aggregation, including
+	// boring spans that will not reach SQLite.
+	if w.accumulator != nil {
+		for i := range spans {
+			w.accumulator.Add(spans[i])
+		}
+	}
+
+	// Classify: only interesting spans (error or slow, plus boring spans that
+	// share a trace with an interesting span) are written to SQLite.
+	interesting := spans
+	if w.cfg.SlowThresholdUs > 0 {
+		interesting = classifyInteresting(spans, w.cfg.SlowThresholdUs)
+	}
+
+	boringCount := len(spans) - len(interesting)
+	if boringCount > 0 {
+		span.SetAttributes(attribute.Int("boring_skipped", boringCount))
+	}
+
+	if len(interesting) == 0 {
+		return
+	}
+
+	// Acquire the shared write lock before touching the DB.
 	if w.writeMu != nil {
 		w.writeMu.Lock()
 		defer w.writeMu.Unlock()
@@ -302,11 +340,11 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 	_, insertSpan := tracer.Start(ctx, "redis_worker.insert_spans")
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		if err := w.repo.InsertSpans(ctx, spans); err != nil {
+		if err := w.repo.InsertSpans(ctx, interesting); err != nil {
 			lastErr = err
 			w.logger.Info("redis worker: insert attempt failed",
 				"attempt", attempt,
-				"count", len(spans),
+				"count", len(interesting),
 				"error", err,
 			)
 			backoff := time.Duration(attempt*attempt) * 500 * time.Millisecond
@@ -328,41 +366,48 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 	insertSpan.End()
 
 	if lastErr != nil {
-		span.SetAttributes(attribute.Int("dead_lettered", len(spans)))
+		span.SetAttributes(attribute.Int("dead_lettered", len(interesting)))
 		w.logger.Error("redis worker: dead-lettering batch after retries",
-			"count", len(spans),
+			"count", len(interesting),
 			"error", lastErr,
 		)
 		w.metrics.mu.Lock()
-		w.metrics.ErrorCount += int64(len(spans))
+		w.metrics.ErrorCount += int64(len(interesting))
 		w.metrics.mu.Unlock()
 		return
 	}
 
 	w.metrics.mu.Lock()
-	w.metrics.ProcessedCount += int64(len(spans))
+	w.metrics.ProcessedCount += int64(len(interesting))
 	w.metrics.mu.Unlock()
 
-	if promptRecs := extractPromptRecords(spans); len(promptRecs) > 0 {
+	if promptRecs := extractPromptRecords(interesting); len(promptRecs) > 0 {
 		if err := w.repo.InsertPromptRecords(ctx, promptRecs); err != nil {
 			w.logger.Warn("redis worker: insert prompt records", "count", len(promptRecs), "error", err)
 		}
 	}
+}
 
-	if w.aggregator != nil && time.Since(w.lastInlineAgg) >= inlineAggInterval {
-		aggs, err := w.aggregator.AggregateSpans(ctx, spans)
-		if err != nil {
-			w.logger.Warn("redis worker: inline aggregate failed", "error", err)
-			return
+// classifyInteresting returns only the spans that should be written to SQLite:
+// those that are errors or slow, plus any boring span that shares a trace_id
+// with an interesting span (preserves waterfall completeness within a batch).
+func classifyInteresting(spans []repository.Span, slowThresholdUs int64) []repository.Span {
+	interestingTraces := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
+		if s.Status == "error" || s.DurationUs > slowThresholdUs {
+			interestingTraces[s.TraceID] = struct{}{}
 		}
-		if len(aggs) > 0 {
-			if err := w.aggregator.Persist(ctx, aggs); err != nil {
-				w.logger.Warn("redis worker: inline aggregate persist failed", "error", err)
-				return
-			}
-		}
-		w.lastInlineAgg = time.Now()
 	}
+	if len(interestingTraces) == 0 {
+		return nil
+	}
+	result := make([]repository.Span, 0, len(spans))
+	for _, s := range spans {
+		if _, ok := interestingTraces[s.TraceID]; ok {
+			result = append(result, s)
+		}
+	}
+	return result
 }
 
 func convertRecords(records []model.SpanRecord) []repository.Span {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -271,3 +271,99 @@ func TestWorkerGracefulShutdown(t *testing.T) {
 		t.Fatalf("after shutdown, got %d spans, want 3", len(got))
 	}
 }
+
+func TestClassifyInteresting(t *testing.T) {
+	spans := []repository.Span{
+		{TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 100},       // boring
+		{TraceID: "t2", SpanID: "s2", Status: "error", DurationUs: 100},    // error → interesting
+		{TraceID: "t2", SpanID: "s3", Status: "ok", DurationUs: 100},       // boring but co-trace with error → promoted
+		{TraceID: "t3", SpanID: "s4", Status: "ok", DurationUs: 2_000_000}, // slow → interesting
+		{TraceID: "t3", SpanID: "s5", Status: "ok", DurationUs: 50},        // boring but co-trace with slow → promoted
+	}
+
+	result := classifyInteresting(spans, 1_000_000)
+
+	if len(result) != 4 {
+		t.Fatalf("expected 4 interesting spans, got %d", len(result))
+	}
+	// t1 (boring, no interesting co-trace) must be absent.
+	for _, s := range result {
+		if s.SpanID == "s1" {
+			t.Error("boring span s1 should not appear in interesting set")
+		}
+	}
+}
+
+func TestClassifyInterestingAllBoring(t *testing.T) {
+	spans := []repository.Span{
+		{TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 50},
+		{TraceID: "t2", SpanID: "s2", Status: "ok", DurationUs: 100},
+	}
+	result := classifyInteresting(spans, 1_000_000)
+	if result != nil {
+		t.Fatalf("expected nil for all-boring batch, got %v", result)
+	}
+}
+
+func TestClassifyInterestingNoThreshold(t *testing.T) {
+	spans := []repository.Span{
+		{TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 50},
+	}
+	// threshold=0 means no filter — all spans are interesting.
+	result := classifyInteresting(spans, 0)
+	if len(result) != 1 {
+		t.Fatalf("threshold=0 should pass all spans, got %d", len(result))
+	}
+}
+
+// mockAccumulator records Add calls for testing.
+type mockAccumulator struct {
+	mu    sync.Mutex
+	added []repository.Span
+}
+
+func (m *mockAccumulator) Add(s repository.Span) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.added = append(m.added, s)
+}
+
+func (m *mockAccumulator) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.added)
+}
+
+func TestRedisWorkerBoringBypass(t *testing.T) {
+	repo := &mockRepo{}
+	acc := &mockAccumulator{}
+
+	records := []model.SpanRecord{
+		{ProjectID: 1, TraceID: "t1", SpanID: "s1", Name: "op", Service: "svc", Status: "OK", DurationUs: 50},        // boring
+		{ProjectID: 1, TraceID: "t2", SpanID: "s2", Name: "op", Service: "svc", Status: "error", DurationUs: 50},     // error
+		{ProjectID: 1, TraceID: "t2", SpanID: "s3", Name: "op", Service: "svc", Status: "OK", DurationUs: 50},        // boring, co-trace with error → promoted
+		{ProjectID: 1, TraceID: "t3", SpanID: "s4", Name: "op", Service: "svc", Status: "OK", DurationUs: 2_000_000}, // slow
+	}
+
+	rw := &RedisWorker{repo: repo, logger: slog.Default()}
+	rw.SetAccumulator(acc)
+	rw.SetConfig(WorkerConfig{SlowThresholdUs: 1_000_000})
+
+	rw.processBatch(context.Background(), records)
+
+	// All 4 spans fed to accumulator.
+	if acc.count() != 4 {
+		t.Errorf("accumulator received %d spans, want 4", acc.count())
+	}
+
+	// Only 3 interesting spans written to SQLite (s1 is boring with no interesting co-trace).
+	inserted := repo.getSpans()
+	if len(inserted) != 3 {
+		t.Errorf("inserted %d spans to SQLite, want 3", len(inserted))
+	}
+	for _, s := range inserted {
+		if s.SpanID == "s1" {
+			t.Error("boring span s1 should not be in SQLite")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause 1**: `GetBoringTraceSpans` — a correlated `NOT EXISTS` on 896k rows that context cancellation can't stop — was holding the SQLite write lock for ~300s every 10 minutes, starving all span inserts. Confirmed by 29 self-trace spans at ~300s each. **Fix**: boring spans are now classified at the Redis queue level and never enter SQLite, so this query path is eliminated entirely.

- **Root cause 2**: 5,526 stale June-8 Redis batches caused all inline aggregates to land 42h in the past. `MAX(bucket) = 2026-06-08 16:40`, UI queries `bucket >= now-1h` → empty. Immediate hotfix: `LTRIM spanbarn:write-queue 0 100`. Code fix: priority queue + in-memory accumulator prevent recurrence.

- **Root cause 3**: `RedisWorker.lastInlineAgg` only advanced on success. A single `Persist` failure (common under lock contention) caused every subsequent batch to retry aggregation immediately.

## Changes

**`internal/aggregation/accumulator.go`** (new) — Thread-safe in-memory slots keyed by `(projectID, service, operation, resource, kind, bucket)`. `Add()` is O(1) per span. `Flush()` computes P50/P95/P99 and upserts to SQLite every 30s. `QueryRecent()` returns synthetic aggregate rows for the query service tail window. Implements `AggregateSpans+Persist` so it replaces `*Aggregator` at the retention worker call site without changing retention internals.

**`internal/worker/worker.go`** — `RedisWorker` now feeds every span to the accumulator (boring + interesting) and writes only interesting spans to SQLite. Interesting = error OR slow, plus any boring span that shares a trace_id with an interesting span (preserves waterfall completeness within a batch). Removes `inlineAggInterval`, `lastInlineAgg`, and the entire inline-aggregation path.

**`internal/queue/redis_queue.go`** — Dual-key priority queue. `Publish` routes batches whose `max(start_time_us)` is within 5 minutes to `spanbarn:write-queue:recent`; older batches go to the legacy `spanbarn:write-queue` (backlog). `Consume` does `BRPOP recent backlog` — recent spans are always drained first.

**`internal/retention/retention.go`** — Removes Phase 1 (`processBoring`, `GetBoringTraceSpans`, `BoringTraceHours`, `BoringInterval`). `Aggregator` field changed to interface so `*Accumulator` can be wired in from `main.go`.

**`internal/repository/repo_spans.go`** — Removes `GetBoringTraceSpans`. Fixes `CountSpansOlderThan` to use `queryContext()` (was missing context timeout).

**`internal/service/query_services.go`** — Replaces the `narrowFallback` raw-span scan in `ListServices`, `ListOperations`, and `GetTimeseries` with `accumulator.QueryRecent`. Falls back to the spans table when no accumulator is wired (reader pods, standalone mode).

**`cmd/spanbarn/main.go`** — Wires `*Accumulator` into worker, retention worker, and query service. Starts `accumulator.Run` goroutine alongside the Redis worker.

## Test plan

- [ ] After deploy: `kubectl exec ... sqlite3 .db "SELECT MAX(bucket) FROM aggregates;"` should be within 30s of now
- [ ] Logs show `persisted aggregates count: X` at ~30s intervals with current timestamps
- [ ] `SELECT COUNT(*) FROM spans WHERE ingested_at > datetime('now','-5 minutes') AND status NOT IN ('error','ERROR','Error') AND duration_us < 1000000;` returns 0
- [ ] `redis-cli LLEN spanbarn:write-queue:recent` stays low; `spanbarn:write-queue` backlog drains over time
- [ ] Self-trace `sqlite.select` spans for spanbarn drop from ~300s to <100ms (no more `GetBoringTraceSpans`)
- [ ] `go test -race ./...` passes