### PR TITLE
feat: IamBarn OAuth login for sb (resource server + device/M2M)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,12 @@ go install github.com/wiebe-xyz/spanbarn/cmd/sb@latest
 ### Usage
 
 ```bash
-# Authenticate — either a read-scoped API key (see apikey create above)
-sb login --url https://spanbarn.example.com --api-key KEY
-# ...or your dashboard username/password (prompts for the password):
-sb login --url https://spanbarn.example.com --username admin
+# Authenticate — pick one:
+sb login --url https://spanbarn.example.com --api-key KEY        # read-scoped API key
+sb login --url https://spanbarn.example.com --oidc               # IamBarn SSO (approve in browser)
+sb login --url https://spanbarn.example.com \
+  --client-id IMC_ID --client-secret SECRET                      # IamBarn M2M (agents/CI)
+sb login --url https://spanbarn.example.com --username admin     # local password (prompts)
 
 # Pin a project for the current directory (writes .spanbarn.json)
 sb init --project my-app

--- a/cmd/sb/client.go
+++ b/cmd/sb/client.go
@@ -40,14 +40,25 @@ func (c *Client) get(path string) (json.RawMessage, error) {
 }
 
 func (c *Client) getRetry(path string, retried bool) (json.RawMessage, error) {
+	// Proactively refresh an OIDC access token that is known to be expired.
+	if !retried && c.cfg.APIKey == "" && c.cfg.AccessToken != "" &&
+		c.cfg.TokenExpiry > 0 && time.Now().Unix() >= c.cfg.TokenExpiry {
+		if err := refreshOIDCToken(&c.cfg); err == nil {
+			_ = saveConfig(c.cfg)
+		}
+	}
+
 	req, err := http.NewRequest(http.MethodGet, c.base+path, nil)
 	if err != nil {
 		return nil, err
 	}
-	// API key takes precedence; otherwise use the session token as a bearer.
-	if c.cfg.APIKey != "" {
+	// Precedence: API key, then OIDC access token, then session token.
+	switch {
+	case c.cfg.APIKey != "":
 		req.Header.Set("X-SpanBarn-Api-Key", c.cfg.APIKey)
-	} else if c.cfg.SessionToken != "" {
+	case c.cfg.AccessToken != "":
+		req.Header.Set("Authorization", "Bearer "+c.cfg.AccessToken)
+	case c.cfg.SessionToken != "":
 		req.Header.Set("Authorization", "Bearer "+c.cfg.SessionToken)
 	}
 
@@ -62,14 +73,20 @@ func (c *Client) getRetry(path string, retried bool) (json.RawMessage, error) {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
-	// Session expired? Re-authenticate once with stored credentials.
-	if resp.StatusCode == http.StatusUnauthorized && !retried &&
-		c.cfg.APIKey == "" && c.cfg.Username != "" && c.cfg.Password != "" {
-		token, lerr := loginWithPassword(c.base, c.cfg.Username, c.cfg.Password)
-		if lerr == nil {
-			c.cfg.SessionToken = token
-			_ = saveConfig(c.cfg)
-			return c.getRetry(path, true)
+	// Expired credentials? Re-authenticate once and retry.
+	if resp.StatusCode == http.StatusUnauthorized && !retried && c.cfg.APIKey == "" {
+		switch {
+		case c.cfg.AuthType == "oidc-device" || c.cfg.AuthType == "oidc-m2m":
+			if err := refreshOIDCToken(&c.cfg); err == nil {
+				_ = saveConfig(c.cfg)
+				return c.getRetry(path, true)
+			}
+		case c.cfg.Username != "" && c.cfg.Password != "":
+			if token, lerr := loginWithPassword(c.base, c.cfg.Username, c.cfg.Password); lerr == nil {
+				c.cfg.SessionToken = token
+				_ = saveConfig(c.cfg)
+				return c.getRetry(path, true)
+			}
 		}
 	}
 

--- a/cmd/sb/commands.go
+++ b/cmd/sb/commands.go
@@ -63,6 +63,10 @@ func cmdLogin(args []string) error {
 	apiKey := fs.String("api-key", os.Getenv("SPANBARN_API_KEY"), "read-scoped API key")
 	username := fs.String("username", os.Getenv("SPANBARN_USERNAME"), "dashboard username (session login)")
 	password := fs.String("password", "", "dashboard password (omit to be prompted)")
+	oidc := fs.Bool("oidc", false, "log in via IamBarn device-code flow (browser approval)")
+	clientID := fs.String("client-id", os.Getenv("SPANBARN_OIDC_CLIENT_ID"), "IamBarn M2M client id (client_credentials)")
+	clientSecret := fs.String("client-secret", os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"), "IamBarn M2M client secret")
+	scope := fs.String("scope", "", "OAuth scope for M2M login (optional)")
 	project := fs.String("project", "", "default project slug")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -76,9 +80,21 @@ func cmdLogin(args []string) error {
 		Project: *project,
 	}
 
+	var method string
 	switch {
 	case *apiKey != "":
 		cfg.APIKey = *apiKey
+		method = "api-key"
+	case *clientID != "" && *clientSecret != "":
+		if err := clientCredentialsLogin(&cfg, "", *clientID, *clientSecret, *scope); err != nil {
+			return err
+		}
+		method = "oidc-m2m"
+	case *oidc:
+		if err := deviceLogin(&cfg); err != nil {
+			return err
+		}
+		method = "oidc-device"
 	case *username != "":
 		if *password == "" {
 			pw, err := promptPassword()
@@ -94,8 +110,9 @@ func cmdLogin(args []string) error {
 		cfg.Username = *username
 		cfg.Password = *password
 		cfg.SessionToken = token
+		method = "session"
 	default:
-		return fmt.Errorf("provide --api-key (scope read/full) or --username to authenticate")
+		return fmt.Errorf("provide one of: --api-key, --oidc (IamBarn device login), --client-id/--client-secret (M2M), or --username")
 	}
 
 	// Verify auth works against a read endpoint.
@@ -104,12 +121,8 @@ func cmdLogin(args []string) error {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
 
-	if err := saveConfig(cfg); err != nil {
+	if err := saveConfig(client.cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)
-	}
-	method := "api-key"
-	if cfg.APIKey == "" {
-		method = "session"
 	}
 	fmt.Fprintf(os.Stderr, "Logged in to %s (%s)\n", cfg.URL, method)
 	writeOut(map[string]any{"ok": true, "url": cfg.URL, "auth": method})

--- a/cmd/sb/config.go
+++ b/cmd/sb/config.go
@@ -8,20 +8,32 @@ import (
 )
 
 // Config is the global CLI config stored at ~/.config/spanbarn/cli.json
-// (override with SB_CONFIG). Two auth methods are supported:
-//   - a read-scoped API key sent via the X-SpanBarn-Api-Key header, or
-//   - username/password login (POST /api/v1/login) which yields a session
-//     token sent as Authorization: Bearer. The password is stored so the CLI
-//     can transparently re-authenticate when the session expires.
-//
-// When an API key is set it takes precedence over session credentials.
+// (override with SB_CONFIG). Several auth methods are supported, tried in this
+// order of precedence: API key, then OIDC access token, then session.
+//   - read-scoped API key (X-SpanBarn-Api-Key), or
+//   - IamBarn OIDC login (device-code or client-credentials) yielding an access
+//     token sent as Authorization: Bearer; refreshed/re-fetched on expiry, or
+//   - username/password login (POST /api/v1/login) yielding a session token,
+//     also sent as Authorization: Bearer.
 type Config struct {
-	URL          string `json:"url"`
-	APIKey       string `json:"api_key,omitempty"`
+	URL     string `json:"url"`
+	Project string `json:"project,omitempty"` // default project slug
+
+	APIKey string `json:"api_key,omitempty"`
+
+	// Local password session.
 	Username     string `json:"username,omitempty"`
 	Password     string `json:"password,omitempty"`
 	SessionToken string `json:"session_token,omitempty"`
-	Project      string `json:"project,omitempty"` // default project slug
+
+	// IamBarn OIDC. AuthType is "oidc-device" or "oidc-m2m" when in use.
+	AuthType         string `json:"auth_type,omitempty"`
+	OIDCIssuer       string `json:"oidc_issuer,omitempty"`
+	OIDCClientID     string `json:"oidc_client_id,omitempty"`
+	OIDCClientSecret string `json:"oidc_client_secret,omitempty"` // m2m only
+	AccessToken      string `json:"access_token,omitempty"`
+	RefreshToken     string `json:"refresh_token,omitempty"` // device only
+	TokenExpiry      int64  `json:"token_expiry,omitempty"`  // unix seconds
 }
 
 func configPath() string {

--- a/cmd/sb/main.go
+++ b/cmd/sb/main.go
@@ -74,7 +74,8 @@ func printUsage() {
 Usage: sb <command> [flags]
 
 Setup:
-  login         Authenticate (--url with --api-key, or --username/--password)
+  login         Authenticate: --api-key, --oidc (IamBarn browser login),
+                --client-id/--client-secret (M2M), or --username/--password
   init          Set the project for this directory (writes .spanbarn.json)
   projects      List projects
 
@@ -97,7 +98,9 @@ Common flags: --project SLUG, --from, --to, --output json|table
 
 Examples:
   sb login --url https://spanbarn.example.com --api-key KEY
-  sb login --url https://spanbarn.example.com --username admin   # prompts for password
+  sb login --url https://spanbarn.example.com --oidc            # IamBarn, approve in browser
+  sb login --url https://spanbarn.example.com --client-id ID --client-secret SECRET  # M2M
+  sb login --url https://spanbarn.example.com --username admin  # prompts for password
   sb init --project my-app
   sb flows --errors
   sb traces --errors --service api --limit 20

--- a/cmd/sb/oauth.go
+++ b/cmd/sb/oauth.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const oidcScope = "openid profile email offline_access"
+
+// oidcDiscovery is the subset of the issuer's discovery document the CLI needs.
+type oidcDiscovery struct {
+	TokenEndpoint       string `json:"token_endpoint"`
+	DeviceAuthEndpoint  string `json:"device_authorization_endpoint"`
+	AuthorizationEndpnt string `json:"authorization_endpoint"`
+}
+
+// spanbarnOIDCConfig is the OIDC block from SpanBarn's /api/v1/client-config.
+type spanbarnOIDCConfig struct {
+	Issuer      string
+	CLIClientID string
+}
+
+// tokenResponse is the OAuth2 token endpoint response (success or error).
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	TokenType        string `json:"token_type"`
+	ExpiresIn        int64  `json:"expires_in"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func httpClient() *http.Client { return &http.Client{Timeout: 30 * time.Second} }
+
+// fetchSpanbarnOIDC reads issuer + cli_client_id from SpanBarn's public
+// client-config so `sb login --oidc` only needs --url.
+func fetchSpanbarnOIDC(base string) (spanbarnOIDCConfig, error) {
+	resp, err := httpClient().Get(strings.TrimRight(base, "/") + "/api/v1/client-config")
+	if err != nil {
+		return spanbarnOIDCConfig{}, fmt.Errorf("fetch client-config: %w", err)
+	}
+	defer resp.Body.Close()
+	var cc struct {
+		OIDC struct {
+			Enabled     bool   `json:"enabled"`
+			Issuer      string `json:"issuer"`
+			CLIClientID string `json:"cli_client_id"`
+		} `json:"oidc"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&cc); err != nil {
+		return spanbarnOIDCConfig{}, fmt.Errorf("decode client-config: %w", err)
+	}
+	if !cc.OIDC.Enabled || cc.OIDC.Issuer == "" {
+		return spanbarnOIDCConfig{}, fmt.Errorf("this SpanBarn instance does not have OIDC enabled")
+	}
+	return spanbarnOIDCConfig{Issuer: cc.OIDC.Issuer, CLIClientID: cc.OIDC.CLIClientID}, nil
+}
+
+func discoverOIDC(issuer string) (oidcDiscovery, error) {
+	resp, err := httpClient().Get(strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration")
+	if err != nil {
+		return oidcDiscovery{}, fmt.Errorf("oidc discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	var d oidcDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&d); err != nil {
+		return oidcDiscovery{}, fmt.Errorf("decode discovery: %w", err)
+	}
+	if d.TokenEndpoint == "" {
+		return oidcDiscovery{}, fmt.Errorf("issuer %q has no token_endpoint", issuer)
+	}
+	return d, nil
+}
+
+// deviceLogin runs the RFC 8628 device authorization grant against the SpanBarn
+// instance's IamBarn issuer and fills the OIDC fields of cfg on success.
+func deviceLogin(cfg *Config) error {
+	sc, err := fetchSpanbarnOIDC(cfg.URL)
+	if err != nil {
+		return err
+	}
+	if sc.CLIClientID == "" {
+		return fmt.Errorf("this SpanBarn instance has no oidc.cli_client_id configured; ask the operator to set SPANBARN_OIDC_CLI_CLIENT_ID")
+	}
+	disco, err := discoverOIDC(sc.Issuer)
+	if err != nil {
+		return err
+	}
+	if disco.DeviceAuthEndpoint == "" {
+		return fmt.Errorf("issuer %q does not support the device authorization grant", sc.Issuer)
+	}
+
+	// 1. Request a device + user code.
+	form := url.Values{"client_id": {sc.CLIClientID}, "scope": {oidcScope}}
+	resp, err := httpClient().PostForm(disco.DeviceAuthEndpoint, form)
+	if err != nil {
+		return fmt.Errorf("device authorization: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("device authorization failed: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var da struct {
+		DeviceCode              string `json:"device_code"`
+		UserCode                string `json:"user_code"`
+		VerificationURI         string `json:"verification_uri"`
+		VerificationURIComplete string `json:"verification_uri_complete"`
+		ExpiresIn               int64  `json:"expires_in"`
+		Interval                int64  `json:"interval"`
+	}
+	if err := json.Unmarshal(body, &da); err != nil {
+		return fmt.Errorf("decode device authorization: %w", err)
+	}
+
+	fmt.Fprintf(os.Stderr, "\nTo sign in, open:\n  %s\n", da.VerificationURI)
+	fmt.Fprintf(os.Stderr, "and enter code:  %s\n", da.UserCode)
+	if da.VerificationURIComplete != "" {
+		fmt.Fprintf(os.Stderr, "(or open directly: %s)\n", da.VerificationURIComplete)
+	}
+	fmt.Fprintln(os.Stderr, "\nWaiting for approval…")
+
+	// 2. Poll the token endpoint.
+	interval := da.Interval
+	if interval <= 0 {
+		interval = 5
+	}
+	deadline := time.Now().Add(time.Duration(da.ExpiresIn) * time.Second)
+	if da.ExpiresIn == 0 {
+		deadline = time.Now().Add(10 * time.Minute)
+	}
+	for time.Now().Before(deadline) {
+		time.Sleep(time.Duration(interval) * time.Second)
+		tok, err := postToken(disco.TokenEndpoint, url.Values{
+			"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
+			"device_code": {da.DeviceCode},
+			"client_id":   {sc.CLIClientID},
+		}, "", "")
+		if err != nil {
+			return err
+		}
+		switch tok.Error {
+		case "":
+			cfg.AuthType = "oidc-device"
+			cfg.OIDCIssuer = sc.Issuer
+			cfg.OIDCClientID = sc.CLIClientID
+			applyToken(cfg, tok)
+			return nil
+		case "authorization_pending":
+			continue
+		case "slow_down":
+			interval += 5
+		default:
+			return fmt.Errorf("device login failed: %s (%s)", tok.Error, tok.ErrorDescription)
+		}
+	}
+	return fmt.Errorf("device login timed out before approval")
+}
+
+// clientCredentialsLogin performs the M2M client_credentials grant.
+func clientCredentialsLogin(cfg *Config, issuer, clientID, clientSecret, scope string) error {
+	if issuer == "" {
+		sc, err := fetchSpanbarnOIDC(cfg.URL)
+		if err != nil {
+			return err
+		}
+		issuer = sc.Issuer
+	}
+	disco, err := discoverOIDC(issuer)
+	if err != nil {
+		return err
+	}
+	form := url.Values{"grant_type": {"client_credentials"}}
+	if scope != "" {
+		form.Set("scope", scope)
+	}
+	tok, err := postToken(disco.TokenEndpoint, form, clientID, clientSecret)
+	if err != nil {
+		return err
+	}
+	if tok.Error != "" {
+		return fmt.Errorf("client_credentials failed: %s (%s)", tok.Error, tok.ErrorDescription)
+	}
+	cfg.AuthType = "oidc-m2m"
+	cfg.OIDCIssuer = issuer
+	cfg.OIDCClientID = clientID
+	cfg.OIDCClientSecret = clientSecret
+	applyToken(cfg, tok)
+	return nil
+}
+
+// refreshOIDCToken obtains a fresh access token for an expired session, using
+// the refresh token (device) or re-running client_credentials (m2m).
+func refreshOIDCToken(cfg *Config) error {
+	disco, err := discoverOIDC(cfg.OIDCIssuer)
+	if err != nil {
+		return err
+	}
+	switch cfg.AuthType {
+	case "oidc-m2m":
+		return clientCredentialsLogin(cfg, cfg.OIDCIssuer, cfg.OIDCClientID, cfg.OIDCClientSecret, "")
+	case "oidc-device":
+		if cfg.RefreshToken == "" {
+			return fmt.Errorf("session expired and no refresh token; run: sb login --oidc")
+		}
+		tok, err := postToken(disco.TokenEndpoint, url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {cfg.RefreshToken},
+			"client_id":     {cfg.OIDCClientID},
+		}, "", "")
+		if err != nil {
+			return err
+		}
+		if tok.Error != "" {
+			return fmt.Errorf("token refresh failed: %s; run: sb login --oidc", tok.Error)
+		}
+		applyToken(cfg, tok)
+		return nil
+	default:
+		return fmt.Errorf("not an OIDC session")
+	}
+}
+
+// postToken posts a form to the token endpoint, optionally with HTTP Basic
+// client authentication (client_secret_basic).
+func postToken(endpoint string, form url.Values, clientID, clientSecret string) (tokenResponse, error) {
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return tokenResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	if clientID != "" {
+		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return tokenResponse{}, fmt.Errorf("token request: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return tokenResponse{}, fmt.Errorf("decode token response (HTTP %d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return tr, nil
+}
+
+// applyToken stores a token response into cfg.
+func applyToken(cfg *Config, tok tokenResponse) {
+	cfg.AccessToken = tok.AccessToken
+	if tok.RefreshToken != "" {
+		cfg.RefreshToken = tok.RefreshToken
+	}
+	if tok.ExpiresIn > 0 {
+		cfg.TokenExpiry = time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second).Unix()
+	} else {
+		cfg.TokenExpiry = 0
+	}
+}

--- a/cmd/sb/oauth_test.go
+++ b/cmd/sb/oauth_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeIssuer serves SpanBarn client-config + OIDC discovery + token/device
+// endpoints on one mux, enough to drive the CLI's OAuth flows. The access
+// tokens are opaque strings (the CLI doesn't validate them).
+func fakeIssuer(t *testing.T) (*httptest.Server, *fakeState) {
+	t.Helper()
+	st := &fakeState{}
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/api/v1/client-config", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"oidc": map[string]any{"enabled": true, "issuer": srv.URL, "cli_client_id": "spanbarn-cli"},
+		})
+	})
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                        srv.URL,
+			"token_endpoint":                srv.URL + "/oauth2/token",
+			"device_authorization_endpoint": srv.URL + "/oauth2/device_authorization",
+			"authorization_endpoint":        srv.URL + "/oauth2/authorize",
+		})
+	})
+	mux.HandleFunc("/oauth2/device_authorization", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"device_code": "dev-123", "user_code": "WXYZ-1234",
+			"verification_uri": srv.URL + "/device", "expires_in": 60, "interval": 1,
+		})
+	})
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		st.lastGrant = r.Form.Get("grant_type")
+		switch st.lastGrant {
+		case "client_credentials":
+			u, p, ok := r.BasicAuth()
+			st.basicUser, st.basicOK = u, ok
+			_ = p
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "m2m-token", "token_type": "Bearer", "expires_in": 3600})
+		case "urn:ietf:params:oauth:grant-type:device_code":
+			st.devicePolls++
+			if st.devicePolls < 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": "authorization_pending"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "device-token", "refresh_token": "refresh-1", "expires_in": 3600})
+		case "refresh_token":
+			_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "device-token-2", "refresh_token": "refresh-2", "expires_in": 3600})
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "unsupported_grant_type"})
+		}
+	})
+	return srv, st
+}
+
+type fakeState struct {
+	lastGrant   string
+	basicUser   string
+	basicOK     bool
+	devicePolls int
+}
+
+func TestClientCredentialsLogin(t *testing.T) {
+	srv, st := fakeIssuer(t)
+	cfg := Config{URL: srv.URL}
+	if err := clientCredentialsLogin(&cfg, "", "imc_x", "secret", "openid"); err != nil {
+		t.Fatalf("m2m login: %v", err)
+	}
+	if cfg.AccessToken != "m2m-token" || cfg.AuthType != "oidc-m2m" {
+		t.Errorf("unexpected cfg: %+v", cfg)
+	}
+	if !st.basicOK || st.basicUser == "" {
+		t.Error("expected client_secret_basic auth")
+	}
+	if cfg.TokenExpiry == 0 {
+		t.Error("expected token expiry to be set")
+	}
+}
+
+func TestDeviceLogin(t *testing.T) {
+	srv, st := fakeIssuer(t)
+	cfg := Config{URL: srv.URL}
+	if err := deviceLogin(&cfg); err != nil {
+		t.Fatalf("device login: %v", err)
+	}
+	if cfg.AccessToken != "device-token" || cfg.RefreshToken != "refresh-1" || cfg.AuthType != "oidc-device" {
+		t.Errorf("unexpected cfg: %+v", cfg)
+	}
+	if st.devicePolls < 2 {
+		t.Errorf("expected polling through authorization_pending, got %d polls", st.devicePolls)
+	}
+	if cfg.OIDCClientID != "spanbarn-cli" {
+		t.Errorf("expected cli client id, got %q", cfg.OIDCClientID)
+	}
+}
+
+func TestRefreshOIDCToken_Device(t *testing.T) {
+	srv, _ := fakeIssuer(t)
+	cfg := Config{
+		URL: srv.URL, AuthType: "oidc-device", OIDCIssuer: srv.URL,
+		OIDCClientID: "spanbarn-cli", RefreshToken: "refresh-1", AccessToken: "old",
+	}
+	if err := refreshOIDCToken(&cfg); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if cfg.AccessToken != "device-token-2" || cfg.RefreshToken != "refresh-2" {
+		t.Errorf("expected rotated tokens, got %+v", cfg)
+	}
+}
+
+func TestDeviceLogin_OIDCDisabled(t *testing.T) {
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	mux.HandleFunc("/api/v1/client-config", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{}) // no oidc block
+	})
+	cfg := Config{URL: srv.URL}
+	if err := deviceLogin(&cfg); err == nil {
+		t.Fatal("expected error when OIDC is not enabled")
+	}
+}

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -809,16 +809,23 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 // not crash the process.
 func buildOIDCClient(cfg config.Config, logger *slog.Logger) *auth.OIDCClient {
 	oc := auth.OIDCConfig{
-		Issuer:        cfg.OIDCIssuer,
-		ClientID:      cfg.OIDCClientID,
-		ClientSecret:  cfg.OIDCClientSecret,
-		RedirectURL:   cfg.OIDCRedirectURL,
-		RequiredGroup: cfg.OIDCRequiredGroup,
+		Issuer:            cfg.OIDCIssuer,
+		ClientID:          cfg.OIDCClientID,
+		ClientSecret:      cfg.OIDCClientSecret,
+		RedirectURL:       cfg.OIDCRedirectURL,
+		RequiredGroup:     cfg.OIDCRequiredGroup,
+		ResourceAudiences: cfg.OIDCResourceAudiences,
+		CLIClientID:       cfg.OIDCCLIClientID,
+	}
+	// The sb CLI's device-code tokens carry the CLI client id as their
+	// audience, so accept it as a resource audience automatically.
+	if cfg.OIDCCLIClientID != "" {
+		oc.ResourceAudiences = append(oc.ResourceAudiences, cfg.OIDCCLIClientID)
 	}
 	if !oc.Enabled() {
 		return nil
 	}
-	logger.Info("oidc: enabled", "issuer", oc.Issuer, "client_id", oc.ClientID, "required_group", oc.RequiredGroup)
+	logger.Info("oidc: enabled", "issuer", oc.Issuer, "client_id", oc.ClientID, "required_group", oc.RequiredGroup, "resource_audiences", oc.ResourceAudiences)
 	return auth.NewOIDCClient(oc)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.19.0
@@ -42,7 +43,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -80,56 +80,91 @@ func APIKeyMiddleware(authorizer *auth.Authorizer) func(http.Handler) http.Handl
 	}
 }
 
-// SessionOrReadKey authorizes read/query endpoints with EITHER a session
-// (cookie or Authorization: Bearer) OR an API key with the "read" or "full"
-// scope. When an API key is presented, the request is scoped to that key's
-// project by overwriting the project_id query parameter, so downstream handlers
-// need no changes. Ingest-scoped keys are rejected with 403.
+// SessionOrReadKey authorizes read/query endpoints with any of:
+//   - an API key with the "read" or "full" scope (X-SpanBarn-Api-Key), or
+//   - an IamBarn access-token JWT (Authorization: Bearer <jwt>) when OIDC is
+//     configured, validated as a resource server and authorized by role/group, or
+//   - a SpanBarn session (cookie or Authorization: Bearer <hmac>).
 //
-// When authorizer is nil (no API key auth configured), behaviour is identical
-// to SessionMiddleware.
-func SessionOrReadKey(sm *auth.SessionManager, authorizer *auth.Authorizer) func(http.Handler) http.Handler {
+// When an API key is presented, the request is scoped to that key's project by
+// overwriting the project_id query parameter. Ingest-scoped keys are rejected
+// with 403. oidcFn is resolved at request time because the OIDC client is wired
+// after routes are registered; it may return nil. When authorizer is nil,
+// behaviour falls back to JWT/session.
+func SessionOrReadKey(sm *auth.SessionManager, authorizer *auth.Authorizer, oidcFn func() *auth.OIDCClient) func(http.Handler) http.Handler {
 	sessionMW := SessionMiddleware(sm)
 	return func(next http.Handler) http.Handler {
 		session := sessionMW(next)
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			key := r.Header.Get("X-SpanBarn-Api-Key")
-			if key == "" || authorizer == nil {
-				session.ServeHTTP(w, r)
+			if key := r.Header.Get("X-SpanBarn-Api-Key"); key != "" && authorizer != nil {
+				serveAPIKey(w, r, next, authorizer, key)
 				return
 			}
 
-			projectID, scope, err := authorizer.Authorize(key)
-			if err != nil {
-				writeError(w, http.StatusUnauthorized, "invalid API key", "")
-				return
-			}
-			if scope != "read" && scope != "full" {
-				writeError(w, http.StatusForbidden, "API key lacks read scope", "")
-				return
-			}
-			// API keys are read-only: never allow mutating requests, even on
-			// handlers that also serve writes for session users.
-			if r.Method != http.MethodGet && r.Method != http.MethodHead {
-				writeError(w, http.StatusForbidden, "API key is read-only", "")
-				return
+			// IamBarn access-token JWT (Bearer with two dots → header.payload.sig).
+			// A SpanBarn session token has a single dot, so this is unambiguous.
+			if oidcFn != nil {
+				if oc := oidcFn(); oc != nil {
+					if bearer := bearerToken(r); strings.Count(bearer, ".") == 2 {
+						claims, err := oc.VerifyAccessToken(r.Context(), bearer)
+						if err != nil {
+							writeError(w, http.StatusUnauthorized, "invalid or expired token", "")
+							return
+						}
+						if !oc.Allowed(claims) {
+							writeError(w, http.StatusForbidden, "not authorized for SpanBarn", "")
+							return
+						}
+						ctx := SetUsername(r.Context(), claims.PreferredName())
+						next.ServeHTTP(w, r.WithContext(ctx))
+						return
+					}
+				}
 			}
 
-			// Scope the request to the key's project. A non-zero project ID
-			// (a per-project key) overrides any client-supplied project_id so a
-			// key cannot read another project's data. The static/full key has
-			// project ID 0 (all projects); leave the query param untouched so
-			// it can target a specific project via project_id.
-			ctx := SetScope(r.Context(), scope)
-			if projectID != 0 {
-				ctx = SetProjectID(ctx, projectID)
-				q := r.URL.Query()
-				q.Set("project_id", strconv.FormatInt(projectID, 10))
-				r.URL.RawQuery = q.Encode()
-			}
-			next.ServeHTTP(w, r.WithContext(ctx))
+			session.ServeHTTP(w, r)
 		})
 	}
+}
+
+// serveAPIKey handles read/full API-key authentication and project scoping.
+func serveAPIKey(w http.ResponseWriter, r *http.Request, next http.Handler, authorizer *auth.Authorizer, key string) {
+	projectID, scope, err := authorizer.Authorize(key)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid API key", "")
+		return
+	}
+	if scope != "read" && scope != "full" {
+		writeError(w, http.StatusForbidden, "API key lacks read scope", "")
+		return
+	}
+	// API keys are read-only: never allow mutating requests, even on handlers
+	// that also serve writes for session users.
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		writeError(w, http.StatusForbidden, "API key is read-only", "")
+		return
+	}
+
+	// Scope the request to the key's project. A non-zero project ID (a
+	// per-project key) overrides any client-supplied project_id so a key cannot
+	// read another project's data. The static/full key has project ID 0 (all
+	// projects); leave the query param untouched so it can target a project.
+	ctx := SetScope(r.Context(), scope)
+	if projectID != 0 {
+		ctx = SetProjectID(ctx, projectID)
+		q := r.URL.Query()
+		q.Set("project_id", strconv.FormatInt(projectID, 10))
+		r.URL.RawQuery = q.Encode()
+	}
+	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// bearerToken returns the value of an Authorization: Bearer header, or "".
+func bearerToken(r *http.Request) string {
+	if ah := r.Header.Get("Authorization"); strings.HasPrefix(ah, "Bearer ") {
+		return strings.TrimPrefix(ah, "Bearer ")
+	}
+	return ""
 }
 
 // SessionMiddleware validates a session cookie or Authorization: Bearer token

--- a/internal/api/auth_middleware_test.go
+++ b/internal/api/auth_middleware_test.go
@@ -152,7 +152,7 @@ func TestSessionOrReadKey(t *testing.T) {
 	authorizer := auth.NewAuthorizer("", lookup, nil)
 
 	newHandler := func() http.Handler {
-		return SessionOrReadKey(sm, authorizer)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		return SessionOrReadKey(sm, authorizer, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_ = r
 		}))
@@ -164,7 +164,7 @@ func TestSessionOrReadKey(t *testing.T) {
 
 		var gotPID int64
 		var gotQueryPID string
-		handler := SessionOrReadKey(sm, authorizer)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := SessionOrReadKey(sm, authorizer, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotPID = GetProjectID(r.Context())
 			gotQueryPID = r.URL.Query().Get("project_id")
 			w.WriteHeader(http.StatusOK)
@@ -231,7 +231,7 @@ func TestSessionOrReadKey(t *testing.T) {
 
 	t.Run("session still works without key", func(t *testing.T) {
 		var gotUser string
-		handler := SessionOrReadKey(sm, authorizer)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler := SessionOrReadKey(sm, authorizer, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			gotUser = GetUsername(r.Context())
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -260,7 +260,7 @@ func TestSessionOrReadKey(t *testing.T) {
 	})
 
 	t.Run("nil authorizer falls back to session", func(t *testing.T) {
-		handler := SessionOrReadKey(sm, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handler := SessionOrReadKey(sm, nil, nil)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}))
 

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -37,11 +37,19 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 	if s.oidc != nil {
-		resp["oidc"] = map[string]any{
+		oc := s.oidc.Config()
+		issuer := strings.TrimRight(oc.Issuer, "/")
+		oidcCfg := map[string]any{
 			"enabled":  true,
 			"loginURL": "/api/v1/oidc/login",
+			"issuer":   issuer,
 		}
-		if issuer := strings.TrimRight(s.oidc.Config().Issuer, "/"); issuer != "" {
+		// The sb CLI uses this public client for the device-code login flow.
+		if oc.CLIClientID != "" {
+			oidcCfg["cli_client_id"] = oc.CLIClientID
+		}
+		resp["oidc"] = oidcCfg
+		if issuer != "" {
 			resp["iambarn"] = map[string]string{
 				"issuer":      issuer,
 				"profile_url": issuer + "/admin#profile",

--- a/internal/api/oidc_resource_middleware_test.go
+++ b/internal/api/oidc_resource_middleware_test.go
@@ -1,0 +1,136 @@
+package api
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
+)
+
+// newTestOIDC starts a minimal EdDSA OIDC issuer and returns a wired
+// OIDCClient plus a token signer, mirroring IamBarn for resource-server tests.
+func newTestOIDC(t *testing.T, audiences ...string) (*auth.OIDCClient, func(map[string]any) string, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	const kid = "k1"
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	issuer := srv.URL
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                issuer,
+			"authorization_endpoint":                issuer + "/authorize",
+			"token_endpoint":                        issuer + "/token",
+			"jwks_uri":                              issuer + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"EdDSA"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+			Key: pub, KeyID: kid, Algorithm: "EdDSA", Use: "sig",
+		}}})
+	})
+
+	oc := auth.NewOIDCClient(auth.OIDCConfig{Issuer: issuer, ClientID: "spanbarn-web", ResourceAudiences: audiences})
+
+	sign := func(claims map[string]any) string {
+		signer, err := jose.NewSigner(
+			jose.SigningKey{Algorithm: jose.EdDSA, Key: jose.JSONWebKey{Key: priv, KeyID: kid, Algorithm: "EdDSA"}},
+			(&jose.SignerOptions{}).WithType("JWT"))
+		if err != nil {
+			t.Fatalf("signer: %v", err)
+		}
+		payload, _ := json.Marshal(claims)
+		obj, err := signer.Sign(payload)
+		if err != nil {
+			t.Fatalf("sign: %v", err)
+		}
+		tok, _ := obj.CompactSerialize()
+		return tok
+	}
+	return oc, sign, issuer
+}
+
+func TestSessionOrReadKey_IamBarnJWT(t *testing.T) {
+	sm := auth.NewSessionManager("test-secret", 3600)
+	oc, sign, issuer := newTestOIDC(t, "spanbarn-cli")
+	oidcFn := func() *auth.OIDCClient { return oc }
+
+	var gotUser string
+	handler := SessionOrReadKey(sm, nil, oidcFn)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser = GetUsername(r.Context())
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	base := func() map[string]any {
+		return map[string]any{
+			"iss": issuer, "sub": "u1", "aud": []string{"spanbarn-cli"},
+			"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Unix(),
+			"token_use": "access_token", "roles": []string{"operator"},
+			"preferred_username": "wiebe",
+		}
+	}
+
+	t.Run("valid token reaches handler", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/traces", nil)
+		req.Header.Set("Authorization", "Bearer "+sign(base()))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+		if gotUser != "wiebe" {
+			t.Errorf("username = %q", gotUser)
+		}
+	})
+
+	t.Run("disallowed role → 403", func(t *testing.T) {
+		c := base()
+		c["roles"] = []string{"member"}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/traces", nil)
+		req.Header.Set("Authorization", "Bearer "+sign(c))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected 403, got %d", rec.Code)
+		}
+	})
+
+	t.Run("wrong audience → 401", func(t *testing.T) {
+		c := base()
+		c["aud"] = []string{"nope"}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/traces", nil)
+		req.Header.Set("Authorization", "Bearer "+sign(c))
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401, got %d", rec.Code)
+		}
+	})
+
+	t.Run("nil oidc falls back to session (JWT rejected as session)", func(t *testing.T) {
+		h := SessionOrReadKey(sm, nil, func() *auth.OIDCClient { return nil })(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/traces", nil)
+		req.Header.Set("Authorization", "Bearer "+sign(base()))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("expected 401 (no oidc, JWT not a valid session), got %d", rec.Code)
+		}
+	})
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -84,7 +84,7 @@ func (s *Server) registerRoutes() {
 	// List/aggregate endpoints get a short cache (30s); detail endpoints are not cached.
 	if s.querySvc != nil && s.sessionMgr != nil {
 		qh := &queryHandlers{svc: s.querySvc}
-		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer)
+		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer, s.oidcClient)
 		sessionAuth := SessionMiddleware(s.sessionMgr)
 		cache60 := func(h http.Handler) http.Handler { return cacheMiddleware(60, h) }
 
@@ -115,7 +115,7 @@ func (s *Server) registerRoutes() {
 	// Metrics query endpoints — rate limited + session auth required.
 	if s.repo != nil && s.sessionMgr != nil {
 		mqh := &metricsQueryHandlers{repo: s.repo}
-		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer)
+		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer, s.oidcClient)
 
 		s.mux.Handle("/api/v1/metrics/names", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricNames))))
 		s.mux.Handle("/api/v1/metrics/series", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricSeries))))
@@ -125,7 +125,7 @@ func (s *Server) registerRoutes() {
 	// per-user state, so they stay session-only.
 	if s.repo != nil && s.sessionMgr != nil {
 		lqh := &logsQueryHandlers{repo: s.repo}
-		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer)
+		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer, s.oidcClient)
 		sessionAuth := SessionMiddleware(s.sessionMgr)
 
 		s.mux.Handle("/api/v1/logs", apiRL(readAuth(http.HandlerFunc(lqh.handleLogs))))
@@ -201,7 +201,7 @@ func (s *Server) registerRoutes() {
 	// middleware blocks mutating methods for API keys.
 	if s.repo != nil && s.sessionMgr != nil {
 		ph := &projectHandlers{repo: s.repo, cache: s.cache}
-		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer)
+		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer, s.oidcClient)
 
 		s.mux.Handle("/api/v1/projects", apiRL(readAuth(ph)))
 		s.mux.Handle("/api/v1/projects/", apiRL(readAuth(ph)))

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -69,6 +69,11 @@ func (s *Server) SetOIDCClient(c *auth.OIDCClient) {
 	s.oidc = c
 }
 
+// oidcClient returns the wired OIDC adapter (may be nil). Used as the
+// request-time getter for SessionOrReadKey, since the adapter is set after
+// routes are registered.
+func (s *Server) oidcClient() *auth.OIDCClient { return s.oidc }
+
 // funnelBarnConfig captures the public bits of the FunnelBarn integration
 // that the SPA needs at boot. Empty Endpoint disables analytics.
 type funnelBarnConfig struct {

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -22,6 +22,17 @@ type OIDCConfig struct {
 	ClientSecret  string
 	RedirectURL   string // e.g. https://spanbarn.wiebe.xyz/api/v1/oidc/callback
 	RequiredGroup string // group slug that grants access; bypass roles always win
+
+	// ResourceAudiences lists the audiences accepted on IamBarn access-token
+	// JWTs when SpanBarn acts as an OAuth2 resource server (the `sb` CLI's
+	// device-code and client-credentials logins). An access token is accepted
+	// only if one of its `aud` values is in this list. ClientID is always
+	// included implicitly.
+	ResourceAudiences []string
+
+	// CLIClientID is the public IamBarn client the `sb` CLI uses for the
+	// device-code flow. Advertised to the CLI via /api/v1/client-config.
+	CLIClientID string
 }
 
 // Enabled reports whether all four required fields are present.
@@ -36,10 +47,11 @@ type OIDCClient struct {
 	cfg     OIDCConfig
 	timeout time.Duration
 
-	mu       sync.Mutex
-	provider *oidcv3.Provider
-	verifier *oidcv3.IDTokenVerifier
-	oauth    *oauth2.Config
+	mu             sync.Mutex
+	provider       *oidcv3.Provider
+	verifier       *oidcv3.IDTokenVerifier // ID tokens: aud must equal ClientID
+	accessVerifier *oidcv3.IDTokenVerifier // access tokens: aud checked manually
+	oauth          *oauth2.Config
 }
 
 // NewOIDCClient returns a client. Discovery is deferred to the first call so
@@ -109,6 +121,55 @@ func (c *OIDCClient) Exchange(ctx context.Context, code, nonce string) (OIDCClai
 	return r.Claims, err
 }
 
+// VerifyAccessToken validates an IamBarn access-token JWT (presented by the
+// `sb` CLI as a Bearer token) and returns its claims. It checks the signature
+// and issuer/expiry via the issuer's JWKS, requires token_use=="access_token",
+// and requires one of the token's audiences to be in ResourceAudiences (or to
+// equal the configured ClientID). Authorization (role/group) is left to the
+// caller via Allowed.
+func (c *OIDCClient) VerifyAccessToken(ctx context.Context, raw string) (OIDCClaims, error) {
+	if err := c.ensureReady(ctx); err != nil {
+		return OIDCClaims{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	tok, err := c.accessVerifier.Verify(ctx, raw)
+	if err != nil {
+		return OIDCClaims{}, fmt.Errorf("oidc: verify access token: %w", err)
+	}
+
+	allowed := append([]string{c.cfg.ClientID}, c.cfg.ResourceAudiences...)
+	if !audienceAllowed(tok.Audience, allowed) {
+		return OIDCClaims{}, fmt.Errorf("oidc: token audience %v not accepted", tok.Audience)
+	}
+
+	var claims OIDCClaims
+	if err := tok.Claims(&claims); err != nil {
+		return OIDCClaims{}, fmt.Errorf("oidc: decode access-token claims: %w", err)
+	}
+	if claims.TokenUse != "access_token" {
+		return OIDCClaims{}, errors.New("oidc: not an access token")
+	}
+	return claims, nil
+}
+
+// audienceAllowed reports whether any token audience appears in the allowlist
+// (ignoring empty entries).
+func audienceAllowed(tokenAud, allowed []string) bool {
+	for _, a := range allowed {
+		if a == "" {
+			continue
+		}
+		for _, t := range tokenAud {
+			if t == a {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Allowed returns true if the claims grant access to this barn.
 // Owner/organization_admin/operator roles bypass the group check.
 func (c *OIDCClient) Allowed(claims OIDCClaims) bool {
@@ -142,6 +203,10 @@ func (c *OIDCClient) ensureReady(ctx context.Context) error {
 	}
 	c.provider = prov
 	c.verifier = prov.Verifier(&oidcv3.Config{ClientID: c.cfg.ClientID})
+	// Access tokens carry the requesting client's id as aud (not SpanBarn's
+	// OIDC client id), so skip the built-in aud check and enforce our own
+	// ResourceAudiences allowlist in VerifyAccessToken.
+	c.accessVerifier = prov.Verifier(&oidcv3.Config{SkipClientIDCheck: true})
 	c.oauth = &oauth2.Config{
 		ClientID:     c.cfg.ClientID,
 		ClientSecret: c.cfg.ClientSecret,
@@ -152,7 +217,8 @@ func (c *OIDCClient) ensureReady(ctx context.Context) error {
 	return nil
 }
 
-// OIDCClaims is the subset of ID-token claims this barn cares about.
+// OIDCClaims is the subset of ID-token / access-token claims this barn cares
+// about.
 type OIDCClaims struct {
 	Subject           string   `json:"sub"`
 	Email             string   `json:"email"`
@@ -160,11 +226,13 @@ type OIDCClaims struct {
 	Name              string   `json:"name"`
 	Groups            []string `json:"groups"`
 	Roles             []string `json:"roles"`
+	TokenUse          string   `json:"token_use"` // "access_token" for resource-server validation
+	ClientName        string   `json:"client_name"`
 }
 
 // PreferredName returns the best human-readable identifier from the claims.
 func (c OIDCClaims) PreferredName() string {
-	for _, v := range []string{c.PreferredUsername, c.Email, c.Name, c.Subject} {
+	for _, v := range []string{c.PreferredUsername, c.Email, c.Name, c.ClientName, c.Subject} {
 		if v = strings.TrimSpace(v); v != "" {
 			return v
 		}

--- a/internal/auth/oidc_resource_test.go
+++ b/internal/auth/oidc_resource_test.go
@@ -1,0 +1,200 @@
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// oidcTestIssuer spins up a minimal OIDC issuer (discovery + JWKS) signing
+// EdDSA tokens, mirroring IamBarn, so VerifyAccessToken can be exercised
+// end-to-end without a live issuer.
+type oidcTestIssuer struct {
+	server *httptest.Server
+	priv   ed25519.PrivateKey
+	kid    string
+}
+
+func newOIDCTestIssuer(t *testing.T) *oidcTestIssuer {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	it := &oidcTestIssuer{priv: priv, kid: "test-key"}
+
+	mux := http.NewServeMux()
+	it.server = httptest.NewServer(mux)
+	issuer := it.server.URL
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                issuer,
+			"authorization_endpoint":                issuer + "/oauth2/authorize",
+			"token_endpoint":                        issuer + "/oauth2/token",
+			"jwks_uri":                              issuer + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"EdDSA"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+			Key:       pub,
+			KeyID:     it.kid,
+			Algorithm: "EdDSA",
+			Use:       "sig",
+		}}})
+	})
+	t.Cleanup(it.server.Close)
+	return it
+}
+
+func (it *oidcTestIssuer) sign(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.EdDSA, Key: jose.JSONWebKey{Key: it.priv, KeyID: it.kid, Algorithm: "EdDSA"}},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	payload, _ := json.Marshal(claims)
+	obj, err := signer.Sign(payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	tok, err := obj.CompactSerialize()
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return tok
+}
+
+func (it *oidcTestIssuer) client(aud ...string) *OIDCClient {
+	return NewOIDCClient(OIDCConfig{
+		Issuer:            it.server.URL,
+		ClientID:          "spanbarn-web",
+		ResourceAudiences: aud,
+	})
+}
+
+func baseClaims(issuer string) map[string]any {
+	return map[string]any{
+		"iss":       issuer,
+		"sub":       "user-123",
+		"aud":       []string{"spanbarn-cli"},
+		"exp":       time.Now().Add(time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"token_use": "access_token",
+		"roles":     []string{"operator"},
+		"email":     "wiebe@wiebe.xyz",
+	}
+}
+
+func TestVerifyAccessToken_Valid(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client("spanbarn-cli")
+	tok := it.sign(t, baseClaims(it.server.URL))
+
+	claims, err := oc.VerifyAccessToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("expected valid token, got %v", err)
+	}
+	if claims.PreferredName() != "wiebe@wiebe.xyz" {
+		t.Errorf("preferred name = %q", claims.PreferredName())
+	}
+	if !oc.Allowed(claims) {
+		t.Errorf("operator role should be allowed")
+	}
+}
+
+func TestVerifyAccessToken_WrongAudience(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client("spanbarn-cli") // only accepts spanbarn-cli
+	c := baseClaims(it.server.URL)
+	c["aud"] = []string{"some-other-app"}
+	tok := it.sign(t, c)
+
+	if _, err := oc.VerifyAccessToken(context.Background(), tok); err == nil {
+		t.Fatal("expected audience rejection")
+	}
+}
+
+func TestVerifyAccessToken_Expired(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client("spanbarn-cli")
+	c := baseClaims(it.server.URL)
+	c["exp"] = time.Now().Add(-time.Hour).Unix()
+	tok := it.sign(t, c)
+
+	if _, err := oc.VerifyAccessToken(context.Background(), tok); err == nil {
+		t.Fatal("expected expiry rejection")
+	}
+}
+
+func TestVerifyAccessToken_NotAccessToken(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client("spanbarn-cli")
+	c := baseClaims(it.server.URL)
+	c["token_use"] = "id_token"
+	tok := it.sign(t, c)
+
+	if _, err := oc.VerifyAccessToken(context.Background(), tok); err == nil {
+		t.Fatal("expected non-access-token rejection")
+	}
+}
+
+func TestVerifyAccessToken_ClientIDAudienceAccepted(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client() // no explicit resource audiences; ClientID implicit
+	c := baseClaims(it.server.URL)
+	c["aud"] = []string{"spanbarn-web"} // == ClientID
+	tok := it.sign(t, c)
+
+	if _, err := oc.VerifyAccessToken(context.Background(), tok); err != nil {
+		t.Fatalf("ClientID audience should be accepted, got %v", err)
+	}
+}
+
+func TestVerifyAccessToken_NotAllowedRole(t *testing.T) {
+	it := newOIDCTestIssuer(t)
+	oc := it.client("spanbarn-cli")
+	c := baseClaims(it.server.URL)
+	c["roles"] = []string{"member"}
+	delete(c, "groups")
+	tok := it.sign(t, c)
+
+	claims, err := oc.VerifyAccessToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("token should verify, got %v", err)
+	}
+	if oc.Allowed(claims) {
+		t.Error("member role without group should not be allowed")
+	}
+}
+
+func TestAudienceAllowed(t *testing.T) {
+	cases := []struct {
+		tok, allow []string
+		want       bool
+	}{
+		{[]string{"a", "b"}, []string{"b"}, true},
+		{[]string{"a"}, []string{"b", "c"}, false},
+		{[]string{"a"}, []string{""}, false},
+		{nil, []string{"a"}, false},
+		{[]string{"a"}, nil, false},
+	}
+	for i, tc := range cases {
+		if got := audienceAllowed(tc.tok, tc.allow); got != tc.want {
+			t.Errorf("case %d: audienceAllowed(%v,%v)=%v want %v", i, tc.tok, tc.allow, got, tc.want)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,8 @@ type Config struct {
 	OIDCClientSecret       string // SPANBARN_OIDC_CLIENT_SECRET
 	OIDCRedirectURL        string // SPANBARN_OIDC_REDIRECT_URL
 	OIDCRequiredGroup      string // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
+	OIDCResourceAudiences  []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
+	OIDCCLIClientID        string // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
 	GRPCAddr               string // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
 }
 
@@ -109,6 +111,7 @@ func Load() Config {
 		OIDCClientSecret:        os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
 		OIDCRedirectURL:         os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
 		OIDCRequiredGroup:       getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
+		OIDCCLIClientID:         os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
 		GRPCAddr:                getenv("SPANBARN_GRPC_ADDR", ":4317"),
 	}
 
@@ -116,6 +119,14 @@ func Load() Config {
 		for _, o := range strings.Split(raw, ",") {
 			if trimmed := strings.TrimSpace(o); trimmed != "" {
 				cfg.AllowedOrigins = append(cfg.AllowedOrigins, trimmed)
+			}
+		}
+	}
+
+	if raw := os.Getenv("SPANBARN_OIDC_RESOURCE_AUDIENCES"); raw != "" {
+		for _, a := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(a); trimmed != "" {
+				cfg.OIDCResourceAudiences = append(cfg.OIDCResourceAudiences, trimmed)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Lets the `sb` CLI log in through **IamBarn** OAuth — both **device code** (interactive, browser-approved) and **client credentials** (M2M, agents/CI) — so the OIDC-only production no longer requires a manually-minted API key.

SpanBarn becomes an OAuth2 **resource server**: read/query endpoints accept an IamBarn access-token JWT as `Authorization: Bearer`, validated against the issuer JWKS (signature, `iss`, `exp`, `token_use=access_token`, audience allowlist) and authorized by the same role/group policy as browser login. Additive — read API keys and password/session login are unchanged; writes stay browser-session only.

## CLI
- `sb login --oidc` — device-code flow (prints code + URL, refresh-token keeps it alive).
- `sb login --client-id ID --client-secret SECRET` — M2M client_credentials.
- Bearer access token sent on requests; refreshed (device) / re-fetched (M2M) on expiry/401.

## Server config (set on the deployment)
- `SPANBARN_OIDC_CLI_CLIENT_ID` — public IamBarn client for the device flow (advertised via `/api/v1/client-config`).
- `SPANBARN_OIDC_RESOURCE_AUDIENCES` — audiences accepted on access tokens.

## Verification
- `go build/vet`, `go test -race ./...` green. New tests: resource-server JWT validation (valid/aud/exp/token_use/role) with a local EdDSA issuer; middleware JWT acceptance; CLI device/M2M/refresh flows.
- End-to-end with a signing issuer + the `sb` binary: M2M login → Bearer JWT → resource server → 200; auto re-fetch on forced expiry.

## Follow-up (ops, not in this PR)
Create a public `spanbarn-cli` device client (and optional M2M client) in IamBarn, set the two env vars on the SpanBarn deployment, and deploy. Then `sb login --oidc --url https://spanbarn.wiebe.xyz` works for `wiebe@wiebe.xyz`.
