### PR TITLE
feat(cli): add username/password session login to sb

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,8 +191,10 @@ go install github.com/wiebe-xyz/spanbarn/cmd/sb@latest
 ### Usage
 
 ```bash
-# Authenticate with a read-scoped API key (see apikey create above)
+# Authenticate — either a read-scoped API key (see apikey create above)
 sb login --url https://spanbarn.example.com --api-key KEY
+# ...or your dashboard username/password (prompts for the password):
+sb login --url https://spanbarn.example.com --username admin
 
 # Pin a project for the current directory (writes .spanbarn.json)
 sb init --project my-app

--- a/cmd/sb/client.go
+++ b/cmd/sb/client.go
@@ -36,12 +36,19 @@ func newClient() (*Client, error) {
 
 // get performs a raw GET and returns the response body as JSON.
 func (c *Client) get(path string) (json.RawMessage, error) {
+	return c.getRetry(path, false)
+}
+
+func (c *Client) getRetry(path string, retried bool) (json.RawMessage, error) {
 	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
 	if err != nil {
 		return nil, err
 	}
+	// API key takes precedence; otherwise use the session token as a bearer.
 	if c.cfg.APIKey != "" {
 		req.Header.Set("X-SpanBarn-Api-Key", c.cfg.APIKey)
+	} else if c.cfg.SessionToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.cfg.SessionToken)
 	}
 
 	resp, err := c.http.Do(req)
@@ -53,6 +60,17 @@ func (c *Client) get(path string) (json.RawMessage, error) {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	// Session expired? Re-authenticate once with stored credentials.
+	if resp.StatusCode == http.StatusUnauthorized && !retried &&
+		c.cfg.APIKey == "" && c.cfg.Username != "" && c.cfg.Password != "" {
+		token, lerr := loginWithPassword(c.base, c.cfg.Username, c.cfg.Password)
+		if lerr == nil {
+			c.cfg.SessionToken = token
+			_ = saveConfig(c.cfg)
+			return c.getRetry(path, true)
+		}
 	}
 
 	if resp.StatusCode >= 400 {

--- a/cmd/sb/commands.go
+++ b/cmd/sb/commands.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // commonFlags registers the flags shared by every data command: --output and
@@ -57,6 +61,8 @@ func cmdLogin(args []string) error {
 	fs := flag.NewFlagSet("login", flag.ContinueOnError)
 	urlFlag := fs.String("url", os.Getenv("SPANBARN_URL"), "SpanBarn instance URL")
 	apiKey := fs.String("api-key", os.Getenv("SPANBARN_API_KEY"), "read-scoped API key")
+	username := fs.String("username", os.Getenv("SPANBARN_USERNAME"), "dashboard username (session login)")
+	password := fs.String("password", "", "dashboard password (omit to be prompted)")
 	project := fs.String("project", "", "default project slug")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -64,17 +70,35 @@ func cmdLogin(args []string) error {
 	if *urlFlag == "" {
 		return fmt.Errorf("--url is required (or set SPANBARN_URL)")
 	}
-	if *apiKey == "" {
-		return fmt.Errorf("--api-key is required (or set SPANBARN_API_KEY); create one with: spanbarn apikey create --project SLUG --name cli --scope read")
-	}
 
 	cfg := Config{
 		URL:     strings.TrimRight(*urlFlag, "/"),
-		APIKey:  *apiKey,
 		Project: *project,
 	}
 
-	// Verify the key works against a read endpoint.
+	switch {
+	case *apiKey != "":
+		cfg.APIKey = *apiKey
+	case *username != "":
+		if *password == "" {
+			pw, err := promptPassword()
+			if err != nil {
+				return err
+			}
+			*password = pw
+		}
+		token, err := loginWithPassword(cfg.URL, *username, *password)
+		if err != nil {
+			return err
+		}
+		cfg.Username = *username
+		cfg.Password = *password
+		cfg.SessionToken = token
+	default:
+		return fmt.Errorf("provide --api-key (scope read/full) or --username to authenticate")
+	}
+
+	// Verify auth works against a read endpoint.
 	client := &Client{base: cfg.URL, http: &http.Client{Timeout: 10 * time.Second}, cfg: cfg}
 	if _, err := client.get("/api/v1/projects"); err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
@@ -83,9 +107,46 @@ func cmdLogin(args []string) error {
 	if err := saveConfig(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "Logged in to %s\n", cfg.URL)
-	writeOut(map[string]any{"ok": true, "url": cfg.URL})
+	method := "api-key"
+	if cfg.APIKey == "" {
+		method = "session"
+	}
+	fmt.Fprintf(os.Stderr, "Logged in to %s (%s)\n", cfg.URL, method)
+	writeOut(map[string]any{"ok": true, "url": cfg.URL, "auth": method})
 	return nil
+}
+
+// loginWithPassword posts credentials to /api/v1/login and returns the session
+// token from the Set-Cookie response.
+func loginWithPassword(baseURL, username, password string) (string, error) {
+	body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+	resp, err := http.Post(baseURL+"/api/v1/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("login request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("login failed: HTTP %d", resp.StatusCode)
+	}
+	for _, ck := range resp.Cookies() {
+		if ck.Name == "session" {
+			return ck.Value, nil
+		}
+	}
+	return "", fmt.Errorf("no session cookie in login response")
+}
+
+// promptPassword reads a password from the terminal without echoing.
+func promptPassword() (string, error) {
+	fmt.Fprint(os.Stderr, "Password: ")
+	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return "", fmt.Errorf("read password: %w", err)
+	}
+	return string(pw), nil
 }
 
 func cmdInit(args []string) error {

--- a/cmd/sb/config.go
+++ b/cmd/sb/config.go
@@ -8,12 +8,20 @@ import (
 )
 
 // Config is the global CLI config stored at ~/.config/spanbarn/cli.json
-// (override with SB_CONFIG). Auth is a read-scoped API key — query endpoints
-// accept it via the X-SpanBarn-Api-Key header.
+// (override with SB_CONFIG). Two auth methods are supported:
+//   - a read-scoped API key sent via the X-SpanBarn-Api-Key header, or
+//   - username/password login (POST /api/v1/login) which yields a session
+//     token sent as Authorization: Bearer. The password is stored so the CLI
+//     can transparently re-authenticate when the session expires.
+//
+// When an API key is set it takes precedence over session credentials.
 type Config struct {
-	URL     string `json:"url"`
-	APIKey  string `json:"api_key,omitempty"`
-	Project string `json:"project,omitempty"` // default project slug
+	URL          string `json:"url"`
+	APIKey       string `json:"api_key,omitempty"`
+	Username     string `json:"username,omitempty"`
+	Password     string `json:"password,omitempty"`
+	SessionToken string `json:"session_token,omitempty"`
+	Project      string `json:"project,omitempty"` // default project slug
 }
 
 func configPath() string {
@@ -31,7 +39,7 @@ func loadConfig() (Config, error) {
 	data, err := os.ReadFile(configPath())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return Config{}, fmt.Errorf("not logged in — run: sb login --url URL --api-key KEY")
+			return Config{}, fmt.Errorf("not logged in — run: sb login --url URL (--api-key KEY | --username USER)")
 		}
 		return Config{}, err
 	}
@@ -40,7 +48,7 @@ func loadConfig() (Config, error) {
 		return Config{}, fmt.Errorf("corrupt config: %w", err)
 	}
 	if cfg.URL == "" {
-		return Config{}, fmt.Errorf("no URL configured — run: sb login --url URL --api-key KEY")
+		return Config{}, fmt.Errorf("no URL configured — run: sb login --url URL (--api-key KEY | --username USER)")
 	}
 	return cfg, nil
 }

--- a/cmd/sb/main.go
+++ b/cmd/sb/main.go
@@ -74,7 +74,7 @@ func printUsage() {
 Usage: sb <command> [flags]
 
 Setup:
-  login         Authenticate with a SpanBarn instance (--url, --api-key)
+  login         Authenticate (--url with --api-key, or --username/--password)
   init          Set the project for this directory (writes .spanbarn.json)
   projects      List projects
 
@@ -97,6 +97,7 @@ Common flags: --project SLUG, --from, --to, --output json|table
 
 Examples:
   sb login --url https://spanbarn.example.com --api-key KEY
+  sb login --url https://spanbarn.example.com --username admin   # prompts for password
   sb init --project my-app
   sb flows --errors
   sb traces --errors --service api --limit 20

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	modernc.org/sqlite v1.50.0
@@ -71,7 +72,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,10 @@ golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=


### PR DESCRIPTION
Adds dashboard username/password login to the `sb` CLI (mirrors `bb`): `sb login --username USER` posts to `/api/v1/login`, stores the session token (and password, in the 0600 config) and sends it as `Authorization: Bearer`; auto re-auths on 401. API key still takes precedence when set. Verified end-to-end against a local server (login, projects, traces, and 401 re-auth).