### PR TITLE
feat(cache): warm services and prompts cache on login

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -246,7 +246,9 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 
 	mux := http.NewServeMux()
 	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr)))
+	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+		api.WarmLoginCaches(context.Background(), queryRepo, querySvc, logger)
+	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	mux.Handle("/", apiServer.Handler())
 
@@ -433,7 +435,9 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 			api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute),
 			"login",
 		)
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr)))
+		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+			api.WarmLoginCaches(context.Background(), roRepo, querySvc, logger)
+		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	}
 	mux.Handle("/", apiServer.Handler())
@@ -612,7 +616,9 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		apiServer.SetOIDCClient(oidcClient)
 	}
 	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr)))
+	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+		api.WarmLoginCaches(context.Background(), queryRepo, querySvc, logger)
+	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	mux.Handle("/", apiServer.Handler())
 	logger.Info("writer API ready")
@@ -972,7 +978,9 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 			api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute),
 			"login",
 		)
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr)))
+		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+			api.WarmLoginCaches(context.Background(), roRepo, querySvc, logger)
+		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	}
 	mux.Handle("/", apiServer.Handler())

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -247,7 +247,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	mux := http.NewServeMux()
 	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
 	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
-		api.WarmLoginCaches(context.Background(), queryRepo, querySvc, logger)
+		api.WarmLoginCaches(context.Background(), querySvc, logger)
 	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	mux.Handle("/", apiServer.Handler())
@@ -436,7 +436,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 			"login",
 		)
 		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
-			api.WarmLoginCaches(context.Background(), roRepo, querySvc, logger)
+			api.WarmLoginCaches(context.Background(), querySvc, logger)
 		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	}
@@ -617,7 +617,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	}
 	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
 	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
-		api.WarmLoginCaches(context.Background(), queryRepo, querySvc, logger)
+		api.WarmLoginCaches(context.Background(), querySvc, logger)
 	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	mux.Handle("/", apiServer.Handler())
@@ -979,7 +979,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 			"login",
 		)
 		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
-			api.WarmLoginCaches(context.Background(), roRepo, querySvc, logger)
+			api.WarmLoginCaches(context.Background(), querySvc, logger)
 		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
 	}

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -18,7 +18,10 @@ type loginResponse struct {
 }
 
 // HandleLogin returns an http.HandlerFunc for POST /api/v1/login.
-func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager) http.HandlerFunc {
+// onLoginSuccess is called (in the request goroutine) after a session is
+// created; pass nil to skip. The function should return quickly or launch its
+// own goroutine — the HTTP response is written immediately after the call.
+func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager, onLoginSuccess func()) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, span := apiTracer.Start(r.Context(), "api.login")
 		defer span.End()
@@ -43,6 +46,10 @@ func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager) http
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to create session", "")
 			return
+		}
+
+		if onLoginSuccess != nil {
+			onLoginSuccess()
 		}
 
 		http.SetCookie(w, &http.Cookie{

--- a/internal/api/login_test.go
+++ b/internal/api/login_test.go
@@ -43,7 +43,7 @@ func setupLoginTest(t *testing.T) (*auth.UserAuthenticator, *auth.SessionManager
 
 func TestLoginSuccess(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm)
+	handler := HandleLogin(userAuth, sm, nil)
 
 	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "correct-pass"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
@@ -84,7 +84,7 @@ func TestLoginSuccess(t *testing.T) {
 
 func TestLoginWrongPassword(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm)
+	handler := HandleLogin(userAuth, sm, nil)
 
 	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "wrong-pass"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
@@ -100,7 +100,7 @@ func TestLoginWrongPassword(t *testing.T) {
 
 func TestLoginMethodNotAllowed(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm)
+	handler := HandleLogin(userAuth, sm, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/login", nil)
 	rec := httptest.NewRecorder()

--- a/internal/api/warm.go
+++ b/internal/api/warm.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wiebe-xyz/spanbarn/internal/cache"
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
+	"github.com/wiebe-xyz/spanbarn/internal/service"
 )
 
 // WarmCaches populates the Redis SWR entries for the expensive read endpoints
@@ -37,6 +38,31 @@ func WarmCaches(ctx context.Context, repo *repository.Repository, c *cache.Cache
 		func(ctx context.Context) (any, error) {
 			return repo.GetDBCounts()
 		})
+}
+
+// WarmLoginCaches pre-populates the per-project Services cache for the 1h and
+// 24h ranges so the first dashboard page load after login hits Redis rather than
+// SQLite. Runs entirely in the background; login latency is unaffected.
+func WarmLoginCaches(ctx context.Context, repo *repository.Repository, qs *service.QueryService, logger *slog.Logger) {
+	if repo == nil || qs == nil {
+		return
+	}
+	go func() {
+		projects, err := repo.ListProjects()
+		if err != nil {
+			logger.Warn("warm login: list projects failed", "err", err)
+			return
+		}
+		now := time.Now()
+		for _, p := range projects {
+			for _, d := range []time.Duration{time.Hour, 24 * time.Hour} {
+				if _, err := qs.ListServices(ctx, p.ID, now.Add(-d), now, false); err != nil {
+					logger.Warn("warm login: list services failed", "project", p.ID, "err", err)
+				}
+			}
+		}
+		logger.Info("warm login: complete", "projects", len(projects))
+	}()
 }
 
 func warmEntry(

--- a/internal/api/warm.go
+++ b/internal/api/warm.go
@@ -44,51 +44,59 @@ func WarmCaches(ctx context.Context, repo *repository.Repository, c *cache.Cache
 		})
 }
 
-// WarmLoginCaches pre-populates the per-project Services cache for all
+// WarmLoginCaches pre-populates the Services and Prompts caches for all
 // dashboard time ranges so the first page load after login hits Redis rather
 // than SQLite. Runs entirely in the background; login latency is unaffected.
-func WarmLoginCaches(ctx context.Context, repo *repository.Repository, qs *service.QueryService, logger *slog.Logger) {
-	if repo == nil || qs == nil {
+//
+// The services endpoint is queried with project_id=0 (all-projects view) and
+// both serverOnly variants to match the two states of the entry-points toggle.
+func WarmLoginCaches(ctx context.Context, qs *service.QueryService, logger *slog.Logger) {
+	if qs == nil {
 		return
 	}
 	go func() {
-		bctx, rootSpan := apiTracer.Start(context.Background(), "api.warm.login")
+		_, rootSpan := apiTracer.Start(context.Background(), "api.warm.login")
 		defer rootSpan.End()
-
-		projects, err := repo.ListProjects()
-		if err != nil {
-			rootSpan.RecordError(err)
-			rootSpan.SetStatus(codes.Error, "list projects failed")
-			logger.Warn("warm login: list projects failed", "err", err)
-			return
-		}
-		rootSpan.SetAttributes(attribute.Int("projects", len(projects)))
 
 		ranges := []time.Duration{time.Hour, 4 * time.Hour, 24 * time.Hour, 7 * 24 * time.Hour, 30 * 24 * time.Hour}
 		now := time.Now()
 		errors := 0
-		for _, p := range projects {
-			_, pSpan := apiTracer.Start(bctx, "api.warm.login.project")
-			pSpan.SetAttributes(attribute.Int64("project.id", p.ID))
+
+		// Services: both serverOnly variants (default=true, toggled=false).
+		for _, serverOnly := range []bool{true, false} {
+			_, sSpan := apiTracer.Start(context.Background(), "api.warm.login.services")
+			sSpan.SetAttributes(attribute.Bool("server_only", serverOnly))
 			for _, d := range ranges {
-				_, err := qs.ListServices(bctx, p.ID, now.Add(-d), now, false)
+				_, err := qs.ListServices(context.Background(), 0, now.Add(-d), now, serverOnly)
 				if err != nil {
-					pSpan.RecordError(fmt.Errorf("range %s: %w", d, err))
-					logger.Warn("warm login: list services failed", "project", p.ID, "range", d, "err", err)
+					sSpan.RecordError(fmt.Errorf("range %s: %w", d, err))
+					logger.Warn("warm login: list services failed", "server_only", serverOnly, "range", d, "err", err)
 					errors++
 				}
 			}
-			pSpan.End()
+			sSpan.End()
 		}
+
+		// Prompts: no service/model filter (the default landing state).
+		_, pSpan := apiTracer.Start(context.Background(), "api.warm.login.prompts")
+		for _, d := range ranges {
+			_, err := qs.ListPrompts(context.Background(), 0, now.Add(-d), now, "", "")
+			if err != nil {
+				pSpan.RecordError(fmt.Errorf("range %s: %w", d, err))
+				logger.Warn("warm login: list prompts failed", "range", d, "err", err)
+				errors++
+			}
+		}
+		pSpan.End()
 
 		rootSpan.SetAttributes(
 			attribute.Int("ranges", len(ranges)),
 			attribute.Int("errors", errors),
 		)
 		if errors > 0 {
-			rootSpan.SetStatus(codes.Error, "some ranges failed")
+			rootSpan.SetStatus(codes.Error, "some queries failed")
 		}
-		logger.Info("warm login: complete", "projects", len(projects), "errors", errors)
+		logger.Info("warm login: complete", "ranges", len(ranges), "errors", errors)
 	}()
 }
 

--- a/internal/api/warm.go
+++ b/internal/api/warm.go
@@ -2,8 +2,12 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/wiebe-xyz/spanbarn/internal/cache"
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
@@ -40,28 +44,51 @@ func WarmCaches(ctx context.Context, repo *repository.Repository, c *cache.Cache
 		})
 }
 
-// WarmLoginCaches pre-populates the per-project Services cache for the 1h and
-// 24h ranges so the first dashboard page load after login hits Redis rather than
-// SQLite. Runs entirely in the background; login latency is unaffected.
+// WarmLoginCaches pre-populates the per-project Services cache for all
+// dashboard time ranges so the first page load after login hits Redis rather
+// than SQLite. Runs entirely in the background; login latency is unaffected.
 func WarmLoginCaches(ctx context.Context, repo *repository.Repository, qs *service.QueryService, logger *slog.Logger) {
 	if repo == nil || qs == nil {
 		return
 	}
 	go func() {
+		bctx, rootSpan := apiTracer.Start(context.Background(), "api.warm.login")
+		defer rootSpan.End()
+
 		projects, err := repo.ListProjects()
 		if err != nil {
+			rootSpan.RecordError(err)
+			rootSpan.SetStatus(codes.Error, "list projects failed")
 			logger.Warn("warm login: list projects failed", "err", err)
 			return
 		}
+		rootSpan.SetAttributes(attribute.Int("projects", len(projects)))
+
+		ranges := []time.Duration{time.Hour, 4 * time.Hour, 24 * time.Hour, 7 * 24 * time.Hour, 30 * 24 * time.Hour}
 		now := time.Now()
+		errors := 0
 		for _, p := range projects {
-			for _, d := range []time.Duration{time.Hour, 4 * time.Hour, 24 * time.Hour, 7 * 24 * time.Hour, 30 * 24 * time.Hour} {
-				if _, err := qs.ListServices(ctx, p.ID, now.Add(-d), now, false); err != nil {
-					logger.Warn("warm login: list services failed", "project", p.ID, "err", err)
+			_, pSpan := apiTracer.Start(bctx, "api.warm.login.project")
+			pSpan.SetAttributes(attribute.Int64("project.id", p.ID))
+			for _, d := range ranges {
+				_, err := qs.ListServices(bctx, p.ID, now.Add(-d), now, false)
+				if err != nil {
+					pSpan.RecordError(fmt.Errorf("range %s: %w", d, err))
+					logger.Warn("warm login: list services failed", "project", p.ID, "range", d, "err", err)
+					errors++
 				}
 			}
+			pSpan.End()
 		}
-		logger.Info("warm login: complete", "projects", len(projects))
+
+		rootSpan.SetAttributes(
+			attribute.Int("ranges", len(ranges)),
+			attribute.Int("errors", errors),
+		)
+		if errors > 0 {
+			rootSpan.SetStatus(codes.Error, "some ranges failed")
+		}
+		logger.Info("warm login: complete", "projects", len(projects), "errors", errors)
 	}()
 }
 

--- a/internal/api/warm.go
+++ b/internal/api/warm.go
@@ -55,7 +55,7 @@ func WarmLoginCaches(ctx context.Context, repo *repository.Repository, qs *servi
 		}
 		now := time.Now()
 		for _, p := range projects {
-			for _, d := range []time.Duration{time.Hour, 24 * time.Hour} {
+			for _, d := range []time.Duration{time.Hour, 4 * time.Hour, 24 * time.Hour, 7 * 24 * time.Hour, 30 * 24 * time.Hour} {
 				if _, err := qs.ListServices(ctx, p.ID, now.Add(-d), now, false); err != nil {
 					logger.Warn("warm login: list services failed", "project", p.ID, "err", err)
 				}


### PR DESCRIPTION
## Summary

- Pre-populates the Services and Prompts Redis cache on every login so the first dashboard page load hits Redis instead of SQLite
- Warms all 5 time ranges (1h / 4h / 24h / 7d / 30d) × both `serverOnly` variants + prompts — matching the actual keys the frontend requests (`project_id=0`)
- Runs entirely in the background; zero login latency impact
- Adds an `api.warm.login` trace (with child spans per cache set) so slow warm-ups are visible in SpanBarn before they become a problem

## Test plan

- [ ] CI passes (lint, tests, staging deploy, E2E)
- [ ] After merging, log in and check `redis-cli KEYS "services:*"` — should show fresh entries immediately
- [ ] Services page first load after login should be ~5ms (cache hit)
- [ ] `api.warm.login` trace visible in SpanBarn traces view