### PR TITLE
feat(logs): OTLP log ingest, explorer, trace correlation, and pinned traces

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -134,6 +134,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	ingestHandler := ingest.NewHandler(ingestQueue, eventSpool, 5*time.Millisecond, logger)
 
 	metricsHandler := ingest.NewMetricsHandler(repo, logger)
+	logsHandler := ingest.NewLogsHandler(repo, logger)
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -145,6 +146,10 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
 	defer metricsCancel()
 	safeGo("metrics-ingest", &wg, func() { metricsHandler.Run(metricsCtx) })
+
+	logsCtx, logsCancel := context.WithCancel(ctx)
+	defer logsCancel()
+	safeGo("logs-ingest", &wg, func() { logsHandler.Run(logsCtx) })
 
 	aggInterval := parseAggregationInterval(cfg.AggregationInterval)
 	aggregator := aggregation.NewAggregator(repo, aggInterval, logger)
@@ -173,6 +178,8 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		ErrorRetentionDays:        cfg.RetentionErrorDays,
 		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
 		MetricsRetentionDays:      cfg.MetricsRetentionDays,
+		LogRetentionHours:         cfg.LogRetentionHours,
+		ErrorLogRetentionDays:     cfg.ErrorLogRetentionDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
 	}
 	retentionWorker := retention.NewRetentionWorker(repo, aggregator, retentionCfg, logger)
@@ -245,6 +252,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		api.WithPaths(cfg.DBPath, cfg.SpoolDir),
 		api.WithCache(querySvc.Cache()),
 		api.WithMetricsHandler(metricsHandler),
+		api.WithLogsHandler(logsHandler),
 	)
 	if oidcClient := buildOIDCClient(cfg, logger); oidcClient != nil {
 		apiServer.SetOIDCClient(oidcClient)
@@ -346,10 +354,14 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 	metricsPublisher := queue.NewMetricsPublisher(writeQueue)
 	readerMetricsHandler := ingest.NewMetricsHandler(metricsPublisher, logger)
 
+	logsPublisher := queue.NewLogsPublisher(writeQueue)
+	readerLogsHandler := ingest.NewLogsHandler(logsPublisher, logger)
+
 	var wg sync.WaitGroup
 	fwd := forward.NewRedisForwarder(eventSpool, writeQueue, logger)
 	safeGo("redis-forwarder", &wg, func() { fwd.Run(readerCtx) })
 	safeGo("metrics-ingest", &wg, func() { readerMetricsHandler.Run(readerCtx) })
+	safeGo("logs-ingest", &wg, func() { readerLogsHandler.Run(readerCtx) })
 
 	var (
 		roRepo     *repository.Repository
@@ -436,7 +448,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 		}
 	})
 
-	opts := []api.ServerOption{api.WithAuthorizer(authorizer), api.WithTraceBuffer(traceBuffer), api.WithMetricsHandler(readerMetricsHandler)}
+	opts := []api.ServerOption{api.WithAuthorizer(authorizer), api.WithTraceBuffer(traceBuffer), api.WithMetricsHandler(readerMetricsHandler), api.WithLogsHandler(readerLogsHandler)}
 	if roRepo != nil {
 		opts = append(opts, api.WithRepository(roRepo), api.WithPaths(cfg.DBPath, cfg.SpoolDir), api.WithCache(queryCache))
 	}
@@ -704,6 +716,26 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 			}
 		}
 	})
+	safeGo("logs-consumer", &wg, func() {
+		for {
+			select {
+			case <-workerCtx.Done():
+				return
+			default:
+			}
+			recs, err := writeQueue.ConsumeLogs(workerCtx)
+			if err != nil {
+				logger.Error("logs consumer error", "error", err)
+				continue
+			}
+			if len(recs) == 0 {
+				continue
+			}
+			if err := repo.InsertLogs(workerCtx, recs); err != nil {
+				logger.Error("logs insert error", "error", err)
+			}
+		}
+	})
 	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
@@ -724,6 +756,8 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		ErrorRetentionDays:        cfg.RetentionErrorDays,
 		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
 		MetricsRetentionDays:      cfg.MetricsRetentionDays,
+		LogRetentionHours:         cfg.LogRetentionHours,
+		ErrorLogRetentionDays:     cfg.ErrorLogRetentionDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
 	}
 	retentionWorker := retention.NewRetentionWorker(retentionRepo, accumulator, retentionCfg, logger)

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	collectormetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	collectortracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 )
@@ -33,6 +34,7 @@ func NewGRPCServer(s *Server, logger *slog.Logger) *GRPCServer {
 	)
 	collectortracepb.RegisterTraceServiceServer(srv, &grpcTraceServer{s: s})
 	collectormetricspb.RegisterMetricsServiceServer(srv, &grpcMetricsServer{s: s})
+	collectorlogspb.RegisterLogsServiceServer(srv, &grpcLogsServer{s: s})
 	return &GRPCServer{server: srv, logger: logger}
 }
 
@@ -101,6 +103,21 @@ func (m *grpcMetricsServer) Export(ctx context.Context, req *collectormetricspb.
 		m.s.metricsIngest.Enqueue(recs)
 	}
 	return &collectormetricspb.ExportMetricsServiceResponse{}, nil
+}
+
+// grpcLogsServer implements the OTLP LogsService, delegating to s.logsIngest.
+type grpcLogsServer struct {
+	collectorlogspb.UnimplementedLogsServiceServer
+	s *Server
+}
+
+func (l *grpcLogsServer) Export(ctx context.Context, req *collectorlogspb.ExportLogsServiceRequest) (*collectorlogspb.ExportLogsServiceResponse, error) {
+	projectID := GetProjectID(ctx)
+	recs := otlpToLogRecords(req, projectID)
+	if l.s.logsIngest != nil {
+		l.s.logsIngest.Enqueue(recs)
+	}
+	return &collectorlogspb.ExportLogsServiceResponse{}, nil
 }
 
 // grpcAuthInterceptor returns a gRPC unary server interceptor that mirrors the

--- a/internal/api/logs_query.go
+++ b/internal/api/logs_query.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type logsQueryHandlers struct {
+	repo *repository.Repository
+}
+
+type logEntryJSON struct {
+	ID             int64           `json:"id"`
+	TraceID        string          `json:"traceId"`
+	SpanID         string          `json:"spanId"`
+	SeverityNumber int32           `json:"severityNumber"`
+	SeverityText   string          `json:"severityText"`
+	TimeUnixNano   int64           `json:"timeUnixNano"`
+	Body           string          `json:"body"`
+	Attributes     json.RawMessage `json:"attributes"`
+	IngestedAt     time.Time       `json:"ingestedAt"`
+}
+
+type logsResponse struct {
+	Logs  []logEntryJSON `json:"logs"`
+	Total int            `json:"total"`
+}
+
+type pinnedTraceJSON struct {
+	TraceID  string    `json:"traceId"`
+	Label    string    `json:"label"`
+	PinnedAt time.Time `json:"pinnedAt"`
+}
+
+type pinnedTracesResponse struct {
+	Pinned []pinnedTraceJSON `json:"pinned"`
+}
+
+// handleLogs handles GET /api/v1/logs
+func (h *logsQueryHandlers) handleLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	projectID := parseInt64Param(r, "project_id", 0)
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+	if from.IsZero() {
+		from = time.Now().Add(-24 * time.Hour)
+	}
+	if to.IsZero() {
+		to = time.Now()
+	}
+
+	f := repository.LogFilter{
+		ProjectID:   projectID,
+		TraceID:     r.URL.Query().Get("trace_id"),
+		SpanID:      r.URL.Query().Get("span_id"),
+		MinSeverity: int32(parseIntParam(r, "severity", 0)),
+		Service:     r.URL.Query().Get("service"),
+		Search:      r.URL.Query().Get("search"),
+		From:        from,
+		To:          to,
+		Limit:       parseIntParam(r, "limit", 200),
+		Offset:      parseIntParam(r, "offset", 0),
+	}
+
+	rows, total, err := h.repo.QueryLogs(r.Context(), f)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed", err.Error())
+		return
+	}
+
+	entries := make([]logEntryJSON, 0, len(rows))
+	for _, row := range rows {
+		attrs := json.RawMessage(row.Attributes)
+		if len(attrs) == 0 {
+			attrs = json.RawMessage("{}")
+		}
+		entries = append(entries, logEntryJSON{
+			ID:             row.ID,
+			TraceID:        row.TraceID,
+			SpanID:         row.SpanID,
+			SeverityNumber: row.SeverityNumber,
+			SeverityText:   row.SeverityText,
+			TimeUnixNano:   row.TimeUnixNano,
+			Body:           row.Body,
+			Attributes:     attrs,
+			IngestedAt:     row.IngestedAt,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, logsResponse{Logs: entries, Total: total})
+}
+
+// handlePinnedTraces handles GET/POST/DELETE on /api/v1/pinned-traces
+func (h *logsQueryHandlers) handlePinnedTraces(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.listPinnedTraces(w, r)
+	case http.MethodPost:
+		h.pinTrace(w, r)
+	case http.MethodDelete:
+		h.unpinTrace(w, r)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+	}
+}
+
+func (h *logsQueryHandlers) listPinnedTraces(w http.ResponseWriter, r *http.Request) {
+	projectID := parseInt64Param(r, "project_id", 0)
+	pins, err := h.repo.ListPinnedTraces(r.Context(), projectID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed", err.Error())
+		return
+	}
+	out := make([]pinnedTraceJSON, 0, len(pins))
+	for _, p := range pins {
+		out = append(out, pinnedTraceJSON{TraceID: p.TraceID, Label: p.Label, PinnedAt: p.PinnedAt})
+	}
+	writeJSON(w, http.StatusOK, pinnedTracesResponse{Pinned: out})
+}
+
+func (h *logsQueryHandlers) pinTrace(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ProjectID int64  `json:"project_id"`
+		TraceID   string `json:"trace_id"`
+		Label     string `json:"label"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
+		return
+	}
+	if body.TraceID == "" {
+		writeError(w, http.StatusBadRequest, "trace_id required", "")
+		return
+	}
+	if err := h.repo.PinTrace(r.Context(), body.ProjectID, body.TraceID, body.Label); err != nil {
+		writeError(w, http.StatusInternalServerError, "pin failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *logsQueryHandlers) unpinTrace(w http.ResponseWriter, r *http.Request) {
+	// DELETE /api/v1/pinned-traces/{traceId}  or  ?trace_id=…&project_id=…
+	projectID := parseInt64Param(r, "project_id", 0)
+
+	// Extract traceId from URL path suffix.
+	traceID := r.URL.Query().Get("trace_id")
+	if traceID == "" {
+		// Try path: /api/v1/pinned-traces/<traceId>
+		path := strings.TrimPrefix(r.URL.Path, "/api/v1/pinned-traces/")
+		if path != "" && path != r.URL.Path {
+			traceID = path
+		}
+	}
+	if traceID == "" {
+		writeError(w, http.StatusBadRequest, "trace_id required", "")
+		return
+	}
+	if err := h.repo.UnpinTrace(r.Context(), projectID, traceID); err != nil {
+		writeError(w, http.StatusInternalServerError, "unpin failed", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/logs_query_test.go
+++ b/internal/api/logs_query_test.go
@@ -1,0 +1,259 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+
+	_ "github.com/wiebe-xyz/spanbarn/internal/repository/migrations"
+)
+
+func setupLogsQueryServer(t *testing.T) (*Server, *auth.SessionManager, *repository.Repository) {
+	t.Helper()
+
+	db, err := repository.NewDB(":memory:")
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	if err := repository.Migrate(db.DB); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	repo := repository.NewRepository(db.DB)
+	sm := auth.NewSessionManager("test-secret", 3600)
+
+	srv := NewServerWithQuery(ServerConfig{
+		APIKey:  "test-key",
+		Version: "test",
+	}, nil, nil, sm, nil, WithRepository(repo))
+
+	return srv, sm, repo
+}
+
+func insertTestLogs(t *testing.T, repo *repository.Repository, recs []model.LogRecord) {
+	t.Helper()
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+}
+
+func TestLogsQueryReturnsLogs(t *testing.T) {
+	srv, sm, repo := setupLogsQueryServer(t)
+	now := time.Now().UTC()
+
+	insertTestLogs(t, repo, []model.LogRecord{
+		{ProjectID: 1, Body: "hello", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{"service.name":"svc"}`)},
+		{ProjectID: 1, Body: "world", SeverityNumber: 13, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{"service.name":"svc"}`)},
+		{ProjectID: 2, Body: "other", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{"service.name":"svc2"}`)},
+	})
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?project_id=1&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp logsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Errorf("want total=2, got %d", resp.Total)
+	}
+	if len(resp.Logs) != 2 {
+		t.Errorf("want 2 logs, got %d", len(resp.Logs))
+	}
+}
+
+func TestLogsQueryTraceIDFilter(t *testing.T) {
+	srv, sm, repo := setupLogsQueryServer(t)
+	now := time.Now().UTC()
+
+	insertTestLogs(t, repo, []model.LogRecord{
+		{ProjectID: 1, TraceID: "trace-abc", Body: "msg1", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+		{ProjectID: 1, TraceID: "trace-def", Body: "msg2", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+	})
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?project_id=1&trace_id=trace-abc&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp logsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("want total=1, got %d", resp.Total)
+	}
+	if len(resp.Logs) == 0 || resp.Logs[0].Body != "msg1" {
+		t.Errorf("unexpected logs: %+v", resp.Logs)
+	}
+}
+
+func TestLogsQuerySeverityFilter(t *testing.T) {
+	srv, sm, repo := setupLogsQueryServer(t)
+	now := time.Now().UTC()
+
+	insertTestLogs(t, repo, []model.LogRecord{
+		{ProjectID: 1, Body: "info", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+		{ProjectID: 1, Body: "warn", SeverityNumber: 13, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+		{ProjectID: 1, Body: "error", SeverityNumber: 17, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+	})
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?project_id=1&severity=13&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp logsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 {
+		t.Errorf("want total=2 (warn+error), got %d", resp.Total)
+	}
+}
+
+func TestLogsQueryBodySearch(t *testing.T) {
+	srv, sm, repo := setupLogsQueryServer(t)
+	now := time.Now().UTC()
+
+	insertTestLogs(t, repo, []model.LogRecord{
+		{ProjectID: 1, Body: "connection timeout", SeverityNumber: 17, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+		{ProjectID: 1, Body: "request OK", SeverityNumber: 9, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+	})
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?project_id=1&search=connection&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp logsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("want total=1, got %d", resp.Total)
+	}
+}
+
+func TestPinUnpinRoundTrip(t *testing.T) {
+	srv, sm, _ := setupLogsQueryServer(t)
+
+	cookie := sessionCookie(t, sm)
+
+	// Pin a trace.
+	body := bytes.NewBufferString(`{"project_id":1,"trace_id":"trace-abc","label":"checkout bug"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/pinned-traces", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("pin: expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// List pinned traces.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/pinned-traces?project_id=1", nil)
+	req2.AddCookie(cookie)
+	rec2 := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", rec2.Code)
+	}
+	var listResp pinnedTracesResponse
+	if err := json.NewDecoder(rec2.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(listResp.Pinned) != 1 || listResp.Pinned[0].TraceID != "trace-abc" {
+		t.Errorf("unexpected list: %+v", listResp)
+	}
+
+	// Unpin by path.
+	req3 := httptest.NewRequest(http.MethodDelete, "/api/v1/pinned-traces/trace-abc?project_id=1", nil)
+	req3.AddCookie(cookie)
+	rec3 := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec3, req3)
+
+	if rec3.Code != http.StatusNoContent {
+		t.Fatalf("unpin: expected 204, got %d", rec3.Code)
+	}
+
+	// Confirm empty list.
+	req4 := httptest.NewRequest(http.MethodGet, "/api/v1/pinned-traces?project_id=1", nil)
+	req4.AddCookie(cookie)
+	rec4 := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec4, req4)
+
+	var listResp2 pinnedTracesResponse
+	if err := json.NewDecoder(rec4.Body).Decode(&listResp2); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(listResp2.Pinned) != 0 {
+		t.Errorf("expected empty list after unpin, got %d", len(listResp2.Pinned))
+	}
+}
+
+func TestLogsQueryAuthRequired(t *testing.T) {
+	srv, _, _ := setupLogsQueryServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/logs?project_id=1", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}
+
+func TestPinnedTracesAuthRequired(t *testing.T) {
+	srv, _, _ := setupLogsQueryServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pinned-traces?project_id=1", nil)
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", rec.Code)
+	}
+}

--- a/internal/api/otlp_logs.go
+++ b/internal/api/otlp_logs.go
@@ -1,0 +1,154 @@
+package api
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+func (s *Server) handleOTLPLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if strings.Contains(err.Error(), "http: request body too large") {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "failed to read body", err.Error())
+		return
+	}
+
+	var req collectorlogspb.ExportLogsServiceRequest
+	ct := r.Header.Get("Content-Type")
+	switch {
+	case strings.Contains(ct, "application/json"):
+		if err := protojson.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
+			return
+		}
+	default:
+		if err := proto.Unmarshal(body, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid protobuf", err.Error())
+			return
+		}
+	}
+
+	projectID := GetProjectID(r.Context())
+	recs := otlpToLogRecords(&req, projectID)
+	s.logsIngest.Enqueue(recs)
+
+	resp := &collectorlogspb.ExportLogsServiceResponse{}
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		data, _ := protojson.Marshal(resp)
+		_, _ = w.Write(data)
+	} else {
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+		data, _ := proto.Marshal(resp)
+		_, _ = w.Write(data)
+	}
+}
+
+// otlpToLogRecords converts an ExportLogsServiceRequest into LogRecords.
+// Attributes are merged resource < scope < log-record (log-record wins).
+func otlpToLogRecords(req *collectorlogspb.ExportLogsServiceRequest, projectID int64) []model.LogRecord {
+	var records []model.LogRecord
+	for _, rl := range req.GetResourceLogs() {
+		resourceAttrs := kvListToMap(rl.GetResource().GetAttributes())
+
+		for _, sl := range rl.GetScopeLogs() {
+			scopeAttrs := kvListToMap(sl.GetScope().GetAttributes())
+
+			for _, lr := range sl.GetLogRecords() {
+				logAttrs := kvListToMap(lr.GetAttributes())
+
+				merged := make(map[string]any, len(resourceAttrs)+len(scopeAttrs)+len(logAttrs))
+				for k, v := range resourceAttrs {
+					merged[k] = v
+				}
+				for k, v := range scopeAttrs {
+					merged[k] = v
+				}
+				for k, v := range logAttrs {
+					merged[k] = v
+				}
+
+				var attrsJSON json.RawMessage
+				if len(merged) > 0 {
+					attrsJSON, _ = json.Marshal(merged)
+				}
+
+				rec := model.LogRecord{
+					ProjectID:            projectID,
+					TraceID:              hexIfNonEmpty(lr.GetTraceId()),
+					SpanID:               hexIfNonEmpty(lr.GetSpanId()),
+					SeverityNumber:       int32(lr.GetSeverityNumber()),
+					SeverityText:         lr.GetSeverityText(),
+					TimeUnixNano:         lr.GetTimeUnixNano(),
+					ObservedTimeUnixNano: lr.GetObservedTimeUnixNano(),
+					Body:                 logBodyToString(lr.GetBody()),
+					Attributes:           attrsJSON,
+				}
+				records = append(records, rec)
+			}
+		}
+	}
+	return records
+}
+
+// logBodyToString converts an OTLP log body AnyValue to a string.
+// StringValue is used directly; KvlistValue is JSON-encoded; everything else uses anyValueToGo.
+func logBodyToString(body *commonpb.AnyValue) string {
+	if body == nil {
+		return ""
+	}
+	switch v := body.GetValue().(type) {
+	case *commonpb.AnyValue_StringValue:
+		return v.StringValue
+	case *commonpb.AnyValue_KvlistValue:
+		m := kvListToMap(v.KvlistValue.GetValues())
+		data, _ := json.Marshal(m)
+		return string(data)
+	default:
+		val := anyValueToGo(body)
+		if val == nil {
+			return ""
+		}
+		data, _ := json.Marshal(val)
+		return string(data)
+	}
+}
+
+// traceIDFromBytes decodes a 16-byte OTLP trace ID to hex; returns "" for all-zeros or empty.
+func traceIDFromBytes(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	allZero := true
+	for _, byt := range b {
+		if byt != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/api/otlp_logs_test.go
+++ b/internal/api/otlp_logs_test.go
@@ -1,0 +1,245 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/api"
+	"github.com/wiebe-xyz/spanbarn/internal/ingest"
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+
+	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+type captureLogsRepo struct {
+	mu      sync.Mutex
+	records []model.LogRecord
+}
+
+func (r *captureLogsRepo) InsertLogs(_ context.Context, recs []model.LogRecord) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, recs...)
+	return nil
+}
+
+func (r *captureLogsRepo) all() []model.LogRecord {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]model.LogRecord{}, r.records...)
+}
+
+func setupLogsTestServer(t *testing.T) (*httptest.Server, *captureLogsRepo) {
+	t.Helper()
+	repo := &captureLogsRepo{}
+	lh := ingest.NewLogsHandler(repo, slog.Default())
+
+	srv := api.NewServerWithQuery(api.ServerConfig{
+		APIKey:       testAPIKey,
+		MaxBodyBytes: 4 << 20,
+		Version:      "test",
+	}, nil, nil, nil, slog.Default(), api.WithLogsHandler(lh))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go lh.Run(ctx)
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, repo
+}
+
+func buildLogRequest(traceID []byte, body, service string, severity int32) *collectorlogspb.ExportLogsServiceRequest {
+	return &collectorlogspb.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{
+			{
+				Resource: &resourcepb.Resource{
+					Attributes: []*commonpb.KeyValue{
+						{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: service}}},
+					},
+				},
+				ScopeLogs: []*logspb.ScopeLogs{
+					{
+						LogRecords: []*logspb.LogRecord{
+							{
+								TimeUnixNano:   1700000000000000000,
+								SeverityNumber: logspb.SeverityNumber(severity),
+								SeverityText:   "ERROR",
+								Body:           &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: body}},
+								TraceId:        traceID,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func postLogs(t *testing.T, ts *httptest.Server, req *collectorlogspb.ExportLogsServiceRequest, contentType string) *http.Response {
+	t.Helper()
+	var body []byte
+	if contentType == "application/json" {
+		var err error
+		body, err = protojson.Marshal(req)
+		if err != nil {
+			t.Fatalf("protojson.Marshal: %v", err)
+		}
+	} else {
+		var err error
+		body, err = proto.Marshal(req)
+		if err != nil {
+			t.Fatalf("proto.Marshal: %v", err)
+		}
+		contentType = "application/x-protobuf"
+	}
+	httpReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/logs", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", contentType)
+	httpReq.Header.Set("X-SpanBarn-Api-Key", testAPIKey)
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("POST /v1/logs: %v", err)
+	}
+	return resp
+}
+
+func waitForLogRecords(t *testing.T, repo *captureLogsRepo, want int) []model.LogRecord {
+	t.Helper()
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if recs := repo.all(); len(recs) >= want {
+			return recs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return repo.all()
+}
+
+func TestOTLPLogsProtobuf(t *testing.T) {
+	ts, repo := setupLogsTestServer(t)
+	traceID, _ := hex.DecodeString("aabbccddeeff00112233445566778899")
+	resp := postLogs(t, ts, buildLogRequest(traceID, "something broke", "my-svc", 17), "application/x-protobuf")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	recs := waitForLogRecords(t, repo, 1)
+	if len(recs) == 0 {
+		t.Fatal("want at least 1 record, got 0")
+	}
+	if recs[0].Body != "something broke" {
+		t.Errorf("body: want 'something broke', got %q", recs[0].Body)
+	}
+	if recs[0].TraceID != "aabbccddeeff00112233445566778899" {
+		t.Errorf("traceID: want hex, got %q", recs[0].TraceID)
+	}
+	if recs[0].SeverityNumber != 17 {
+		t.Errorf("severity: want 17, got %d", recs[0].SeverityNumber)
+	}
+}
+
+func TestOTLPLogsJSON(t *testing.T) {
+	ts, repo := setupLogsTestServer(t)
+	resp := postLogs(t, ts, buildLogRequest(nil, "no trace log", "my-svc", 9), "application/json")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	recs := waitForLogRecords(t, repo, 1)
+	if len(recs) == 0 {
+		t.Fatal("want at least 1 record, got 0")
+	}
+	if recs[0].TraceID != "" {
+		t.Errorf("traceID should be empty for nil traceID, got %q", recs[0].TraceID)
+	}
+}
+
+func TestOTLPLogsNoTraceID(t *testing.T) {
+	ts, repo := setupLogsTestServer(t)
+	resp := postLogs(t, ts, buildLogRequest(nil, "orphan log", "svc", 9), "application/x-protobuf")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	recs := waitForLogRecords(t, repo, 1)
+	if len(recs) == 0 {
+		t.Fatal("want at least 1 record")
+	}
+	if recs[0].TraceID != "" {
+		t.Errorf("want empty traceID, got %q", recs[0].TraceID)
+	}
+}
+
+func TestOTLPLogsNoAPIKey(t *testing.T) {
+	ts, _ := setupLogsTestServer(t)
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/logs", bytes.NewReader([]byte{}))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("want 401, got %d", resp.StatusCode)
+	}
+}
+
+func TestOTLPLogsMethodNotAllowed(t *testing.T) {
+	ts, _ := setupLogsTestServer(t)
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/v1/logs", nil)
+	req.Header.Set("X-SpanBarn-Api-Key", testAPIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("want 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestOTLPLogsAttributeMerge(t *testing.T) {
+	ts, repo := setupLogsTestServer(t)
+
+	req := &collectorlogspb.ExportLogsServiceRequest{
+		ResourceLogs: []*logspb.ResourceLogs{{
+			Resource: &resourcepb.Resource{
+				Attributes: []*commonpb.KeyValue{
+					{Key: "service.name", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "checkout"}}},
+					{Key: "env", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "prod"}}},
+				},
+			},
+			ScopeLogs: []*logspb.ScopeLogs{{
+				LogRecords: []*logspb.LogRecord{{
+					TimeUnixNano:   1700000000000000000,
+					SeverityNumber: logspb.SeverityNumber_SEVERITY_NUMBER_INFO,
+					Body:           &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "order placed"}},
+					Attributes: []*commonpb.KeyValue{
+						{Key: "order.id", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "ord-123"}}},
+					},
+				}},
+			}},
+		}},
+	}
+
+	resp := postLogs(t, ts, req, "application/x-protobuf")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	recs := waitForLogRecords(t, repo, 1)
+	if len(recs) == 0 {
+		t.Fatal("want 1 record")
+	}
+	// Attributes JSON should contain merged resource + log-record attrs.
+	attrs := string(recs[0].Attributes)
+	if attrs == "" || attrs == "{}" {
+		t.Error("attributes should not be empty")
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -75,6 +75,10 @@ func (s *Server) registerRoutes() {
 		// OTLP/HTTP metrics endpoint.
 		s.mux.Handle("/v1/metrics", ingestRL(otlpAuth(http.HandlerFunc(s.handleOTLPMetrics))))
 	}
+	if s.logsIngest != nil {
+		// OTLP/HTTP logs endpoint.
+		s.mux.Handle("/v1/logs", ingestRL(otlpAuth(http.HandlerFunc(s.handleOTLPLogs))))
+	}
 
 	// Query endpoints — rate limited + session auth required.
 	// List/aggregate endpoints get a short cache (30s); detail endpoints are not cached.
@@ -112,6 +116,16 @@ func (s *Server) registerRoutes() {
 
 		s.mux.Handle("/api/v1/metrics/names", apiRL(sessionAuth(http.HandlerFunc(mqh.handleMetricNames))))
 		s.mux.Handle("/api/v1/metrics/series", apiRL(sessionAuth(http.HandlerFunc(mqh.handleMetricSeries))))
+	}
+
+	// Logs query + pinned-traces endpoints — rate limited + session auth required.
+	if s.repo != nil && s.sessionMgr != nil {
+		lqh := &logsQueryHandlers{repo: s.repo}
+		sessionAuth := SessionMiddleware(s.sessionMgr)
+
+		s.mux.Handle("/api/v1/logs", apiRL(sessionAuth(http.HandlerFunc(lqh.handleLogs))))
+		s.mux.Handle("/api/v1/pinned-traces", apiRL(sessionAuth(http.HandlerFunc(lqh.handlePinnedTraces))))
+		s.mux.Handle("/api/v1/pinned-traces/", apiRL(sessionAuth(http.HandlerFunc(lqh.handlePinnedTraces))))
 	}
 
 	// Alert endpoints — rate limited + session auth required.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	metrics        *Metrics
 	ingest         *ingest.Handler
 	metricsIngest  *ingest.MetricsHandler
+	logsIngest     *ingest.LogsHandler
 	traceBuffer    *ingest.TraceBuffer
 	querySvc       *service.QueryService
 	sessionMgr     *auth.SessionManager
@@ -118,6 +119,13 @@ func WithTraceBuffer(tb *ingest.TraceBuffer) ServerOption {
 func WithMetricsHandler(h *ingest.MetricsHandler) ServerOption {
 	return func(s *Server) {
 		s.metricsIngest = h
+	}
+}
+
+// WithLogsHandler attaches a LogsHandler for OTLP logs ingest.
+func WithLogsHandler(h *ingest.LogsHandler) ServerOption {
+	return func(s *Server) {
+		s.logsIngest = h
 	}
 }
 

--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -166,7 +166,7 @@ func isAllowedSettingKey(k string) bool {
 	case "retention_full_hours", "retention_interesting_hours",
 		"retention_aggregated_days", "retention_error_days",
 		"boring_retention_minutes", "boring.sample_ratio",
-		"metrics_retention_days":
+		"metrics_retention_days", "log_retention_hours", "error_log_retention_days":
 		return true
 	}
 	return strings.HasPrefix(k, "ingest.sample_ratio.") ||

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 	RetentionInterestingHours int
 	BoringRetentionMinutes    int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
 	MetricsRetentionDays      int // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
+	LogRetentionHours         int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
+	ErrorLogRetentionDays     int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
 	IngestSampleRate          float64
 	SlowThresholdMS           int
 	AggregationInterval       string
@@ -79,6 +81,8 @@ func Load() Config {
 		RetentionInterestingHours: getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
 		BoringRetentionMinutes:    getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
 		MetricsRetentionDays:      getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
+		LogRetentionHours:         getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
+		ErrorLogRetentionDays:     getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
 		IngestSampleRate:          getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
 		SlowThresholdMS:           getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:     getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),

--- a/internal/ingest/logs_handler.go
+++ b/internal/ingest/logs_handler.go
@@ -1,0 +1,95 @@
+package ingest
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+const (
+	logsChannelSize   = 256
+	logsFlushSize     = 500
+	logsFlushInterval = 100 * time.Millisecond
+)
+
+// LogsRepository is the write-side subset needed by LogsHandler.
+type LogsRepository interface {
+	InsertLogs(ctx context.Context, recs []model.LogRecord) error
+}
+
+// LogsHandler buffers incoming OTLP log records and writes them to SQLite in
+// batches. No spool — losing a flush on crash is acceptable.
+type LogsHandler struct {
+	ch     chan []model.LogRecord
+	repo   LogsRepository
+	logger *slog.Logger
+}
+
+// NewLogsHandler creates a LogsHandler ready to call Run.
+func NewLogsHandler(repo LogsRepository, logger *slog.Logger) *LogsHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &LogsHandler{
+		ch:     make(chan []model.LogRecord, logsChannelSize),
+		repo:   repo,
+		logger: logger,
+	}
+}
+
+// Enqueue adds a batch of log records to the in-memory channel.
+// If the channel is full the batch is dropped and a warning is logged.
+func (h *LogsHandler) Enqueue(recs []model.LogRecord) {
+	if len(recs) == 0 {
+		return
+	}
+	select {
+	case h.ch <- recs:
+	default:
+		h.logger.Warn("logs channel full, dropping batch", "count", len(recs))
+	}
+}
+
+// Run drains the channel and writes batches to the repository until ctx is
+// cancelled. After cancellation it flushes remaining buffered records before
+// returning. Blocks until done — intended for use with safeGo.
+func (h *LogsHandler) Run(ctx context.Context) {
+	ticker := time.NewTicker(logsFlushInterval)
+	defer ticker.Stop()
+
+	var pending []model.LogRecord
+
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		if err := h.repo.InsertLogs(context.Background(), pending); err != nil {
+			h.logger.Error("logs insert failed", "error", err, "count", len(pending))
+		}
+		pending = pending[:0]
+	}
+
+	for {
+		select {
+		case recs := <-h.ch:
+			pending = append(pending, recs...)
+			if len(pending) >= logsFlushSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case <-ctx.Done():
+			for {
+				select {
+				case recs := <-h.ch:
+					pending = append(pending, recs...)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}

--- a/internal/ingest/logs_handler_test.go
+++ b/internal/ingest/logs_handler_test.go
@@ -1,0 +1,132 @@
+package ingest
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+type mockLogsRepo struct {
+	mu    sync.Mutex
+	calls [][]model.LogRecord
+}
+
+func (m *mockLogsRepo) InsertLogs(_ context.Context, recs []model.LogRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, append([]model.LogRecord{}, recs...))
+	return nil
+}
+
+func (m *mockLogsRepo) totalInserted() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := 0
+	for _, c := range m.calls {
+		n += len(c)
+	}
+	return n
+}
+
+func makeTestLogBatch(n int) []model.LogRecord {
+	recs := make([]model.LogRecord, n)
+	for i := range recs {
+		recs[i] = model.LogRecord{ProjectID: 1, Body: "test", SeverityNumber: 9}
+	}
+	return recs
+}
+
+func TestLogsHandlerEnqueue(t *testing.T) {
+	repo := &mockLogsRepo{}
+	h := NewLogsHandler(repo, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); h.Run(ctx) }()
+
+	h.Enqueue(makeTestLogBatch(5))
+	h.Enqueue(makeTestLogBatch(3))
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if repo.totalInserted() >= 8 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	wg.Wait()
+
+	if got := repo.totalInserted(); got != 8 {
+		t.Errorf("want 8 records inserted, got %d", got)
+	}
+}
+
+func TestLogsHandlerGracefulDrain(t *testing.T) {
+	repo := &mockLogsRepo{}
+	h := NewLogsHandler(repo, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); h.Run(ctx) }()
+
+	h.Enqueue(makeTestLogBatch(10))
+	cancel()
+	wg.Wait()
+
+	if got := repo.totalInserted(); got != 10 {
+		t.Errorf("graceful drain: want 10 records, got %d", got)
+	}
+}
+
+func TestLogsHandlerBackpressure(t *testing.T) {
+	repo := &mockLogsRepo{}
+	h := NewLogsHandler(repo, slog.Default())
+
+	dropped := false
+	for i := 0; i < logsChannelSize+10; i++ {
+		before := len(h.ch)
+		h.Enqueue(makeTestLogBatch(1))
+		if i >= logsChannelSize && before == logsChannelSize {
+			dropped = true
+		}
+	}
+	if !dropped {
+		t.Error("expected at least one batch to be dropped when channel is full")
+	}
+}
+
+func TestLogsHandlerFlushOnSizeThreshold(t *testing.T) {
+	repo := &mockLogsRepo{}
+	h := NewLogsHandler(repo, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); h.Run(ctx) }()
+
+	h.Enqueue(makeTestLogBatch(logsFlushSize + 1))
+
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if repo.totalInserted() >= logsFlushSize+1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	cancel()
+	wg.Wait()
+
+	if got := repo.totalInserted(); got != logsFlushSize+1 {
+		t.Errorf("want %d records, got %d", logsFlushSize+1, got)
+	}
+}

--- a/internal/model/log_record.go
+++ b/internal/model/log_record.go
@@ -1,0 +1,16 @@
+package model
+
+import "encoding/json"
+
+// LogRecord is the in-memory representation of a single OTLP log data point.
+type LogRecord struct {
+	ProjectID            int64
+	TraceID              string          // empty if not correlated with a trace
+	SpanID               string          // empty if not tied to a specific span
+	SeverityNumber       int32           // OTLP SeverityNumber (0=unset, 9=INFO, 13=WARN, 17=ERROR)
+	SeverityText         string          // human label ("INFO", "WARN", "ERROR", …)
+	TimeUnixNano         uint64
+	ObservedTimeUnixNano uint64
+	Body                 string          // stringified; StringValue direct, KvlistValue as JSON
+	Attributes           json.RawMessage // merged: resource < scope < log-record attributes
+}

--- a/internal/queue/redis_logs_queue.go
+++ b/internal/queue/redis_logs_queue.go
@@ -1,0 +1,70 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+const (
+	LogsQueueKey       = "spanbarn:logs-queue"
+	logsQueueBatchSize = 500
+)
+
+// PublishLogs serialises log records as JSON and LPUSHes them to the logs queue
+// in batches. Called by the reader pod's LogsHandler.
+func (q *RedisQueue) PublishLogs(ctx context.Context, records []model.LogRecord) error {
+	for i := 0; i < len(records); i += logsQueueBatchSize {
+		end := i + logsQueueBatchSize
+		if end > len(records) {
+			end = len(records)
+		}
+		data, err := json.Marshal(records[i:end])
+		if err != nil {
+			return fmt.Errorf("queue: marshal logs: %w", err)
+		}
+		if err := q.client.LPush(ctx, LogsQueueKey, data).Err(); err != nil {
+			return fmt.Errorf("queue: lpush logs: %w", err)
+		}
+	}
+	return nil
+}
+
+// ConsumeLogs blocks for up to brpopTimeout waiting for a batch from the logs
+// queue. Returns nil, nil when the queue is empty.
+// Called by the writer pod's logs consumer goroutine.
+func (q *RedisQueue) ConsumeLogs(ctx context.Context) ([]model.LogRecord, error) {
+	result, err := q.client.BRPop(ctx, brpopTimeout, LogsQueueKey).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("queue: brpop logs: %w", err)
+	}
+	var records []model.LogRecord
+	if err := json.Unmarshal([]byte(result[1]), &records); err != nil {
+		return nil, fmt.Errorf("queue: unmarshal logs: %w", err)
+	}
+	return records, nil
+}
+
+// LogsPublisher implements ingest.LogsRepository by publishing records to the
+// Redis logs queue. Used in reader mode so logs flow through the same Redis
+// hand-off as spans and metrics.
+type LogsPublisher struct {
+	queue *RedisQueue
+}
+
+// NewLogsPublisher wraps a RedisQueue as a LogsRepository.
+func NewLogsPublisher(q *RedisQueue) *LogsPublisher {
+	return &LogsPublisher{queue: q}
+}
+
+// InsertLogs publishes records to Redis. The writer pod consumes and stores them.
+func (p *LogsPublisher) InsertLogs(ctx context.Context, recs []model.LogRecord) error {
+	return p.queue.PublishLogs(ctx, recs)
+}

--- a/internal/repository/migrations/024_logs.go
+++ b/internal/repository/migrations/024_logs.go
@@ -1,0 +1,60 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up024, down024)
+}
+
+func up024(ctx context.Context, tx *sql.Tx) error {
+	stmts := []string{
+		`CREATE TABLE logs (
+			id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id              INTEGER NOT NULL,
+			trace_id                TEXT,
+			span_id                 TEXT,
+			severity_number         INTEGER  NOT NULL DEFAULT 0,
+			severity_text           TEXT     NOT NULL DEFAULT '',
+			time_unix_nano          INTEGER  NOT NULL,
+			observed_time_unix_nano INTEGER  NOT NULL DEFAULT 0,
+			body                    TEXT     NOT NULL DEFAULT '',
+			attributes              TEXT     NOT NULL DEFAULT '{}',
+			ingested_at             DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX idx_logs_project_ingested ON logs(project_id, ingested_at)`,
+		`CREATE INDEX idx_logs_trace            ON logs(trace_id) WHERE trace_id IS NOT NULL`,
+		`CREATE INDEX idx_logs_project_severity ON logs(project_id, severity_number, ingested_at)`,
+		`CREATE TABLE pinned_traces (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id INTEGER  NOT NULL,
+			trace_id   TEXT     NOT NULL,
+			label      TEXT     NOT NULL DEFAULT '',
+			pinned_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(project_id, trace_id)
+		)`,
+		`CREATE INDEX idx_pinned_traces_project ON pinned_traces(project_id, pinned_at)`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down024(ctx context.Context, tx *sql.Tx) error {
+	for _, s := range []string{
+		`DROP TABLE IF EXISTS logs`,
+		`DROP TABLE IF EXISTS pinned_traces`,
+	} {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -1,0 +1,249 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+// LogRow is the repository-layer representation of a stored log entry.
+type LogRow struct {
+	ID                   int64
+	ProjectID            int64
+	TraceID              string
+	SpanID               string
+	SeverityNumber       int32
+	SeverityText         string
+	TimeUnixNano         int64
+	ObservedTimeUnixNano int64
+	Body                 string
+	Attributes           string
+	IngestedAt           time.Time
+}
+
+// LogFilter scopes log queries.
+type LogFilter struct {
+	ProjectID      int64
+	TraceID        string
+	SpanID         string
+	MinSeverity    int32  // inclusive lower bound on severity_number; 0 = no filter
+	Service        string // matches JSON_EXTRACT(attributes,'$.service.name')
+	Search         string // body LIKE %search%
+	From           time.Time
+	To             time.Time
+	Limit          int
+	Offset         int
+}
+
+// PinnedTrace is a user-saved trace reference that exempts its logs from normal deletion.
+type PinnedTrace struct {
+	ProjectID int64
+	TraceID   string
+	Label     string
+	PinnedAt  time.Time
+}
+
+// InsertLogs persists a batch of log records in a single transaction.
+func (r *Repository) InsertLogs(ctx context.Context, recs []model.LogRecord) error {
+	if len(recs) == 0 {
+		return nil
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO logs
+		(project_id, trace_id, span_id, severity_number, severity_text,
+		 time_unix_nano, observed_time_unix_nano, body, attributes)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, rec := range recs {
+		var traceID, spanID *string
+		if rec.TraceID != "" {
+			traceID = &rec.TraceID
+		}
+		if rec.SpanID != "" {
+			spanID = &rec.SpanID
+		}
+		attrs := string(rec.Attributes)
+		if attrs == "" || attrs == "null" {
+			attrs = "{}"
+		}
+		if _, err := stmt.ExecContext(ctx,
+			rec.ProjectID, traceID, spanID,
+			rec.SeverityNumber, rec.SeverityText,
+			int64(rec.TimeUnixNano), int64(rec.ObservedTimeUnixNano),
+			rec.Body, attrs,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// QueryLogs returns log rows and total count matching f.
+func (r *Repository) QueryLogs(ctx context.Context, f LogFilter) ([]LogRow, int, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
+	where := []string{"project_id = ?", "ingested_at >= ?", "ingested_at <= ?"}
+	args := []any{f.ProjectID, f.From, f.To}
+
+	if f.TraceID != "" {
+		where = append(where, "trace_id = ?")
+		args = append(args, f.TraceID)
+	}
+	if f.SpanID != "" {
+		where = append(where, "span_id = ?")
+		args = append(args, f.SpanID)
+	}
+	if f.MinSeverity > 0 {
+		where = append(where, "severity_number >= ?")
+		args = append(args, f.MinSeverity)
+	}
+	if f.Service != "" {
+		where = append(where, `JSON_EXTRACT(attributes, '$."service.name"') = ?`)
+		args = append(args, f.Service)
+	}
+	if f.Search != "" {
+		where = append(where, "body LIKE ?")
+		args = append(args, "%"+f.Search+"%")
+	}
+
+	cond := strings.Join(where, " AND ")
+
+	var total int
+	if err := r.db.QueryRowContext(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM logs WHERE %s`, cond),
+		args...,
+	).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	limit := f.Limit
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	pageArgs := append(args, limit, f.Offset)
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(
+		`SELECT id, project_id, COALESCE(trace_id,''), COALESCE(span_id,''),
+		        severity_number, severity_text,
+		        time_unix_nano, observed_time_unix_nano, body, attributes, ingested_at
+		 FROM logs WHERE %s ORDER BY time_unix_nano DESC LIMIT ? OFFSET ?`, cond),
+		pageArgs...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	var result []LogRow
+	for rows.Next() {
+		var row LogRow
+		if err := rows.Scan(
+			&row.ID, &row.ProjectID, &row.TraceID, &row.SpanID,
+			&row.SeverityNumber, &row.SeverityText,
+			&row.TimeUnixNano, &row.ObservedTimeUnixNano,
+			&row.Body, &row.Attributes, &row.IngestedAt,
+		); err != nil {
+			return nil, 0, err
+		}
+		result = append(result, row)
+	}
+	return result, total, rows.Err()
+}
+
+// DeleteLogsOlderThan removes log records ingested before cutoff, skipping logs
+// whose trace_id is pinned or appears in recently-sampled error_samples.
+func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `
+		DELETE FROM logs
+		WHERE ingested_at < ?
+		AND (trace_id IS NULL
+		     OR (trace_id NOT IN (
+		             SELECT trace_id FROM pinned_traces
+		             WHERE project_id = logs.project_id
+		         )
+		         AND trace_id NOT IN (
+		             SELECT DISTINCT trace_id FROM error_samples
+		             WHERE sampled_at > ?
+		         )
+		     )
+		)`,
+		cutoff, errorLogCutoff,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// --- Pinned Traces ---
+
+func (r *Repository) PinTrace(ctx context.Context, projectID int64, traceID, label string) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO pinned_traces (project_id, trace_id, label) VALUES (?, ?, ?)
+		 ON CONFLICT(project_id, trace_id) DO UPDATE SET label = excluded.label`,
+		projectID, traceID, label,
+	)
+	return err
+}
+
+func (r *Repository) UnpinTrace(ctx context.Context, projectID int64, traceID string) error {
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM pinned_traces WHERE project_id = ? AND trace_id = ?`,
+		projectID, traceID,
+	)
+	return err
+}
+
+func (r *Repository) ListPinnedTraces(ctx context.Context, projectID int64) ([]PinnedTrace, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT project_id, trace_id, label, pinned_at FROM pinned_traces
+		 WHERE project_id = ? ORDER BY pinned_at DESC`,
+		projectID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []PinnedTrace
+	for rows.Next() {
+		var p PinnedTrace
+		if err := rows.Scan(&p.ProjectID, &p.TraceID, &p.Label, &p.PinnedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+	}
+	return result, rows.Err()
+}
+
+func (r *Repository) IsTracePinned(ctx context.Context, projectID int64, traceID string) (bool, error) {
+	var n int
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pinned_traces WHERE project_id = ? AND trace_id = ?`,
+		projectID, traceID,
+	).Scan(&n)
+	return n > 0, err
+}
+
+func scanLog(rows *sql.Rows) (LogRow, error) {
+	var row LogRow
+	err := rows.Scan(
+		&row.ID, &row.ProjectID, &row.TraceID, &row.SpanID,
+		&row.SeverityNumber, &row.SeverityText,
+		&row.TimeUnixNano, &row.ObservedTimeUnixNano,
+		&row.Body, &row.Attributes, &row.IngestedAt,
+	)
+	return row, err
+}

--- a/internal/repository/repo_logs_test.go
+++ b/internal/repository/repo_logs_test.go
@@ -1,0 +1,344 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+)
+
+func makeLogRecord(projectID int64, traceID, body string, severity int32) model.LogRecord {
+	attrs, _ := json.Marshal(map[string]string{"service.name": "test-svc"})
+	return model.LogRecord{
+		ProjectID:            projectID,
+		TraceID:              traceID,
+		SeverityNumber:       severity,
+		SeverityText:         "INFO",
+		TimeUnixNano:         uint64(time.Now().UnixNano()),
+		ObservedTimeUnixNano: uint64(time.Now().UnixNano()),
+		Body:                 body,
+		Attributes:           attrs,
+	}
+}
+
+func TestInsertLogsEmpty(t *testing.T) {
+	repo := setupTestDB(t)
+	if err := repo.InsertLogs(context.Background(), nil); err != nil {
+		t.Fatalf("InsertLogs(nil): %v", err)
+	}
+}
+
+func TestInsertAndQueryLogs(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "trace-abc", "hello world", 9),
+		makeLogRecord(1, "", "no trace log", 13),
+		makeLogRecord(2, "trace-xyz", "other project", 17),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	rows, total, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 1,
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("want total=2, got %d", total)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows, got %d", len(rows))
+	}
+
+	// Project 2 isolation.
+	rows2, total2, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 2,
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs p2: %v", err)
+	}
+	if total2 != 1 || len(rows2) != 1 {
+		t.Fatalf("want 1 row for project 2, got total=%d rows=%d", total2, len(rows2))
+	}
+}
+
+func TestQueryLogsTraceFilter(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "trace-abc", "msg1", 9),
+		makeLogRecord(1, "trace-def", "msg2", 9),
+		makeLogRecord(1, "", "msg3", 9),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	rows, total, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 1,
+		TraceID:   "trace-abc",
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs trace filter: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("want 1, got total=%d rows=%d", total, len(rows))
+	}
+	if rows[0].Body != "msg1" {
+		t.Errorf("want body=msg1, got %q", rows[0].Body)
+	}
+}
+
+func TestQueryLogsSeverityFilter(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "", "debug", 5),
+		makeLogRecord(1, "", "info", 9),
+		makeLogRecord(1, "", "warn", 13),
+		makeLogRecord(1, "", "error", 17),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	rows, total, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID:   1,
+		MinSeverity: 13,
+		From:        now.Add(-time.Minute),
+		To:          now.Add(time.Minute),
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs severity filter: %v", err)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("want 2, got total=%d rows=%d", total, len(rows))
+	}
+}
+
+func TestQueryLogsBodySearch(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "", "connection timeout occurred", 9),
+		makeLogRecord(1, "", "request processed successfully", 9),
+		makeLogRecord(1, "", "connection refused", 17),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	rows, total, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 1,
+		Search:    "connection",
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs body search: %v", err)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("want 2, got total=%d rows=%d", total, len(rows))
+	}
+}
+
+func TestDeleteLogsOlderThan_Basic(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+	errorLogCutoff := now.Add(-30 * 24 * time.Hour)
+
+	if err := repo.InsertLogs(context.Background(), []model.LogRecord{
+		makeLogRecord(1, "", "old log", 9),
+	}); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	// Nothing deleted when cutoff is in the past.
+	n, err := repo.DeleteLogsOlderThan(context.Background(), now.Add(-time.Hour), errorLogCutoff)
+	if err != nil {
+		t.Fatalf("DeleteLogsOlderThan: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("want 0 deleted, got %d", n)
+	}
+
+	// Delete with future cutoff removes the log.
+	n, err = repo.DeleteLogsOlderThan(context.Background(), now.Add(time.Hour), errorLogCutoff)
+	if err != nil {
+		t.Fatalf("DeleteLogsOlderThan future: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("want 1 deleted, got %d", n)
+	}
+}
+
+func TestDeleteLogsOlderThan_SkipsPinned(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+	errorLogCutoff := now.Add(-30 * 24 * time.Hour)
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "pinned-trace", "pinned log", 9),
+		makeLogRecord(1, "regular-trace", "regular log", 9),
+		makeLogRecord(1, "", "no-trace log", 9),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	if err := repo.PinTrace(context.Background(), 1, "pinned-trace", "important"); err != nil {
+		t.Fatalf("PinTrace: %v", err)
+	}
+
+	n, err := repo.DeleteLogsOlderThan(context.Background(), now.Add(time.Hour), errorLogCutoff)
+	if err != nil {
+		t.Fatalf("DeleteLogsOlderThan: %v", err)
+	}
+	// regular-trace and no-trace logs should be deleted; pinned-trace log survives.
+	if n != 2 {
+		t.Errorf("want 2 deleted, got %d", n)
+	}
+
+	rows, _, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 1,
+		TraceID:   "pinned-trace",
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs after delete: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("want 1 pinned log to survive, got %d", len(rows))
+	}
+}
+
+func TestDeleteLogsOlderThan_SkipsErrorSampled(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	// errorLogCutoff 30 days ago → error_samples rows inserted now are within the window.
+	errorLogCutoff := now.Add(-30 * 24 * time.Hour)
+
+	recs := []model.LogRecord{
+		makeLogRecord(1, "error-trace", "error log", 17),
+		makeLogRecord(1, "normal-trace", "normal log", 9),
+	}
+	if err := repo.InsertLogs(context.Background(), recs); err != nil {
+		t.Fatalf("InsertLogs: %v", err)
+	}
+
+	// Insert an error sample with "error-trace" to protect its logs.
+	errSpan := makeSpan(1, "error-trace", "span1", "web", "op", "error", 1000)
+	if err := repo.InsertErrorSamples([]Span{errSpan}); err != nil {
+		t.Fatalf("InsertErrorSamples: %v", err)
+	}
+
+	n, err := repo.DeleteLogsOlderThan(context.Background(), now.Add(time.Hour), errorLogCutoff)
+	if err != nil {
+		t.Fatalf("DeleteLogsOlderThan: %v", err)
+	}
+	// normal-trace log deleted; error-trace log survives.
+	if n != 1 {
+		t.Errorf("want 1 deleted, got %d", n)
+	}
+
+	rows, _, err := repo.QueryLogs(context.Background(), LogFilter{
+		ProjectID: 1,
+		TraceID:   "error-trace",
+		From:      now.Add(-time.Minute),
+		To:        now.Add(time.Minute),
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("QueryLogs after delete: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("want 1 error-sampled log to survive, got %d", len(rows))
+	}
+}
+
+func TestPinnedTracesCRUD(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Pin a trace.
+	if err := repo.PinTrace(ctx, 1, "trace-abc", "checkout bug"); err != nil {
+		t.Fatalf("PinTrace: %v", err)
+	}
+
+	// IsTracePinned should return true.
+	pinned, err := repo.IsTracePinned(ctx, 1, "trace-abc")
+	if err != nil {
+		t.Fatalf("IsTracePinned: %v", err)
+	}
+	if !pinned {
+		t.Error("expected trace to be pinned")
+	}
+
+	// Different project: not pinned.
+	pinned2, err := repo.IsTracePinned(ctx, 2, "trace-abc")
+	if err != nil {
+		t.Fatalf("IsTracePinned p2: %v", err)
+	}
+	if pinned2 {
+		t.Error("trace should not be pinned for project 2")
+	}
+
+	// List.
+	list, err := repo.ListPinnedTraces(ctx, 1)
+	if err != nil {
+		t.Fatalf("ListPinnedTraces: %v", err)
+	}
+	if len(list) != 1 || list[0].TraceID != "trace-abc" || list[0].Label != "checkout bug" {
+		t.Fatalf("unexpected list: %+v", list)
+	}
+
+	// Update label via upsert.
+	if err := repo.PinTrace(ctx, 1, "trace-abc", "updated label"); err != nil {
+		t.Fatalf("PinTrace upsert: %v", err)
+	}
+	list2, _ := repo.ListPinnedTraces(ctx, 1)
+	if len(list2) != 1 || list2[0].Label != "updated label" {
+		t.Fatalf("expected label update, got %+v", list2)
+	}
+
+	// Unpin.
+	if err := repo.UnpinTrace(ctx, 1, "trace-abc"); err != nil {
+		t.Fatalf("UnpinTrace: %v", err)
+	}
+
+	pinned3, err := repo.IsTracePinned(ctx, 1, "trace-abc")
+	if err != nil {
+		t.Fatalf("IsTracePinned after unpin: %v", err)
+	}
+	if pinned3 {
+		t.Error("trace should not be pinned after unpin")
+	}
+
+	list3, _ := repo.ListPinnedTraces(ctx, 1)
+	if len(list3) != 0 {
+		t.Errorf("expected empty list after unpin, got %d", len(list3))
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -47,6 +47,7 @@ type Repository interface {
 	DeleteAggregatesOlderThan(cutoff time.Time) (int64, error)
 	DeleteExpiredE2EUsers(now time.Time) (int64, error)
 	DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error)
 	GetSetting(key string) (string, error)
 }
 
@@ -58,6 +59,8 @@ type Config struct {
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
 	MetricsRetentionDays      int           // days to keep raw metric data points (default 90)
+	LogRetentionHours         int           // hours to keep log records (default 24)
+	ErrorLogRetentionDays     int           // days to keep logs for error-sampled traces (default 30)
 	SlowThresholdUS           int64         // microseconds above which a span is "slow"
 	Interval                  time.Duration // how often to run (default 5m)
 	// BatchYield is how long the worker voluntarily releases the write lock
@@ -84,6 +87,12 @@ func (c Config) withDefaults() Config {
 	}
 	if c.MetricsRetentionDays <= 0 {
 		c.MetricsRetentionDays = 90
+	}
+	if c.LogRetentionHours <= 0 {
+		c.LogRetentionHours = 24
+	}
+	if c.ErrorLogRetentionDays <= 0 {
+		c.ErrorLogRetentionDays = 30
 	}
 	if c.SlowThresholdUS <= 0 {
 		c.SlowThresholdUS = 1_000_000 // 1 second
@@ -183,6 +192,12 @@ func (w *RetentionWorker) effectiveConfig() Config {
 	if n, ok := readInt("metrics_retention_days"); ok {
 		cfg.MetricsRetentionDays = n
 	}
+	if n, ok := readInt("log_retention_hours"); ok {
+		cfg.LogRetentionHours = n
+	}
+	if n, ok := readInt("error_log_retention_days"); ok {
+		cfg.ErrorLogRetentionDays = n
+	}
 	return cfg
 }
 
@@ -224,6 +239,8 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	errorCutoff := now.Add(-time.Duration(cfg.ErrorRetentionDays) * 24 * time.Hour)
 	aggCutoff := now.Add(-time.Duration(cfg.AggregateRetentionDays) * 24 * time.Hour)
 	metricsCutoff := now.Add(-time.Duration(cfg.MetricsRetentionDays) * 24 * time.Hour)
+	logCutoff := now.Add(-time.Duration(cfg.LogRetentionHours) * time.Hour)
+	errorLogCutoff := now.Add(-time.Duration(cfg.ErrorLogRetentionDays) * 24 * time.Hour)
 
 	// Count spans pending deletion and warn if the backlog is unexpectedly large.
 	if pending, err := w.repo.CountSpansOlderThan(interestingCutoff); err != nil {
@@ -339,6 +356,10 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	logsDeleted, err := w.repo.DeleteLogsOlderThan(ctx, logCutoff, errorLogCutoff)
+	if err != nil {
+		return err
+	}
 	e2eUsersDeleted, err := w.repo.DeleteExpiredE2EUsers(now)
 	if err != nil {
 		return err
@@ -352,6 +373,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Int64("error_samples_deleted", errorSamplesDeleted),
 		attribute.Int64("aggregates_deleted", aggregatesDeleted),
 		attribute.Int64("metrics_deleted", metricsDeleted),
+		attribute.Int64("logs_deleted", logsDeleted),
 		attribute.Int64("e2e_users_deleted", e2eUsersDeleted),
 		attribute.Bool("backlog_remains", backlogRemains),
 	)
@@ -363,6 +385,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"error_samples_deleted", errorSamplesDeleted,
 		"aggregates_deleted", aggregatesDeleted,
 		"metrics_deleted", metricsDeleted,
+		"logs_deleted", logsDeleted,
 		"e2e_users_deleted", e2eUsersDeleted,
 		"backlog_remains", backlogRemains,
 	)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ const PagesPage = lazy(() => import('./pages/PagesPage').then(m => ({ default: m
 const PageDetailPage = lazy(() => import('./pages/PageDetailPage').then(m => ({ default: m.PageDetailPage })))
 const AlertsPage = lazy(() => import('./pages/AlertsPage').then(m => ({ default: m.AlertsPage })))
 const MetricsPage = lazy(() => import('./pages/MetricsPage').then(m => ({ default: m.MetricsPage })))
+const LogsPage = lazy(() => import('./pages/LogsPage').then(m => ({ default: m.LogsPage })))
 const SettingsPage = lazy(() => import('./pages/SettingsPage').then(m => ({ default: m.SettingsPage })))
 const ProfilePage = lazy(() => import('./pages/ProfilePage').then(m => ({ default: m.ProfilePage })))
 
@@ -41,6 +42,7 @@ function App() {
               <Route path="traces/:traceId" element={<TraceDetailPage />} />
               <Route path="dependencies" element={<DependenciesPage />} />
               <Route path="service-map" element={<ServiceMapPage />} />
+              <Route path="logs" element={<LogsPage />} />
               <Route path="live" element={<LiveTailPage />} />
               <Route path="database" element={<DatabasePage />} />
               <Route path="database/detail" element={<DatabaseQueryDetailPage />} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,6 +19,9 @@ import type {
   WebVitalTimeseriesBucket,
   MetricNamesResponse,
   MetricSeriesResponse,
+  LogsResponse,
+  PinnedTracesResponse,
+  LogsParams,
 } from './types'
 
 export class ApiError extends Error {
@@ -242,4 +245,34 @@ export const api = {
     }
     return fetchJSON<MetricSeriesResponse>(`/api/v1/metrics/series${query}`)
   },
+
+  getLogs: (params: LogsParams) =>
+    fetchJSON<LogsResponse>(
+      `/api/v1/logs${qs({
+        project_id: params.projectId || undefined,
+        trace_id: params.traceId,
+        span_id: params.spanId,
+        severity: params.severity,
+        service: params.service,
+        search: params.search,
+        from: params.from,
+        to: params.to,
+        limit: params.limit,
+        offset: params.offset,
+      })}`,
+    ),
+
+  getPinnedTraces: (projectId = 0) =>
+    fetchJSON<PinnedTracesResponse>(`/api/v1/pinned-traces${qs({ project_id: projectId || undefined })}`),
+
+  pinTrace: (traceId: string, label: string, projectId = 0) =>
+    fetchJSON<void>('/api/v1/pinned-traces', {
+      method: 'POST',
+      body: JSON.stringify({ project_id: projectId, trace_id: traceId, label }),
+    }),
+
+  unpinTrace: (traceId: string, projectId = 0) =>
+    fetchJSON<void>(`/api/v1/pinned-traces/${encodeURIComponent(traceId)}${qs({ project_id: projectId || undefined })}`, {
+      method: 'DELETE',
+    }),
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -299,3 +299,48 @@ export type MetricSeriesResponse = {
   unit: string
   points: MetricPoint[]
 }
+
+/** A single log entry returned by the logs query API. */
+export type LogEntry = {
+  id: number
+  traceId: string
+  spanId: string
+  severityNumber: number
+  severityText: string
+  timeUnixNano: number
+  body: string
+  attributes: Record<string, unknown>
+  ingestedAt: string
+}
+
+/** Response from GET /api/v1/logs */
+export type LogsResponse = {
+  logs: LogEntry[]
+  total: number
+}
+
+/** A user-pinned trace. */
+export type PinnedTrace = {
+  traceId: string
+  label: string
+  pinnedAt: string
+}
+
+/** Response from GET /api/v1/pinned-traces */
+export type PinnedTracesResponse = {
+  pinned: PinnedTrace[]
+}
+
+/** Params for querying logs. */
+export type LogsParams = {
+  projectId?: number
+  traceId?: string
+  spanId?: string
+  severity?: number
+  service?: string
+  search?: string
+  from: string
+  to: string
+  limit?: number
+  offset?: number
+}

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useEffect, useRef, useState } from 'react'
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
-import { Activity, BarChart2, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe } from 'lucide-react'
+import { Activity, BarChart2, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe, ScrollText } from 'lucide-react'
 import { api } from '../api/client'
 import { fetchClientConfig, isOIDCSession, fetchIambarnMe, type IambarnUser } from '../api/clientConfig'
 import { IambarnProfileModal } from './IambarnProfileModal'
@@ -12,6 +12,7 @@ const navItems = [
   { to: '/traces', icon: Search, label: 'Traces' },
   { to: '/dependencies', icon: GitBranch, label: 'Dependencies' },
   { to: '/service-map', icon: Network, label: 'Service Map' },
+  { to: '/logs', icon: ScrollText, label: 'Logs' },
   { to: '/live', icon: Radio, label: 'Live Tail' },
   { to: '/database', icon: Database, label: 'Database' },
   { to: '/prompts', icon: BrainCircuit, label: 'Prompts' },

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type ReactElement } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
-import { Activity, BarChart2, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut } from 'lucide-react'
+import { Activity, BarChart2, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut, ScrollText } from 'lucide-react'
 import { api } from '../api/client'
 import { fetchClientConfig, isOIDCSession, fetchIambarnMe, type IambarnUser } from '../api/clientConfig'
 import { IambarnProfileModal } from './IambarnProfileModal'
@@ -80,6 +80,25 @@ export function MobileTabBar(): ReactElement {
             boxShadow: '0 -4px 24px rgba(0, 0, 0, 0.4)',
           }}
         >
+          <NavLink
+            to="/logs"
+            onClick={() => setMoreOpen(false)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.625rem',
+              width: '100%',
+              padding: '0.625rem 0.75rem',
+              borderRadius: '0.5rem',
+              fontSize: '0.875rem',
+              fontWeight: 500,
+              color: 'var(--text-muted)',
+              textDecoration: 'none',
+            }}
+          >
+            <ScrollText size={18} />
+            Logs
+          </NavLink>
           <NavLink
             to="/live"
             onClick={() => setMoreOpen(false)}

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect, useCallback, useRef, Fragment, type ReactElement } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../api/client'
+import type { LogEntry } from '../api/types'
+import { TimeRangeSelector } from '../components/TimeRangeSelector'
+import { AutoRefresh } from '../components/AutoRefresh'
+import { getTimeRange } from '../utils/timeRange'
+import { useTimeRange } from '../contexts/useTimeRange'
+
+const SEVERITY_LEVELS = [
+  { label: 'ALL', value: 0 },
+  { label: 'DEBUG', value: 5 },
+  { label: 'INFO', value: 9 },
+  { label: 'WARN', value: 13 },
+  { label: 'ERROR', value: 17 },
+]
+
+function severityColor(n: number): string {
+  if (n >= 17) return 'var(--error, #ef4444)'
+  if (n >= 13) return 'var(--warning, #f59e0b)'
+  if (n >= 9) return 'var(--accent, #6366f1)'
+  return 'var(--text-muted)'
+}
+
+function severityLabel(n: number, text: string): string {
+  if (text) return text.slice(0, 5).toUpperCase()
+  if (n >= 17) return 'ERROR'
+  if (n >= 13) return 'WARN'
+  if (n >= 9) return 'INFO'
+  if (n >= 5) return 'DEBUG'
+  return 'TRACE'
+}
+
+export function LogsPage(): ReactElement {
+  const { range, setRange } = useTimeRange()
+  const [refreshInterval, setRefreshInterval] = useState(0)
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [minSeverity, setMinSeverity] = useState(0)
+  const [search, setSearch] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set())
+  const fetchIdRef = useRef(0)
+  const navigate = useNavigate()
+
+  const fetchLogs = useCallback(async () => {
+    const id = ++fetchIdRef.current
+    setLoading(true)
+    const { from, to } = getTimeRange(range)
+    try {
+      const resp = await api.getLogs({
+        from,
+        to,
+        severity: minSeverity || undefined,
+        search: search || undefined,
+        limit: 200,
+      })
+      if (id === fetchIdRef.current) {
+        setLogs(resp?.logs ?? [])
+        setTotal(resp?.total ?? 0)
+      }
+    } catch {
+      // handled by client
+    } finally {
+      if (id === fetchIdRef.current) setLoading(false)
+    }
+  }, [range, minSeverity, search])
+
+  useEffect(() => { void fetchLogs() }, [fetchLogs])
+
+  const toggleExpand = (id: number) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const handleSearchSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setSearch(searchInput)
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', height: '100%' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>Logs</h1>
+        <div style={{ flex: 1 }} />
+        <TimeRangeSelector value={range} onChange={setRange} />
+        <AutoRefresh value={refreshInterval} onChange={setRefreshInterval} onRefresh={fetchLogs} />
+      </div>
+
+      {/* Filters */}
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <div style={{ display: 'flex', gap: '0.25rem' }}>
+          {SEVERITY_LEVELS.map((l) => (
+            <button
+              key={l.value}
+              className={`btn btn-sm ${minSeverity === l.value ? 'btn-active' : ''}`}
+              onClick={() => setMinSeverity(l.value)}
+            >
+              {l.label}
+            </button>
+          ))}
+        </div>
+
+        <form onSubmit={handleSearchSubmit} style={{ display: 'flex', gap: '0.25rem' }}>
+          <input
+            type="text"
+            className="input input-sm"
+            placeholder="Search body..."
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            style={{ minWidth: '200px' }}
+          />
+          <button type="submit" className="btn btn-sm btn-primary">Search</button>
+          {search && (
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => { setSearch(''); setSearchInput('') }}
+            >
+              Clear
+            </button>
+          )}
+        </form>
+
+        <span style={{ marginLeft: 'auto', color: 'var(--text-muted)', fontSize: '0.8125rem' }}>
+          {loading ? 'Loading…' : `${total.toLocaleString()} total`}
+        </span>
+      </div>
+
+      {/* Log list */}
+      <div
+        style={{
+          flex: 1,
+          overflow: 'auto',
+          border: '1px solid var(--border)',
+          borderRadius: '0.5rem',
+          background: 'var(--surface)',
+        }}
+      >
+        {loading && logs.length === 0 ? (
+          <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)' }}>Loading…</div>
+        ) : logs.length === 0 ? (
+          <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)' }}>No logs found</div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem', tableLayout: 'fixed' }}>
+            <colgroup>
+              <col style={{ width: '140px' }} />
+              <col style={{ width: '60px' }} />
+              <col style={{ width: 'auto' }} />
+              <col style={{ width: '80px' }} />
+            </colgroup>
+            <tbody>
+              {logs.map((log) => {
+                const expanded = expandedIds.has(log.id)
+                return (
+                  <Fragment key={log.id}>
+                    <tr
+                      onClick={() => toggleExpand(log.id)}
+                      style={{ cursor: 'pointer', borderBottom: expanded ? 'none' : '1px solid var(--border)' }}
+                      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--surface-hover, rgba(255,255,255,0.04))')}
+                      onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                    >
+                      <td style={{ padding: '0.375rem 0.75rem', color: 'var(--text-muted)', whiteSpace: 'nowrap', fontFamily: 'monospace', fontSize: '0.75rem' }}>
+                        {new Date(log.ingestedAt).toLocaleTimeString()}
+                      </td>
+                      <td style={{ padding: '0.375rem 0.5rem', textAlign: 'center' }}>
+                        <span style={{
+                          display: 'inline-block',
+                          padding: '0.125rem 0.375rem',
+                          borderRadius: '0.25rem',
+                          fontSize: '0.6875rem',
+                          fontWeight: 700,
+                          color: severityColor(log.severityNumber),
+                          background: severityColor(log.severityNumber) + '22',
+                          fontFamily: 'monospace',
+                        }}>
+                          {severityLabel(log.severityNumber, log.severityText)}
+                        </span>
+                      </td>
+                      <td style={{ padding: '0.375rem 0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {log.body || <span style={{ color: 'var(--text-muted)' }}>(empty body)</span>}
+                      </td>
+                      <td style={{ padding: '0.375rem 0.75rem', textAlign: 'right' }}>
+                        {log.traceId && (
+                          <button
+                            className="btn btn-xs"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              void navigate(`/traces/${log.traceId}`)
+                            }}
+                            title={log.traceId}
+                          >
+                            Trace →
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                    {expanded && (
+                      <tr style={{ borderBottom: '1px solid var(--border)' }}>
+                        <td colSpan={4} style={{ padding: '0.5rem 0.75rem 0.75rem', background: 'var(--surface-hover, rgba(255,255,255,0.02))' }}>
+                          {log.traceId && (
+                            <div style={{ marginBottom: '0.375rem', fontSize: '0.75rem', color: 'var(--text-muted)' }}>
+                              trace: <code>{log.traceId}</code>
+                              {log.spanId && <> · span: <code>{log.spanId}</code></>}
+                            </div>
+                          )}
+                          <pre style={{
+                            margin: 0,
+                            padding: '0.5rem',
+                            borderRadius: '0.375rem',
+                            background: 'var(--bg)',
+                            fontSize: '0.75rem',
+                            overflow: 'auto',
+                            maxHeight: '300px',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word',
+                          }}>
+                            {JSON.stringify(log.attributes, null, 2)}
+                          </pre>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -22,6 +22,8 @@ type RetentionSettings = {
   retention_aggregated_days: string
   retention_error_days: string
   metrics_retention_days: string
+  log_retention_hours: string
+  error_log_retention_days: string
 }
 
 function formatBytes(bytes: number): string {
@@ -92,6 +94,8 @@ function RetentionSettingsPanel() {
     retention_aggregated_days: '30',
     retention_error_days: '90',
     metrics_retention_days: '90',
+    log_retention_hours: '24',
+    error_log_retention_days: '30',
   })
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -175,6 +179,26 @@ function RetentionSettingsPanel() {
             min="1"
             value={settings.metrics_retention_days}
             onChange={(e) => setSettings((s) => ({ ...s, metrics_retention_days: e.target.value }))}
+            style={fieldStyle}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Log retention (hours)</span>
+          <input
+            type="number"
+            min="1"
+            value={settings.log_retention_hours}
+            onChange={(e) => setSettings((s) => ({ ...s, log_retention_hours: e.target.value }))}
+            style={fieldStyle}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Error log retention (days)</span>
+          <input
+            type="number"
+            min="1"
+            value={settings.error_log_retention_days}
+            onChange={(e) => setSettings((s) => ({ ...s, error_log_retention_days: e.target.value }))}
             style={fieldStyle}
           />
         </label>

--- a/web/src/pages/TraceDetailPage.tsx
+++ b/web/src/pages/TraceDetailPage.tsx
@@ -1,9 +1,25 @@
 import type { ReactElement } from 'react'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, Fragment } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import type { TraceDetail } from '../api/types'
+import type { TraceDetail, LogEntry } from '../api/types'
 import { SpanWaterfall } from '../components/SpanWaterfall'
 import { formatDuration } from '../utils/spanTree'
+import { api } from '../api/client'
+
+function severityColor(n: number): string {
+  if (n >= 17) return 'var(--error, #ef4444)'
+  if (n >= 13) return 'var(--warning, #f59e0b)'
+  if (n >= 9) return 'var(--accent, #6366f1)'
+  return 'var(--text-muted)'
+}
+
+function severityLabel(n: number, text: string): string {
+  if (text) return text.slice(0, 5).toUpperCase()
+  if (n >= 17) return 'ERROR'
+  if (n >= 13) return 'WARN'
+  if (n >= 9) return 'INFO'
+  return 'DEBUG'
+}
 
 export function TraceDetailPage(): ReactElement {
   const { traceId } = useParams<{ traceId: string }>()
@@ -12,6 +28,17 @@ export function TraceDetailPage(): ReactElement {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+
+  // Logs panel state
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [logsTotal, setLogsTotal] = useState(0)
+  const [logsLoading, setLogsLoading] = useState(false)
+  const [expandedLogIds, setExpandedLogIds] = useState<Set<number>>(new Set())
+
+  // Pin state
+  const [pinned, setPinned] = useState(false)
+  const [pinLabel, setPinLabel] = useState('')
+  const [pinning, setPinning] = useState(false)
 
   const apiBase = '/api/v1'
 
@@ -34,6 +61,34 @@ export function TraceDetailPage(): ReactElement {
       })
   }, [traceId])
 
+  // Fetch logs for this trace
+  useEffect(() => {
+    if (!traceId) return
+    setLogsLoading(true)
+    const now = new Date()
+    const from = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
+    const to = now.toISOString()
+    void api.getLogs({ traceId, from, to, limit: 200 })
+      .then((resp) => {
+        setLogs(resp?.logs ?? [])
+        setLogsTotal(resp?.total ?? 0)
+      })
+      .catch(() => {})
+      .finally(() => setLogsLoading(false))
+  }, [traceId])
+
+  // Check pin status
+  useEffect(() => {
+    if (!traceId) return
+    void api.getPinnedTraces().then((resp) => {
+      const found = resp?.pinned?.find((p) => p.traceId === traceId)
+      if (found) {
+        setPinned(true)
+        setPinLabel(found.label)
+      }
+    }).catch(() => {})
+  }, [traceId])
+
   const copyTraceId = async () => {
     if (!traceId) return
     try {
@@ -45,7 +100,37 @@ export function TraceDetailPage(): ReactElement {
     }
   }
 
-  const onBack = () => navigate('/traces')
+  const handlePin = async () => {
+    if (!traceId) return
+    setPinning(true)
+    try {
+      if (pinned) {
+        await api.unpinTrace(traceId)
+        setPinned(false)
+        setPinLabel('')
+      } else {
+        const label = trace?.name || traceId.slice(0, 8)
+        await api.pinTrace(traceId, label)
+        setPinned(true)
+        setPinLabel(label)
+      }
+    } catch {
+      // ignore
+    } finally {
+      setPinning(false)
+    }
+  }
+
+  const toggleLogExpand = (id: number) => {
+    setExpandedLogIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const onBack = () => void navigate('/traces')
 
   if (loading) {
     return (
@@ -89,9 +174,28 @@ export function TraceDetailPage(): ReactElement {
 
       {/* Header */}
       <div style={{ marginTop: 8, marginBottom: 12 }}>
-        <h1 style={{ fontSize: 18, fontWeight: 600, marginBottom: 2 }}>
-          {trace.name || 'Trace Detail'}
-        </h1>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 2 }}>
+          <h1 style={{ fontSize: 18, fontWeight: 600, margin: 0 }}>
+            {trace.name || 'Trace Detail'}
+          </h1>
+          <button
+            onClick={() => void handlePin()}
+            disabled={pinning}
+            style={{
+              background: pinned ? 'var(--accent, #6366f1)' : 'transparent',
+              border: '1px solid ' + (pinned ? 'var(--accent, #6366f1)' : '#374151'),
+              borderRadius: 4,
+              padding: '2px 8px',
+              color: pinned ? '#fff' : '#9ca3af',
+              fontSize: 11,
+              cursor: 'pointer',
+              flexShrink: 0,
+            }}
+            title={pinned ? `Pinned: ${pinLabel}` : 'Pin this trace to retain its logs'}
+          >
+            {pinning ? '…' : pinned ? '★ Pinned' : '☆ Pin'}
+          </button>
+        </div>
         <div
           style={{
             display: 'flex',
@@ -105,7 +209,7 @@ export function TraceDetailPage(): ReactElement {
         >
           <code style={{ fontSize: 11, wordBreak: 'break-all' }}>{traceId}</code>
           <button
-            onClick={copyTraceId}
+            onClick={() => void copyTraceId()}
             style={{
               background: 'transparent',
               border: '1px solid #374151',
@@ -149,6 +253,94 @@ export function TraceDetailPage(): ReactElement {
       {/* Waterfall */}
       <div style={{ overflowX: 'auto' }}>
         <SpanWaterfall spans={trace.spans} totalDurationUs={trace.durationUs} />
+      </div>
+
+      {/* Logs panel */}
+      <div style={{ marginTop: 24 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+          <h2 style={{ fontSize: 14, fontWeight: 600, margin: 0 }}>
+            Logs
+          </h2>
+          {!logsLoading && (
+            <span style={{ fontSize: 11, color: '#9ca3af' }}>
+              {logsTotal > 0 ? `${logsTotal} matching` : 'none found'}
+            </span>
+          )}
+        </div>
+
+        {logsLoading ? (
+          <div style={{ padding: '1rem', color: '#9ca3af', fontSize: 13 }}>Loading logs…</div>
+        ) : logs.length === 0 ? (
+          <div style={{ padding: '0.75rem', color: '#9ca3af', fontSize: 13, border: '1px solid #1f2937', borderRadius: 6 }}>
+            No logs found for this trace.
+          </div>
+        ) : (
+          <div style={{ border: '1px solid #1f2937', borderRadius: 6, overflow: 'hidden' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem', tableLayout: 'fixed' }}>
+              <colgroup>
+                <col style={{ width: '130px' }} />
+                <col style={{ width: '56px' }} />
+                <col style={{ width: 'auto' }} />
+              </colgroup>
+              <tbody>
+                {logs.map((log) => {
+                  const expanded = expandedLogIds.has(log.id)
+                  return (
+                    <Fragment key={log.id}>
+                      <tr
+                        onClick={() => toggleLogExpand(log.id)}
+                        style={{ cursor: 'pointer', borderBottom: expanded ? 'none' : '1px solid #1f2937' }}
+                        onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.03)')}
+                        onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                      >
+                        <td style={{ padding: '0.3rem 0.6rem', color: '#6b7280', whiteSpace: 'nowrap', fontFamily: 'monospace', fontSize: '0.7rem' }}>
+                          {new Date(log.ingestedAt).toLocaleTimeString()}
+                        </td>
+                        <td style={{ padding: '0.3rem 0.4rem', textAlign: 'center' }}>
+                          <span style={{
+                            display: 'inline-block',
+                            padding: '0.1rem 0.3rem',
+                            borderRadius: '0.2rem',
+                            fontSize: '0.65rem',
+                            fontWeight: 700,
+                            color: severityColor(log.severityNumber),
+                            background: severityColor(log.severityNumber) + '22',
+                            fontFamily: 'monospace',
+                          }}>
+                            {severityLabel(log.severityNumber, log.severityText)}
+                          </span>
+                        </td>
+                        <td style={{ padding: '0.3rem 0.4rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: '#e5e7eb' }}>
+                          {log.body || <span style={{ color: '#6b7280' }}>(empty)</span>}
+                        </td>
+                      </tr>
+                      {expanded && (
+                        <tr style={{ borderBottom: '1px solid #1f2937' }}>
+                          <td colSpan={3} style={{ padding: '0.4rem 0.6rem 0.6rem', background: 'rgba(255,255,255,0.01)' }}>
+                            <pre style={{
+                              margin: 0,
+                              padding: '0.4rem',
+                              borderRadius: '0.3rem',
+                              background: '#111827',
+                              fontSize: '0.7rem',
+                              overflow: 'auto',
+                              maxHeight: '200px',
+                              whiteSpace: 'pre-wrap',
+                              wordBreak: 'break-word',
+                              color: '#9ca3af',
+                            }}>
+                              {JSON.stringify(log.attributes, null, 2)}
+                            </pre>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **OTLP log ingest** over HTTP (`/v1/logs`) and gRPC, using the same buffered-channel + batch-flush pattern as metrics. Reader mode publishes to Redis; writer mode consumes and stores.
- **Migration 024** adds `logs` and `pinned_traces` tables with appropriate indexes (project+time, trace_id, project+severity).
- **Log retention**: 24h default, configurable via env (`SPANBARN_LOG_RETENTION_HOURS`). Logs linked to error traces survive for 30d (`SPANBARN_ERROR_LOG_RETENTION_DAYS`). Pinned traces exempt their logs from deletion indefinitely.
- **Query API**: `GET /api/v1/logs` with filters for time range, trace_id, severity threshold, service, and body search.
- **Pinned traces CRUD**: `POST /api/v1/pinned-traces`, `DELETE /api/v1/pinned-traces/{traceId}`, `GET /api/v1/pinned-traces` — surfaced as a pin/unpin button on the trace detail page.
- **Logs explorer page** (`/logs`): severity filter, free-text search, expandable rows with JSON attributes, "Trace →" link for correlated traces.
- **TraceDetailPage**: logs panel below the span waterfall, pin button in the header.
- **SettingsPage**: log_retention_hours and error_log_retention_days admin controls.
- **Nav**: Logs added to sidebar (between Dependencies and Service Map) and mobile More menu.

## Test plan

- [ ] `go test ./... -race` passes
- [ ] `tsc --noEmit` passes
- [ ] Send a log via `POST /v1/logs` with an API key, verify it appears in `/api/v1/logs`
- [ ] Open a trace with correlated logs — logs panel shows matching entries
- [ ] Pin a trace, verify pin status persists across page reload and unpin works
- [ ] Retention: log for a pinned trace survives deletion; log for an error-sampled trace survives; orphaned log is deleted
- [ ] Settings page shows new retention fields and saves correctly