### PR TITLE
feat(logs): volume histogram and card-style log entries

### DIFF
--- a/internal/api/logs_query.go
+++ b/internal/api/logs_query.go
@@ -101,6 +101,75 @@ func (h *logsQueryHandlers) handleLogs(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, logsResponse{Logs: entries, Total: total})
 }
 
+type logHistogramBucketJSON struct {
+	Ts    string `json:"ts"`
+	Count int    `json:"count"`
+}
+
+type logsHistogramResponse struct {
+	Buckets []logHistogramBucketJSON `json:"buckets"`
+}
+
+// handleLogsHistogram handles GET /api/v1/logs/histogram
+func (h *logsQueryHandlers) handleLogsHistogram(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	projectID := parseInt64Param(r, "project_id", 0)
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+	if from.IsZero() {
+		from = time.Now().Add(-24 * time.Hour)
+	}
+	if to.IsZero() {
+		to = time.Now()
+	}
+
+	span := to.Sub(from)
+	var bucketSecs int
+	switch {
+	case span <= time.Hour:
+		bucketSecs = 60
+	case span <= 4*time.Hour:
+		bucketSecs = 300
+	case span <= 24*time.Hour:
+		bucketSecs = 1800
+	case span <= 7*24*time.Hour:
+		bucketSecs = 10800
+	default:
+		bucketSecs = 86400
+	}
+
+	f := repository.LogFilter{
+		ProjectID:   projectID,
+		MinSeverity: int32(parseIntParam(r, "severity", 0)),
+		Service:     r.URL.Query().Get("service"),
+		Search:      r.URL.Query().Get("search"),
+		From:        from,
+		To:          to,
+	}
+
+	buckets, err := h.repo.LogHistogram(r.Context(), f, bucketSecs)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "histogram query failed", err.Error())
+		return
+	}
+
+	out := make([]logHistogramBucketJSON, 0, len(buckets))
+	for _, b := range buckets {
+		out = append(out, logHistogramBucketJSON{
+			Ts:    b.Ts.Format(time.RFC3339),
+			Count: b.Count,
+		})
+	}
+	writeJSON(w, http.StatusOK, logsHistogramResponse{Buckets: out})
+}
+
 // handlePinnedTraces handles GET/POST/DELETE on /api/v1/pinned-traces
 func (h *logsQueryHandlers) handlePinnedTraces(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -124,6 +124,7 @@ func (s *Server) registerRoutes() {
 		sessionAuth := SessionMiddleware(s.sessionMgr)
 
 		s.mux.Handle("/api/v1/logs", apiRL(sessionAuth(http.HandlerFunc(lqh.handleLogs))))
+		s.mux.Handle("/api/v1/logs/histogram", apiRL(sessionAuth(http.HandlerFunc(lqh.handleLogsHistogram))))
 		s.mux.Handle("/api/v1/pinned-traces", apiRL(sessionAuth(http.HandlerFunc(lqh.handlePinnedTraces))))
 		s.mux.Handle("/api/v1/pinned-traces/", apiRL(sessionAuth(http.HandlerFunc(lqh.handlePinnedTraces))))
 	}

--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -162,6 +162,66 @@ func (r *Repository) QueryLogs(ctx context.Context, f LogFilter) ([]LogRow, int,
 	return result, total, rows.Err()
 }
 
+// LogHistogramBucket is one time-bucket in a log volume histogram.
+type LogHistogramBucket struct {
+	Ts    time.Time `json:"ts"`
+	Count int       `json:"count"`
+}
+
+// LogHistogram returns per-bucket log counts for the given filter.
+// bucketSecs controls the width of each bucket in seconds.
+func (r *Repository) LogHistogram(ctx context.Context, f LogFilter, bucketSecs int) ([]LogHistogramBucket, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
+	where := []string{"project_id = ?", "ingested_at >= ?", "ingested_at <= ?"}
+	args := []any{f.ProjectID, f.From, f.To}
+
+	if f.TraceID != "" {
+		where = append(where, "trace_id = ?")
+		args = append(args, f.TraceID)
+	}
+	if f.MinSeverity > 0 {
+		where = append(where, "severity_number >= ?")
+		args = append(args, f.MinSeverity)
+	}
+	if f.Service != "" {
+		where = append(where, `JSON_EXTRACT(attributes, '$."service.name"') = ?`)
+		args = append(args, f.Service)
+	}
+	if f.Search != "" {
+		where = append(where, "body LIKE ?")
+		args = append(args, "%"+f.Search+"%")
+	}
+
+	cond := strings.Join(where, " AND ")
+	// Prepend bucketSecs twice: once for the division, once for the multiply.
+	qargs := append([]any{bucketSecs, bucketSecs}, args...)
+
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT CAST(strftime('%%s', ingested_at) / ? AS INTEGER) * ? AS bucket_ts, COUNT(*)
+		FROM logs WHERE %s
+		GROUP BY bucket_ts ORDER BY bucket_ts`, cond), qargs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []LogHistogramBucket
+	for rows.Next() {
+		var epochSecs int64
+		var cnt int
+		if err := rows.Scan(&epochSecs, &cnt); err != nil {
+			return nil, err
+		}
+		result = append(result, LogHistogramBucket{
+			Ts:    time.Unix(epochSecs, 0).UTC(),
+			Count: cnt,
+		})
+	}
+	return result, rows.Err()
+}
+
 // DeleteLogsOlderThan removes log records ingested before cutoff, skipping logs
 // whose trace_id is pinned or appears in recently-sampled error_samples.
 func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -20,6 +20,7 @@ import type {
   MetricNamesResponse,
   MetricSeriesResponse,
   LogsResponse,
+  LogsHistogramResponse,
   PinnedTracesResponse,
   LogsParams,
 } from './types'
@@ -259,6 +260,18 @@ export const api = {
         to: params.to,
         limit: params.limit,
         offset: params.offset,
+      })}`,
+    ),
+
+  getLogsHistogram: (params: Pick<LogsParams, 'from' | 'to' | 'severity' | 'service' | 'search' | 'projectId'>) =>
+    fetchJSON<LogsHistogramResponse>(
+      `/api/v1/logs/histogram${qs({
+        project_id: params.projectId || undefined,
+        severity: params.severity,
+        service: params.service,
+        search: params.search,
+        from: params.from,
+        to: params.to,
       })}`,
     ),
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -331,6 +331,17 @@ export type PinnedTracesResponse = {
   pinned: PinnedTrace[]
 }
 
+/** One time bucket in a log volume histogram. */
+export type LogHistogramBucket = {
+  ts: string
+  count: number
+}
+
+/** Response from GET /api/v1/logs/histogram */
+export type LogsHistogramResponse = {
+  buckets: LogHistogramBucket[]
+}
+
 /** Params for querying logs. */
 export type LogsParams = {
   projectId?: number

--- a/web/src/pages/LogsPage.tsx
+++ b/web/src/pages/LogsPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useCallback, useRef, Fragment, type ReactElement } from 'react'
+import { useState, useEffect, useCallback, useRef, type ReactElement } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { api } from '../api/client'
-import type { LogEntry } from '../api/types'
+import type { LogEntry, LogHistogramBucket } from '../api/types'
 import { TimeRangeSelector } from '../components/TimeRangeSelector'
 import { AutoRefresh } from '../components/AutoRefresh'
 import { getTimeRange } from '../utils/timeRange'
@@ -16,10 +16,10 @@ const SEVERITY_LEVELS = [
 ]
 
 function severityColor(n: number): string {
-  if (n >= 17) return 'var(--error, #ef4444)'
-  if (n >= 13) return 'var(--warning, #f59e0b)'
-  if (n >= 9) return 'var(--accent, #6366f1)'
-  return 'var(--text-muted)'
+  if (n >= 17) return '#ef4444'
+  if (n >= 13) return '#f59e0b'
+  if (n >= 9) return '#6366f1'
+  return '#6b7280'
 }
 
 function severityLabel(n: number, text: string): string {
@@ -31,12 +31,212 @@ function severityLabel(n: number, text: string): string {
   return 'TRACE'
 }
 
+function getServiceName(attrs: Record<string, unknown>): string {
+  const v = attrs['service.name']
+  return typeof v === 'string' ? v : ''
+}
+
+function getAttrChips(attrs: Record<string, unknown>): { k: string; v: string }[] {
+  const skip = new Set(['service.name', 'service.version', 'deployment.environment', 'telemetry.sdk.name', 'telemetry.sdk.version', 'telemetry.sdk.language'])
+  const chips: { k: string; v: string }[] = []
+  for (const [k, v] of Object.entries(attrs)) {
+    if (skip.has(k)) continue
+    const str = typeof v === 'string' ? v : typeof v === 'number' ? String(v) : JSON.stringify(v)
+    chips.push({ k, v: str.length > 60 ? str.slice(0, 60) + '…' : str })
+    if (chips.length >= 6) break
+  }
+  return chips
+}
+
+// --- Histogram SVG ---
+
+function LogHistogram({ buckets, height = 56 }: { buckets: LogHistogramBucket[]; height?: number }): ReactElement {
+  if (buckets.length === 0) {
+    return <div style={{ height, background: 'rgba(255,255,255,0.02)', borderRadius: 6 }} />
+  }
+  const max = Math.max(...buckets.map((b) => b.count), 1)
+  const w = 100 / buckets.length
+  return (
+    <svg
+      viewBox={`0 0 100 ${height}`}
+      preserveAspectRatio="none"
+      style={{ width: '100%', height, display: 'block', borderRadius: 6, background: 'rgba(255,255,255,0.02)' }}
+    >
+      {buckets.map((b, i) => {
+        const barH = (b.count / max) * (height - 4)
+        return (
+          <rect
+            key={i}
+            x={i * w + 0.2}
+            y={height - barH - 2}
+            width={Math.max(w - 0.4, 0.2)}
+            height={barH}
+            fill="#6366f1"
+            opacity={0.7}
+          >
+            <title>{new Date(b.ts).toLocaleString()}: {b.count}</title>
+          </rect>
+        )
+      })}
+    </svg>
+  )
+}
+
+// --- Log card ---
+
+function LogCard({
+  log,
+  expanded,
+  onToggle,
+  onTrace,
+}: {
+  log: LogEntry
+  expanded: boolean
+  onToggle: () => void
+  onTrace: (id: string) => void
+}): ReactElement {
+  const color = severityColor(log.severityNumber)
+  const label = severityLabel(log.severityNumber, log.severityText)
+  const service = getServiceName(log.attributes)
+  const chips = getAttrChips(log.attributes)
+  const ts = new Date(log.ingestedAt)
+
+  return (
+    <div
+      style={{
+        borderBottom: '1px solid var(--border)',
+        cursor: 'pointer',
+        transition: 'background 0.1s',
+      }}
+      onClick={onToggle}
+      onMouseEnter={(e) => ((e.currentTarget as HTMLDivElement).style.background = 'rgba(255,255,255,0.03)')}
+      onMouseLeave={(e) => ((e.currentTarget as HTMLDivElement).style.background = '')}
+    >
+      <div style={{ display: 'flex', borderLeft: `3px solid ${color}` }}>
+        <div style={{ flex: 1, padding: '0.5rem 0.75rem', minWidth: 0 }}>
+          {/* Meta row */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.25rem' }}>
+            <span style={{
+              display: 'inline-block',
+              padding: '0.1rem 0.35rem',
+              borderRadius: 3,
+              fontSize: '0.625rem',
+              fontWeight: 700,
+              fontFamily: 'monospace',
+              color,
+              background: color + '22',
+              flexShrink: 0,
+            }}>
+              {label}
+            </span>
+            {service && (
+              <span style={{
+                display: 'inline-block',
+                padding: '0.1rem 0.4rem',
+                borderRadius: 3,
+                fontSize: '0.6875rem',
+                background: 'rgba(99,102,241,0.15)',
+                color: '#818cf8',
+                fontWeight: 500,
+                flexShrink: 0,
+              }}>
+                {service}
+              </span>
+            )}
+            <span style={{ fontSize: '0.6875rem', color: 'var(--text-muted)', fontFamily: 'monospace', flexShrink: 0 }}>
+              {ts.toLocaleString()}
+            </span>
+            {log.traceId && (
+              <button
+                className="btn btn-xs"
+                style={{ marginLeft: 'auto', flexShrink: 0 }}
+                onClick={(e) => { e.stopPropagation(); onTrace(log.traceId) }}
+                title={log.traceId}
+              >
+                Trace →
+              </button>
+            )}
+          </div>
+
+          {/* Body */}
+          <div style={{ fontSize: '0.8125rem', color: 'var(--text)', lineHeight: 1.4, wordBreak: 'break-word', marginBottom: chips.length > 0 ? '0.375rem' : 0 }}>
+            {log.body || <span style={{ color: 'var(--text-muted)', fontStyle: 'italic' }}>(empty body)</span>}
+          </div>
+
+          {/* Attribute chips */}
+          {chips.length > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
+              {chips.map(({ k, v }) => (
+                <span
+                  key={k}
+                  style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '0.2rem',
+                    padding: '0.1rem 0.4rem',
+                    borderRadius: 3,
+                    fontSize: '0.6875rem',
+                    background: 'rgba(255,255,255,0.05)',
+                    border: '1px solid rgba(255,255,255,0.08)',
+                    fontFamily: 'monospace',
+                    color: 'var(--text-muted)',
+                    maxWidth: '280px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={`${k}: ${v}`}
+                >
+                  <span style={{ color: '#94a3b8', fontWeight: 600 }}>{k}:</span>
+                  <span style={{ color: 'var(--text)' }}>{v}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div
+          style={{ padding: '0.5rem 0.75rem 0.75rem', background: 'rgba(255,255,255,0.01)', borderLeft: `3px solid ${color}` }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {(log.traceId || log.spanId) && (
+            <div style={{ marginBottom: '0.375rem', fontSize: '0.75rem', color: 'var(--text-muted)', fontFamily: 'monospace' }}>
+              {log.traceId && <>trace: {log.traceId}</>}
+              {log.spanId && <> · span: {log.spanId}</>}
+            </div>
+          )}
+          <pre style={{
+            margin: 0,
+            padding: '0.5rem',
+            borderRadius: 4,
+            background: 'var(--bg, #0f1117)',
+            fontSize: '0.75rem',
+            overflow: 'auto',
+            maxHeight: 320,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            color: '#9ca3af',
+          }}>
+            {JSON.stringify(log.attributes, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// --- Page ---
+
 export function LogsPage(): ReactElement {
   const { range, setRange } = useTimeRange()
   const [refreshInterval, setRefreshInterval] = useState(0)
   const [logs, setLogs] = useState<LogEntry[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [histogram, setHistogram] = useState<LogHistogramBucket[]>([])
   const [minSeverity, setMinSeverity] = useState(0)
   const [search, setSearch] = useState('')
   const [searchInput, setSearchInput] = useState('')
@@ -48,16 +248,14 @@ export function LogsPage(): ReactElement {
     const id = ++fetchIdRef.current
     const { from, to } = getTimeRange(range)
     try {
-      const resp = await api.getLogs({
-        from,
-        to,
-        severity: minSeverity || undefined,
-        search: search || undefined,
-        limit: 200,
-      })
+      const [logsResp, histResp] = await Promise.all([
+        api.getLogs({ from, to, severity: minSeverity || undefined, search: search || undefined, limit: 200 }),
+        api.getLogsHistogram({ from, to, severity: minSeverity || undefined, search: search || undefined }),
+      ])
       if (id === fetchIdRef.current) {
-        setLogs(resp?.logs ?? [])
-        setTotal(resp?.total ?? 0)
+        setLogs(logsResp?.logs ?? [])
+        setTotal(logsResp?.total ?? 0)
+        setHistogram(histResp?.buckets ?? [])
       }
     } catch {
       // handled by client
@@ -87,11 +285,26 @@ export function LogsPage(): ReactElement {
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', height: '100%' }}>
       {/* Header */}
       <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
-        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>Logs</h1>
+        <h1 style={{ margin: 0, fontSize: '1.25rem', fontWeight: 600 }}>Log stream</h1>
+        {!loading && total > 0 && (
+          <span style={{
+            padding: '0.1rem 0.5rem',
+            borderRadius: 12,
+            background: 'var(--accent, #6366f1)',
+            color: '#fff',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+          }}>
+            {total.toLocaleString()}
+          </span>
+        )}
         <div style={{ flex: 1 }} />
         <TimeRangeSelector value={range} onChange={setRange} />
         <AutoRefresh value={refreshInterval} onChange={setRefreshInterval} onRefresh={fetchLogs} />
       </div>
+
+      {/* Histogram */}
+      <LogHistogram buckets={histogram} />
 
       {/* Filters */}
       <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
@@ -107,14 +320,14 @@ export function LogsPage(): ReactElement {
           ))}
         </div>
 
-        <form onSubmit={handleSearchSubmit} style={{ display: 'flex', gap: '0.25rem' }}>
+        <form onSubmit={handleSearchSubmit} style={{ display: 'flex', gap: '0.25rem', flex: 1, minWidth: 0 }}>
           <input
             type="text"
             className="input input-sm"
-            placeholder="Search body..."
+            placeholder="Filter by message…"
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            style={{ minWidth: '200px' }}
+            style={{ flex: 1, minWidth: '140px' }}
           />
           <button type="submit" className="btn btn-sm btn-primary">Search</button>
           {search && (
@@ -127,10 +340,6 @@ export function LogsPage(): ReactElement {
             </button>
           )}
         </form>
-
-        <span style={{ marginLeft: 'auto', color: 'var(--text-muted)', fontSize: '0.8125rem' }}>
-          {loading ? 'Loading…' : `${total.toLocaleString()} total`}
-        </span>
       </div>
 
       {/* Log list */}
@@ -148,89 +357,15 @@ export function LogsPage(): ReactElement {
         ) : logs.length === 0 ? (
           <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)' }}>No logs found</div>
         ) : (
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem', tableLayout: 'fixed' }}>
-            <colgroup>
-              <col style={{ width: '140px' }} />
-              <col style={{ width: '60px' }} />
-              <col style={{ width: 'auto' }} />
-              <col style={{ width: '80px' }} />
-            </colgroup>
-            <tbody>
-              {logs.map((log) => {
-                const expanded = expandedIds.has(log.id)
-                return (
-                  <Fragment key={log.id}>
-                    <tr
-                      onClick={() => toggleExpand(log.id)}
-                      style={{ cursor: 'pointer', borderBottom: expanded ? 'none' : '1px solid var(--border)' }}
-                      onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--surface-hover, rgba(255,255,255,0.04))')}
-                      onMouseLeave={(e) => (e.currentTarget.style.background = '')}
-                    >
-                      <td style={{ padding: '0.375rem 0.75rem', color: 'var(--text-muted)', whiteSpace: 'nowrap', fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                        {new Date(log.ingestedAt).toLocaleTimeString()}
-                      </td>
-                      <td style={{ padding: '0.375rem 0.5rem', textAlign: 'center' }}>
-                        <span style={{
-                          display: 'inline-block',
-                          padding: '0.125rem 0.375rem',
-                          borderRadius: '0.25rem',
-                          fontSize: '0.6875rem',
-                          fontWeight: 700,
-                          color: severityColor(log.severityNumber),
-                          background: severityColor(log.severityNumber) + '22',
-                          fontFamily: 'monospace',
-                        }}>
-                          {severityLabel(log.severityNumber, log.severityText)}
-                        </span>
-                      </td>
-                      <td style={{ padding: '0.375rem 0.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {log.body || <span style={{ color: 'var(--text-muted)' }}>(empty body)</span>}
-                      </td>
-                      <td style={{ padding: '0.375rem 0.75rem', textAlign: 'right' }}>
-                        {log.traceId && (
-                          <button
-                            className="btn btn-xs"
-                            onClick={(e) => {
-                              e.stopPropagation()
-                              void navigate(`/traces/${log.traceId}`)
-                            }}
-                            title={log.traceId}
-                          >
-                            Trace →
-                          </button>
-                        )}
-                      </td>
-                    </tr>
-                    {expanded && (
-                      <tr style={{ borderBottom: '1px solid var(--border)' }}>
-                        <td colSpan={4} style={{ padding: '0.5rem 0.75rem 0.75rem', background: 'var(--surface-hover, rgba(255,255,255,0.02))' }}>
-                          {log.traceId && (
-                            <div style={{ marginBottom: '0.375rem', fontSize: '0.75rem', color: 'var(--text-muted)' }}>
-                              trace: <code>{log.traceId}</code>
-                              {log.spanId && <> · span: <code>{log.spanId}</code></>}
-                            </div>
-                          )}
-                          <pre style={{
-                            margin: 0,
-                            padding: '0.5rem',
-                            borderRadius: '0.375rem',
-                            background: 'var(--bg)',
-                            fontSize: '0.75rem',
-                            overflow: 'auto',
-                            maxHeight: '300px',
-                            whiteSpace: 'pre-wrap',
-                            wordBreak: 'break-word',
-                          }}>
-                            {JSON.stringify(log.attributes, null, 2)}
-                          </pre>
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
-                )
-              })}
-            </tbody>
-          </table>
+          logs.map((log) => (
+            <LogCard
+              key={log.id}
+              log={log}
+              expanded={expandedIds.has(log.id)}
+              onToggle={() => toggleExpand(log.id)}
+              onTrace={(id) => void navigate(`/traces/${id}`)}
+            />
+          ))
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/logs/histogram` endpoint with auto-sized time buckets (1min/5min/30min/3h/1d depending on range)
- Rewrite LogsPage with SVG bar-chart histogram, severity-colored log cards, service chips, and up to 6 attribute chips per entry
- Parallel fetch of logs + histogram in a single render cycle