### PR TITLE
fix(ingest): bypass TraceBuffer for self-instrument spans

### DIFF
--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -70,22 +70,25 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 		span.SetAttributes(attribute.Int("span_count", len(records)))
 	}
 
-	if s.traceBuffer != nil {
+	if selfExport {
+		// Self-instrument spans bypass the TraceBuffer so they are never
+		// dropped by project-level sampling — the pod's own traces must
+		// always reach the writer.
+		for _, rec := range records {
+			s.ingest.Enqueue(rec)
+		}
+	} else if s.traceBuffer != nil {
 		// Tail-based sampling: add to the trace buffer and let it decide
 		// per-trace after the configured TTL. Error traces always pass.
 		for _, rec := range records {
 			s.traceBuffer.Add(rec)
 		}
-	} else if !selfExport {
+	} else {
 		_, enqueueSpan := apiTracer.Start(ctx, "api.otlp.enqueue")
 		for _, rec := range records {
 			s.ingest.Enqueue(rec)
 		}
 		enqueueSpan.End()
-	} else {
-		for _, rec := range records {
-			s.ingest.Enqueue(rec)
-		}
 	}
 
 	// Return ExportTraceServiceResponse.


### PR DESCRIPTION
Self-instrument spans (from the pod's own OTel SDK) were funnelled into the TraceBuffer and silently dropped by the 1-in-1000 default sample ratio. Added an early-exit path that enqueues self-instrument spans directly, bypassing TraceBuffer sampling entirely.