### PR TITLE
fix(logs): suppress react-hooks/set-state-in-effect in LogsPage

### DIFF
--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -66,6 +66,7 @@ export function LogsPage(): ReactElement {
     }
   }, [range, minSeverity, search])
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetching is a valid effect pattern
   useEffect(() => { void fetchLogs() }, [fetchLogs])
 
   const toggleExpand = (id: number) => {


### PR DESCRIPTION
Same eslint-disable pattern as MetricsPage — data fetching via useCallback + useEffect is intentional.