### PR TITLE
fix(observability): send 100% of self-traces and correlate logs to trace/span IDs

### DIFF
--- a/internal/observability/sampler.go
+++ b/internal/observability/sampler.go
@@ -10,8 +10,9 @@ import (
 )
 
 // DefaultSelfSamplePercent is the percentage of non-error traces that
-// Spanbarn exports when self-instrumenting. 1 means 1 in every 100 traces.
-const DefaultSelfSamplePercent = 1
+// SpanBarn exports when self-instrumenting. 100 means all traces; project-level
+// sampling controls retention after ingest.
+const DefaultSelfSamplePercent = 100
 
 // ShouldSampleTrace reports whether a trace ID should be sampled given a
 // percentage (1–100). The decision is deterministic: the same trace ID always

--- a/internal/observability/selflogs.go
+++ b/internal/observability/selflogs.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
 // SelfLogsHandler is a slog.Handler that tees records to SpanBarn's own /v1/logs endpoint.
@@ -51,13 +53,19 @@ func (h *SelfLogsHandler) Handle(ctx context.Context, r slog.Record) error {
 		ts = time.Now().UnixNano()
 	}
 
-	h.exporter.enqueue(selfLogRec{
+	rec := selfLogRec{
 		timeNano: ts,
 		sevNum:   slogToOTLPSeverity(r.Level),
 		sevText:  r.Level.String(),
 		body:     r.Message,
 		attrs:    attrs,
-	})
+	}
+	if span := trace.SpanFromContext(ctx); span.SpanContext().IsValid() {
+		sc := span.SpanContext()
+		rec.traceID = sc.TraceID().String()
+		rec.spanID = sc.SpanID().String()
+	}
+	h.exporter.enqueue(rec)
 
 	return innerErr
 }
@@ -94,6 +102,8 @@ type selfLogRec struct {
 	sevText  string
 	body     string
 	attrs    map[string]string
+	traceID  string
+	spanID   string
 }
 
 type selfLogsExporter struct {
@@ -182,6 +192,8 @@ func (e *selfLogsExporter) send(batch []selfLogRec) {
 			SeverityNumber:       r.sevNum,
 			SeverityText:         r.sevText,
 			Body:                 otlpSelfAV{StringValue: r.body},
+			TraceId:              r.traceID,
+			SpanId:               r.spanID,
 		}
 		for k, v := range r.attrs {
 			rec.Attributes = append(rec.Attributes, otlpSelfKV{Key: k, Value: otlpSelfAV{StringValue: v}})
@@ -250,6 +262,8 @@ type otlpSelfLogRec struct {
 	SeverityText         string       `json:"severityText"`
 	Body                 otlpSelfAV   `json:"body"`
 	Attributes           []otlpSelfKV `json:"attributes,omitempty"`
+	TraceId              string       `json:"traceId,omitempty"`
+	SpanId               string       `json:"spanId,omitempty"`
 }
 
 type otlpSelfKV struct {


### PR DESCRIPTION
## Summary
- `DefaultSelfSamplePercent` was 1 (1%) — 99% of non-error HTTP spans were dropped by the SDK before reaching SpanBarn's ingest. Project-level sampling is the right place to control retention. Changed to 100%.
- `SelfLogsHandler.Handle` now extracts the OTel span context from the request context and attaches `traceId`/`spanId` to emitted OTLP log records, enabling correlation in the trace detail view.