### PR TITLE
feat(ingest): boring span sampling, short retention, and verbose project mode

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -163,6 +163,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
 		InterestingRetentionHours: cfg.RetentionInterestingHours,
+		BoringRetentionMinutes:    cfg.BoringRetentionMinutes,
 		ErrorRetentionDays:        cfg.RetentionErrorDays,
 		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
@@ -637,9 +638,12 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	// SQLite only ever sees one writer at a time.
 	writeMu := &sync.Mutex{}
 
+	boringPolicy := worker.NewCachedBoringPolicy(repo, 30*time.Second)
+
 	rw := worker.NewRedisWorker(writeQueue, &workerRepoAdapter{repo: repo}, logger)
 	rw.SetAccumulator(accumulator)
 	rw.SetConfig(worker.WorkerConfig{SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000})
+	rw.SetBoringPolicy(boringPolicy)
 	rw.SetWriteMutex(writeMu)
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
@@ -661,6 +665,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,
 		InterestingRetentionHours: cfg.RetentionInterestingHours,
+		BoringRetentionMinutes:    cfg.BoringRetentionMinutes,
 		ErrorRetentionDays:        cfg.RetentionErrorDays,
 		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -79,6 +80,16 @@ func (h *projectHandlers) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			h.handleEnableE2E(w, r, id)
 		case http.MethodDelete:
 			h.handleDisableE2E(w, r, id)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		}
+		return
+	case "verbose":
+		switch r.Method {
+		case http.MethodPost:
+			h.handleEnableVerbose(w, r, id)
+		case http.MethodDelete:
+			h.handleDisableVerbose(w, r, id)
 		default:
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
 		}
@@ -183,6 +194,62 @@ func (h *projectHandlers) handleListAPIKeys(w http.ResponseWriter, r *http.Reque
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(out)
+}
+
+type verboseRequest struct {
+	DurationMinutes int `json:"durationMinutes"`
+}
+
+type verboseResponse struct {
+	ProjectID    int64  `json:"projectId"`
+	VerboseUntil string `json:"verboseUntil"`
+}
+
+// handleEnableVerbose sets verbose (record-in-detail) mode for a project.
+// POST /api/v1/projects/{id}/verbose with body {"durationMinutes": 60}
+// Stores boring.verbose_until.project.{id} = Unix timestamp of expiry.
+func (h *projectHandlers) handleEnableVerbose(w http.ResponseWriter, r *http.Request, id int64) {
+	_, span := apiTracer.Start(r.Context(), "api.projects.enable_verbose")
+	defer span.End()
+	span.SetAttributes(attribute.Int64("project.id", id))
+
+	var req verboseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
+		return
+	}
+	if req.DurationMinutes <= 0 {
+		req.DurationMinutes = 60
+	}
+	if req.DurationMinutes > 1440 { // cap at 24h
+		req.DurationMinutes = 1440
+	}
+
+	until := time.Now().Add(time.Duration(req.DurationMinutes) * time.Minute)
+	key := fmt.Sprintf("boring.verbose_until.project.%d", id)
+	if err := h.repo.SetSetting(key, strconv.FormatInt(until.Unix(), 10)); err != nil {
+		writeServerError(w, r, "failed to set verbose mode", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, verboseResponse{
+		ProjectID:    id,
+		VerboseUntil: until.UTC().Format(time.RFC3339),
+	})
+}
+
+// handleDisableVerbose clears verbose mode for a project.
+// DELETE /api/v1/projects/{id}/verbose
+func (h *projectHandlers) handleDisableVerbose(w http.ResponseWriter, r *http.Request, id int64) {
+	_, span := apiTracer.Start(r.Context(), "api.projects.disable_verbose")
+	defer span.End()
+	span.SetAttributes(attribute.Int64("project.id", id))
+
+	key := fmt.Sprintf("boring.verbose_until.project.%d", id)
+	if err := h.repo.DeleteSetting(key); err != nil {
+		writeServerError(w, r, "failed to clear verbose mode", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (h *projectHandlers) handleEnableE2E(w http.ResponseWriter, r *http.Request, id int64) {

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -159,13 +159,18 @@ func serveSWR[T any](
 // Retention keys are plain identifiers; sampling keys use a dot-namespaced
 // hierarchy: ingest.sample_ratio.default, ingest.sample_ratio.project.{id},
 // ingest.sample_ratio.project.{id}.op.{operation}.
+// Boring span keys: boring.sample_ratio, boring.sample_ratio.project.{id},
+// boring_retention_minutes, boring.verbose_until.project.{id}.
 func isAllowedSettingKey(k string) bool {
 	switch k {
 	case "retention_full_hours", "retention_interesting_hours",
-		"retention_aggregated_days", "retention_error_days":
+		"retention_aggregated_days", "retention_error_days",
+		"boring_retention_minutes", "boring.sample_ratio":
 		return true
 	}
-	return strings.HasPrefix(k, "ingest.sample_ratio.")
+	return strings.HasPrefix(k, "ingest.sample_ratio.") ||
+		strings.HasPrefix(k, "boring.sample_ratio.") ||
+		strings.HasPrefix(k, "boring.verbose_until.")
 }
 
 func (h *settingsHandlers) handleStatsDBSize(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,10 +21,11 @@ type Config struct {
 	SessionTTLSeconds      int
 	MaxBodyBytes           int64
 	MaxSpoolBytes          int64
-	RetentionFullHours     int
-	RetentionAggregatedDays int
-	RetentionErrorDays     int
+	RetentionFullHours        int
+	RetentionAggregatedDays   int
+	RetentionErrorDays        int
 	RetentionInterestingHours int
+	BoringRetentionMinutes    int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
 	IngestSampleRate          float64
 	SlowThresholdMS           int
 	AggregationInterval       string
@@ -74,6 +75,7 @@ func Load() Config {
 		RetentionAggregatedDays: getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
 		RetentionErrorDays:      getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
 		RetentionInterestingHours: getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
+		BoringRetentionMinutes:    getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
 		IngestSampleRate:          getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
 		SlowThresholdMS:           getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:     getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),

--- a/internal/repository/migrations/022_index_boring_cleanup.go
+++ b/internal/repository/migrations/022_index_boring_cleanup.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up022, down022)
+}
+
+// up022 adds a covering index for the fast boring-span deletion query.
+// The retention worker periodically runs:
+//
+//	DELETE FROM spans WHERE ingested_at < ? AND status NOT IN ('error') AND duration_us < ?
+//
+// (ingested_at, status, duration_us) lets SQLite resolve the range + predicate
+// entirely from the index without touching the main table rows.
+func up022(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		CREATE INDEX IF NOT EXISTS idx_spans_boring_cleanup
+		ON spans(ingested_at, status, duration_us)
+	`)
+	return err
+}
+
+func down022(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS idx_spans_boring_cleanup`)
+	return err
+}

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -183,6 +183,20 @@ func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
 	return res.RowsAffected()
 }
 
+// DeleteBoringSpansOlderThan removes non-error, fast spans ingested before cutoff.
+// This is the fast boring-span cleanup: a simple range DELETE using the
+// idx_spans_boring_cleanup index rather than a correlated subquery.
+func (r *Repository) DeleteBoringSpansOlderThan(cutoff time.Time, slowThresholdUs int64) (int64, error) {
+	res, err := r.db.Exec(
+		`DELETE FROM spans WHERE ingested_at < ? AND status NOT IN ('error','ERROR','Error') AND duration_us < ?`,
+		cutoff, slowThresholdUs,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 func (r *Repository) CountSpansOlderThan(cutoff time.Time) (int64, error) {
 	ctx, cancel := r.queryContext()
 	defer cancel()

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -41,6 +41,7 @@ type Repository interface {
 	GetSpansForAggregation(cutoff time.Time, limit int) ([]repository.Span, error)
 	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
+	DeleteBoringSpansOlderThan(cutoff time.Time, slowThresholdUs int64) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
 	DeleteErrorSamplesOlderThan(cutoff time.Time) (int64, error)
 	DeleteAggregatesOlderThan(cutoff time.Time) (int64, error)
@@ -52,6 +53,7 @@ type Repository interface {
 type Config struct {
 	FullRetentionHours        int           // hours to keep ALL spans (default 4)
 	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 168 = 7d)
+	BoringRetentionMinutes    int           // minutes to keep sampled boring spans (default 30); 0 disables boring cleanup
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
 	SlowThresholdUS           int64         // microseconds above which a span is "slow"
@@ -68,6 +70,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.InterestingRetentionHours <= 0 {
 		c.InterestingRetentionHours = 168
+	}
+	if c.BoringRetentionMinutes <= 0 {
+		c.BoringRetentionMinutes = 30
 	}
 	if c.ErrorRetentionDays <= 0 {
 		c.ErrorRetentionDays = 30
@@ -166,6 +171,9 @@ func (w *RetentionWorker) effectiveConfig() Config {
 	}
 	if n, ok := readInt("retention_error_days"); ok {
 		cfg.ErrorRetentionDays = n
+	}
+	if n, ok := readInt("boring_retention_minutes"); ok {
+		cfg.BoringRetentionMinutes = n
 	}
 	return cfg
 }
@@ -298,6 +306,18 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		}
 	}
 
+	// Fast boring-span cleanup: delete sampled boring spans past their short retention window.
+	// This is a simple indexed range DELETE — no correlated subquery, runs in milliseconds.
+	var boringDeleted int64
+	if cfg.BoringRetentionMinutes > 0 && cfg.SlowThresholdUS > 0 {
+		boringCutoff := now.Add(-time.Duration(cfg.BoringRetentionMinutes) * time.Minute)
+		var boringErr error
+		boringDeleted, boringErr = w.repo.DeleteBoringSpansOlderThan(boringCutoff, cfg.SlowThresholdUS)
+		if boringErr != nil {
+			return boringErr
+		}
+	}
+
 	errorSamplesDeleted, err := w.repo.DeleteErrorSamplesOlderThan(errorCutoff)
 	if err != nil {
 		return err
@@ -315,6 +335,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Int64("spans_aggregated", totalAggregated),
 		attribute.Int64("errors_sampled", totalSampled),
 		attribute.Int64("spans_deleted", spansDeleted),
+		attribute.Int64("boring_deleted", boringDeleted),
 		attribute.Int64("error_samples_deleted", errorSamplesDeleted),
 		attribute.Int64("aggregates_deleted", aggregatesDeleted),
 		attribute.Int64("e2e_users_deleted", e2eUsersDeleted),
@@ -324,6 +345,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"spans_aggregated", totalAggregated,
 		"errors_sampled", totalSampled,
 		"spans_deleted", spansDeleted,
+		"boring_deleted", boringDeleted,
 		"error_samples_deleted", errorSamplesDeleted,
 		"aggregates_deleted", aggregatesDeleted,
 		"e2e_users_deleted", e2eUsersDeleted,

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -423,3 +423,53 @@ func TestRunOnceMultipleBatches(t *testing.T) {
 		t.Fatalf("expected aggregate count %d, got %d", total, totalCount)
 	}
 }
+
+func TestRunOnceDeletesBoringSpans(t *testing.T) {
+	cfg := Config{
+		FullRetentionHours:        24,
+		InterestingRetentionHours: 168,
+		BoringRetentionMinutes:    30,
+		ErrorRetentionDays:        30,
+		AggregateRetentionDays:    365,
+		SlowThresholdUS:           1_000_000,
+	}
+	worker, repo := setupTestWorker(t, cfg)
+
+	if _, err := repo.CreateProject("test", "Test"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// Insert in chronological order so insertTestSpans' UPDATE doesn't backdate later spans.
+	// insertTestSpans does "UPDATE SET ingested_at=? WHERE ingested_at > ?" which would
+	// backdate a newer span if an older insertion comes after it.
+	oldBoring := time.Now().UTC().Add(-45 * time.Minute)
+	insertTestSpans(t, repo, 2, "ok", 100_000, oldBoring) // 100ms, not slow
+
+	// Insert old error span before the recent boring span.
+	oldErr := time.Now().UTC().Add(-45 * time.Minute)
+	insertTestSpans(t, repo, 1, "error", 100_000, oldErr)
+
+	// Insert a recent boring span (within 30 minutes) — must survive boring cleanup.
+	recentBoring := time.Now().UTC().Add(-5 * time.Minute)
+	insertTestSpans(t, repo, 1, "ok", 100_000, recentBoring)
+
+	if err := worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	spans, err := repo.QuerySpans(repository.SpanFilter{ProjectID: 1, Limit: 100})
+	if err != nil {
+		t.Fatalf("QuerySpans: %v", err)
+	}
+
+	// Only 2 spans should remain: 1 recent boring + 1 old error.
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 remaining spans (1 recent boring + 1 old error), got %d", len(spans))
+	}
+	for _, s := range spans {
+		if s.Status == "ok" && s.DurationUs == 100_000 {
+			// This is a boring span — it should only be the recent one.
+			// We can't easily check the exact time but since only 1 recent boring was inserted, that's fine.
+		}
+	}
+}

--- a/internal/worker/boring_policy.go
+++ b/internal/worker/boring_policy.go
@@ -1,0 +1,103 @@
+package worker
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// BoringSettingsReader reads settings by key.
+// Satisfied by *repository.Repository.
+type BoringSettingsReader interface {
+	GetSetting(key string) (string, error)
+}
+
+// BoringPolicyReader provides per-project boring span policy.
+// Satisfied by *CachedBoringPolicy.
+type BoringPolicyReader interface {
+	// SampleRatio returns 1-in-N sampling for boring spans for the project.
+	// 0 = skip all boring spans. 1 = keep all boring spans. N>1 = keep 1-in-N.
+	SampleRatio(projectID int64) int
+	// VerboseUntil returns the time until which all spans for the project
+	// should be stored (verbose / record-in-detail mode). Zero = inactive.
+	VerboseUntil(projectID int64) time.Time
+}
+
+// CachedBoringPolicy reads boring span policy from the settings table with a TTL
+// cache to avoid DB hits on every batch.
+//
+// Settings keys (all optional):
+//
+//	boring.sample_ratio                  → global 1-in-N (0 or absent = skip all boring spans)
+//	boring.sample_ratio.project.{id}     → per-project override
+//	boring.verbose_until.project.{id}    → Unix timestamp (seconds) until project is verbose
+type CachedBoringPolicy struct {
+	repo     BoringSettingsReader
+	cacheTTL time.Duration
+	mu       sync.Mutex
+	entries  map[string]boringEntry
+}
+
+type boringEntry struct {
+	value     string
+	expiresAt time.Time
+}
+
+// NewCachedBoringPolicy creates a policy backed by the given settings reader.
+func NewCachedBoringPolicy(repo BoringSettingsReader, cacheTTL time.Duration) *CachedBoringPolicy {
+	return &CachedBoringPolicy{
+		repo:     repo,
+		cacheTTL: cacheTTL,
+		entries:  make(map[string]boringEntry),
+	}
+}
+
+func (p *CachedBoringPolicy) SampleRatio(projectID int64) int {
+	projKey := fmt.Sprintf("boring.sample_ratio.project.%d", projectID)
+	if s := p.get(projKey); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			return n
+		}
+	}
+	if s := p.get("boring.sample_ratio"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+func (p *CachedBoringPolicy) VerboseUntil(projectID int64) time.Time {
+	key := fmt.Sprintf("boring.verbose_until.project.%d", projectID)
+	s := p.get(key)
+	if s == "" {
+		return time.Time{}
+	}
+	ts, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(ts, 0)
+}
+
+func (p *CachedBoringPolicy) get(key string) string {
+	p.mu.Lock()
+	entry, ok := p.entries[key]
+	now := time.Now()
+	p.mu.Unlock()
+
+	if ok && now.Before(entry.expiresAt) {
+		return entry.value
+	}
+
+	val := ""
+	if s, err := p.repo.GetSetting(key); err == nil {
+		val = s
+	}
+
+	p.mu.Lock()
+	p.entries[key] = boringEntry{value: val, expiresAt: now.Add(p.cacheTTL)}
+	p.mu.Unlock()
+	return val
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"log/slog"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -233,13 +234,14 @@ type WorkerConfig struct {
 // threshold) are fed only to the in-memory accumulator and never written to
 // SQLite, keeping the spans table small and fast.
 type RedisWorker struct {
-	queue       *queue.RedisQueue
-	repo        Repository
-	accumulator SpanAccumulator
-	logger      *slog.Logger
-	metrics     Metrics
-	writeMu     *sync.Mutex
-	cfg         WorkerConfig
+	queue        *queue.RedisQueue
+	repo         Repository
+	accumulator  SpanAccumulator
+	boringPolicy BoringPolicyReader
+	logger       *slog.Logger
+	metrics      Metrics
+	writeMu      *sync.Mutex
+	cfg          WorkerConfig
 }
 
 // NewRedisWorker creates a worker that drains the Redis write queue.
@@ -259,6 +261,11 @@ func (w *RedisWorker) SetAccumulator(a SpanAccumulator) {
 // SetConfig applies worker tuning parameters.
 func (w *RedisWorker) SetConfig(cfg WorkerConfig) {
 	w.cfg = cfg
+}
+
+// SetBoringPolicy wires in the per-project boring span policy (sampling + verbose mode).
+func (w *RedisWorker) SetBoringPolicy(p BoringPolicyReader) {
+	w.boringPolicy = p
 }
 
 // SetWriteMutex wires in the shared write serializer. When set, the worker
@@ -315,12 +322,9 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 		}
 	}
 
-	// Classify: only interesting spans (error or slow, plus boring spans that
-	// share a trace with an interesting span) are written to SQLite.
-	interesting := spans
-	if w.cfg.SlowThresholdUs > 0 {
-		interesting = classifyInteresting(spans, w.cfg.SlowThresholdUs)
-	}
+	// Classify: interesting spans (error, slow, or verbose-project) are written to
+	// SQLite unconditionally; boring spans may be sampled based on per-project policy.
+	interesting := w.classifyForStorage(spans)
 
 	boringCount := len(spans) - len(interesting)
 	if boringCount > 0 {
@@ -388,9 +392,76 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 	}
 }
 
+// classifyForStorage builds the set of spans to write to SQLite.
+// All spans in error/slow traces are included unconditionally. Spans in
+// verbose-mode projects bypass boring classification. Remaining boring spans
+// are sampled at the per-project ratio from boringPolicy (if wired).
+func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.Span {
+	if w.cfg.SlowThresholdUs <= 0 {
+		return spans
+	}
+
+	now := time.Now()
+
+	// Determine which projects are in verbose mode (record all spans).
+	verboseProject := make(map[int64]bool, 2)
+	if w.boringPolicy != nil {
+		for _, s := range spans {
+			if _, seen := verboseProject[s.ProjectID]; !seen {
+				until := w.boringPolicy.VerboseUntil(s.ProjectID)
+				verboseProject[s.ProjectID] = !until.IsZero() && now.Before(until)
+			}
+		}
+	}
+
+	// First pass: find trace IDs that are definitely interesting.
+	interestingTraces := make(map[string]struct{}, len(spans))
+	for _, s := range spans {
+		if verboseProject[s.ProjectID] || s.Status == "error" || s.DurationUs > w.cfg.SlowThresholdUs {
+			interestingTraces[s.TraceID] = struct{}{}
+		}
+	}
+
+	// Second pass: separate interesting from boring.
+	result := make([]repository.Span, 0, len(spans))
+	boring := make([]repository.Span, 0, 8)
+	for _, s := range spans {
+		if _, ok := interestingTraces[s.TraceID]; ok {
+			result = append(result, s)
+		} else {
+			boring = append(boring, s)
+		}
+	}
+
+	// Sample boring spans per project policy.
+	if w.boringPolicy == nil || len(boring) == 0 {
+		return result
+	}
+	byProject := make(map[int64][]repository.Span, 2)
+	for _, s := range boring {
+		byProject[s.ProjectID] = append(byProject[s.ProjectID], s)
+	}
+	for projID, projectBoring := range byProject {
+		ratio := w.boringPolicy.SampleRatio(projID)
+		switch {
+		case ratio == 1:
+			result = append(result, projectBoring...)
+		case ratio > 1:
+			for _, s := range projectBoring {
+				if rand.IntN(ratio) == 0 {
+					result = append(result, s)
+				}
+			}
+			// ratio == 0: skip all boring spans for this project
+		}
+	}
+	return result
+}
+
 // classifyInteresting returns only the spans that should be written to SQLite:
 // those that are errors or slow, plus any boring span that shares a trace_id
 // with an interesting span (preserves waterfall completeness within a batch).
+// Used by tests directly; production code uses classifyForStorage.
 func classifyInteresting(spans []repository.Span, slowThresholdUs int64) []repository.Span {
 	interestingTraces := make(map[string]struct{}, len(spans))
 	for _, s := range spans {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -394,8 +394,9 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 
 // classifyForStorage builds the set of spans to write to SQLite.
 // All spans in error/slow traces are included unconditionally. Spans in
-// verbose-mode projects bypass boring classification. Remaining boring spans
-// are sampled at the per-project ratio from boringPolicy (if wired).
+// verbose-mode projects bypass boring classification. Remaining boring traces
+// are sampled whole at the per-project ratio — the die is rolled once per
+// trace_id, and either all spans in that trace are kept or none are.
 func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.Span {
 	if w.cfg.SlowThresholdUs <= 0 {
 		return spans
@@ -422,37 +423,49 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 		}
 	}
 
-	// Second pass: separate interesting from boring.
+	// Second pass: separate interesting from boring, grouping boring by trace.
 	result := make([]repository.Span, 0, len(spans))
-	boring := make([]repository.Span, 0, 8)
+	// boringTraces maps trace_id → (projectID, spans) for all-or-nothing sampling.
+	type boringTrace struct {
+		projectID int64
+		spans     []repository.Span
+	}
+	var boringTraceOrder []string
+	boringTraceMap := make(map[string]*boringTrace, 8)
 	for _, s := range spans {
 		if _, ok := interestingTraces[s.TraceID]; ok {
 			result = append(result, s)
 		} else {
-			boring = append(boring, s)
+			bt := boringTraceMap[s.TraceID]
+			if bt == nil {
+				bt = &boringTrace{projectID: s.ProjectID}
+				boringTraceMap[s.TraceID] = bt
+				boringTraceOrder = append(boringTraceOrder, s.TraceID)
+			}
+			bt.spans = append(bt.spans, s)
 		}
 	}
 
-	// Sample boring spans per project policy.
-	if w.boringPolicy == nil || len(boring) == 0 {
+	// Sample whole boring traces per project policy.
+	if w.boringPolicy == nil || len(boringTraceOrder) == 0 {
 		return result
 	}
-	byProject := make(map[int64][]repository.Span, 2)
-	for _, s := range boring {
-		byProject[s.ProjectID] = append(byProject[s.ProjectID], s)
-	}
-	for projID, projectBoring := range byProject {
-		ratio := w.boringPolicy.SampleRatio(projID)
+	ratioCache := make(map[int64]int, 2)
+	for _, traceID := range boringTraceOrder {
+		bt := boringTraceMap[traceID]
+		ratio, ok := ratioCache[bt.projectID]
+		if !ok {
+			ratio = w.boringPolicy.SampleRatio(bt.projectID)
+			ratioCache[bt.projectID] = ratio
+		}
 		switch {
 		case ratio == 1:
-			result = append(result, projectBoring...)
+			result = append(result, bt.spans...)
 		case ratio > 1:
-			for _, s := range projectBoring {
-				if rand.IntN(ratio) == 0 {
-					result = append(result, s)
-				}
+			if rand.IntN(ratio) == 0 {
+				result = append(result, bt.spans...)
 			}
-			// ratio == 0: skip all boring spans for this project
+			// ratio == 0: skip all boring traces for this project
 		}
 	}
 	return result

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -386,17 +386,45 @@ func TestClassifyForStorageBoringPolicy(t *testing.T) {
 
 	rw := &RedisWorker{cfg: WorkerConfig{SlowThresholdUs: 1_000_000}}
 
-	// No policy: boring spans are dropped.
+	// No policy: boring traces are dropped.
 	result := rw.classifyForStorage(spans)
 	if len(result) != 1 {
 		t.Fatalf("no policy: want 1 interesting span, got %d", len(result))
 	}
 
-	// Policy ratio=1: keep all boring spans.
+	// Policy ratio=1: keep all boring traces (all spans).
 	rw.boringPolicy = &mockBoringPolicy{ratio: 1}
 	result = rw.classifyForStorage(spans)
 	if len(result) != 3 {
 		t.Fatalf("ratio=1: want all 3 spans, got %d", len(result))
+	}
+}
+
+func TestClassifyForStorageSamplesWholeTrace(t *testing.T) {
+	// A boring trace with 3 spans — when sampled, all 3 must be included.
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "boring-trace", SpanID: "root", Status: "ok", DurationUs: 100},
+		{ProjectID: 1, TraceID: "boring-trace", SpanID: "child1", Status: "ok", DurationUs: 50},
+		{ProjectID: 1, TraceID: "boring-trace", SpanID: "child2", Status: "ok", DurationUs: 30},
+	}
+
+	rw := &RedisWorker{
+		cfg:          WorkerConfig{SlowThresholdUs: 1_000_000},
+		boringPolicy: &mockBoringPolicy{ratio: 1}, // keep all boring traces
+	}
+
+	result := rw.classifyForStorage(spans)
+	if len(result) != 3 {
+		t.Fatalf("all spans of a sampled boring trace must be kept, got %d", len(result))
+	}
+	ids := make(map[string]bool)
+	for _, s := range result {
+		ids[s.SpanID] = true
+	}
+	for _, want := range []string{"root", "child1", "child2"} {
+		if !ids[want] {
+			t.Errorf("span %q missing from sampled boring trace", want)
+		}
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -367,3 +367,68 @@ func TestRedisWorkerBoringBypass(t *testing.T) {
 		}
 	}
 }
+
+// mockBoringPolicy implements BoringPolicyReader for testing.
+type mockBoringPolicy struct {
+	ratio        int
+	verboseUntil time.Time
+}
+
+func (m *mockBoringPolicy) SampleRatio(_ int64) int        { return m.ratio }
+func (m *mockBoringPolicy) VerboseUntil(_ int64) time.Time { return m.verboseUntil }
+
+func TestClassifyForStorageBoringPolicy(t *testing.T) {
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 100},    // boring
+		{ProjectID: 1, TraceID: "t2", SpanID: "s2", Status: "ok", DurationUs: 100},    // boring
+		{ProjectID: 1, TraceID: "t3", SpanID: "s3", Status: "error", DurationUs: 100}, // interesting
+	}
+
+	rw := &RedisWorker{cfg: WorkerConfig{SlowThresholdUs: 1_000_000}}
+
+	// No policy: boring spans are dropped.
+	result := rw.classifyForStorage(spans)
+	if len(result) != 1 {
+		t.Fatalf("no policy: want 1 interesting span, got %d", len(result))
+	}
+
+	// Policy ratio=1: keep all boring spans.
+	rw.boringPolicy = &mockBoringPolicy{ratio: 1}
+	result = rw.classifyForStorage(spans)
+	if len(result) != 3 {
+		t.Fatalf("ratio=1: want all 3 spans, got %d", len(result))
+	}
+}
+
+func TestClassifyForStorageVerboseMode(t *testing.T) {
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 100},
+		{ProjectID: 1, TraceID: "t2", SpanID: "s2", Status: "ok", DurationUs: 100},
+	}
+
+	rw := &RedisWorker{
+		cfg:          WorkerConfig{SlowThresholdUs: 1_000_000},
+		boringPolicy: &mockBoringPolicy{verboseUntil: time.Now().Add(time.Hour)},
+	}
+
+	result := rw.classifyForStorage(spans)
+	if len(result) != 2 {
+		t.Fatalf("verbose mode: want all 2 spans, got %d", len(result))
+	}
+}
+
+func TestClassifyForStorageVerboseExpired(t *testing.T) {
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "t1", SpanID: "s1", Status: "ok", DurationUs: 100},
+	}
+
+	rw := &RedisWorker{
+		cfg:          WorkerConfig{SlowThresholdUs: 1_000_000},
+		boringPolicy: &mockBoringPolicy{verboseUntil: time.Now().Add(-time.Hour)}, // expired
+	}
+
+	result := rw.classifyForStorage(spans)
+	if len(result) != 0 {
+		t.Fatalf("expired verbose: want 0 spans, got %d", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

Addresses the tension between keeping boring spans visible and keeping up with ingest volume. Three configurable knobs:

- **Boring span sampling** — 1-in-N sampling before writing boring spans (non-error, below slow threshold) to SQLite. Default 0 = skip all (existing behaviour). Configurable globally or per-project via settings keys `boring.sample_ratio` / `boring.sample_ratio.project.{id}`.

- **Short boring retention** — fast indexed range DELETE removes boring spans after a configurable window (default 30 min, `boring_retention_minutes` setting or `SPANBARN_BORING_RETENTION_MINUTES` env). No correlated subquery — runs in milliseconds using the new `idx_spans_boring_cleanup` index.

- **Verbose project mode** — `POST /api/v1/projects/{id}/verbose {"durationMinutes": 60}` bypasses boring classification for a project for up to 24 h, writing all spans to SQLite. `DELETE` clears it. Stored as `boring.verbose_until.project.{id}` Unix timestamp in settings.

## Test plan

- [ ] `go test ./internal/worker/... ./internal/retention/...` passes (includes new tests for boring policy, verbose mode, and boring cleanup)
- [ ] `go test ./... -race` passes with no data races
- [ ] After deploy: set `boring.sample_ratio=100` in settings, confirm ~1% of boring spans appear in traces
- [ ] Enable verbose mode for a project, confirm all spans appear; disable, confirm sampling resumes
- [ ] Boring spans ingested >30 min ago are cleaned up in the next retention cycle (check `boring_deleted` log field)