### PR TITLE
feat(metrics): shape-aware OTLP metrics — rollups, catalog, insights, alerting

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -136,6 +136,11 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	metricsHandler := ingest.NewMetricsHandler(repo, logger)
 	logsHandler := ingest.NewLogsHandler(repo, logger)
 
+	// Fold every ingested metric data point into downsampled rollups so
+	// long-range queries don't scan the raw metrics table.
+	metricAccumulator := aggregation.NewMetricAccumulator(repo, parseAggregationInterval(cfg.AggregationInterval), 30*time.Second, logger)
+	metricsHandler.SetRollupSink(metricAccumulator)
+
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -146,6 +151,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
 	defer metricsCancel()
 	safeGo("metrics-ingest", &wg, func() { metricsHandler.Run(metricsCtx) })
+	safeGo("metric-accumulator", &wg, func() { metricAccumulator.Run(metricsCtx) })
 
 	logsCtx, logsCancel := context.WithCancel(ctx)
 	defer logsCancel()
@@ -677,6 +683,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 
 	aggInterval := parseAggregationInterval(cfg.AggregationInterval)
 	accumulator := aggregation.NewAccumulator(repo, aggInterval, 30*time.Second, logger)
+	metricAccumulator := aggregation.NewMetricAccumulator(repo, aggInterval, 30*time.Second, logger)
 
 	// writeMu serialises all SQLite writes between the span worker and the
 	// retention worker. Without this they compete for the write connection:
@@ -696,6 +703,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
 	safeGo("accumulator", &wg, func() { accumulator.Run(workerCtx) })
+	safeGo("metric-accumulator", &wg, func() { metricAccumulator.Run(workerCtx) })
 	safeGo("metrics-consumer", &wg, func() {
 		for {
 			select {
@@ -710,6 +718,9 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 			}
 			if len(recs) == 0 {
 				continue
+			}
+			for i := range recs {
+				metricAccumulator.AddMetric(recs[i])
 			}
 			if err := repo.InsertMetrics(workerCtx, recs); err != nil {
 				logger.Error("metrics insert error", "error", err)

--- a/internal/aggregation/metric_accumulator.go
+++ b/internal/aggregation/metric_accumulator.go
@@ -1,0 +1,253 @@
+package aggregation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/metrics"
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// MetricRollupWriter persists downsampled metric buckets.
+type MetricRollupWriter interface {
+	UpsertMetricRollups(rollups []repository.MetricRollup) error
+}
+
+// MetricAccumulator folds raw OTLP metric data points into per-series, per-bucket
+// rollups in memory, then flushes closed buckets to SQLite. It mirrors the span
+// Accumulator but is type-aware: it merges histogram bucket counts, tracks the
+// last cumulative value for counters, and keeps min/max/sum for gauges.
+//
+// Unlike the span accumulator it only flushes buckets that are already closed
+// (bucket end <= now), so each bucket is normally written exactly once and the
+// merged histogram distribution stored in `extra` is complete.
+type MetricAccumulator struct {
+	mu            sync.Mutex
+	slots         map[metricKey]*metricSlot
+	interval      time.Duration
+	flushInterval time.Duration
+	repo          MetricRollupWriter
+	logger        *slog.Logger
+	now           func() time.Time
+}
+
+type metricKey struct {
+	projectID   int64
+	name        string
+	fingerprint string
+	bucket      time.Time
+}
+
+type metricSlot struct {
+	metricType string
+	unit       string
+	attributes string
+
+	count    int64
+	sum      float64
+	min      float64
+	max      float64
+	last     float64
+	lastNano uint64
+	obsCount int64
+	haveVal  bool
+
+	// explicit-bucket histogram merge state
+	histBounds []float64
+	histCounts []float64
+	haveHist   bool
+
+	// exp_histogram / summary: keep the latest data point's extra
+	lastExtra json.RawMessage
+}
+
+// NewMetricAccumulator creates a MetricAccumulator. interval is the bucket
+// granularity; flushInterval is how often closed buckets are written.
+func NewMetricAccumulator(repo MetricRollupWriter, interval, flushInterval time.Duration, logger *slog.Logger) *MetricAccumulator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MetricAccumulator{
+		slots:         make(map[metricKey]*metricSlot),
+		interval:      interval,
+		flushInterval: flushInterval,
+		repo:          repo,
+		logger:        logger,
+		now:           time.Now,
+	}
+}
+
+// AddMetric folds a single metric data point into its bucket slot. Thread-safe.
+func (a *MetricAccumulator) AddMetric(rec model.MetricRecord) {
+	attrs := metrics.ParseAttributes(rec.Attributes)
+	bucket := TruncateToBucket(time.Unix(0, int64(rec.TimeUnixNano)).UTC(), a.interval)
+	k := metricKey{
+		projectID:   rec.ProjectID,
+		name:        rec.Name,
+		fingerprint: metrics.Fingerprint(attrs),
+		bucket:      bucket,
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	sl := a.slots[k]
+	if sl == nil {
+		sl = &metricSlot{
+			metricType: string(rec.Type),
+			unit:       rec.Unit,
+			attributes: metrics.CanonicalAttributes(attrs),
+		}
+		a.slots[k] = sl
+	}
+	sl.count++
+
+	switch rec.Type {
+	case model.MetricTypeGauge, model.MetricTypeSum:
+		v := rec.Value
+		sl.sum += v
+		if !sl.haveVal || v < sl.min {
+			sl.min = v
+		}
+		if !sl.haveVal || v > sl.max {
+			sl.max = v
+		}
+		sl.haveVal = true
+		if rec.TimeUnixNano >= sl.lastNano {
+			sl.last = v
+			sl.lastNano = rec.TimeUnixNano
+		}
+	case model.MetricTypeHistogram:
+		sl.sum += rec.Value
+		sl.obsCount += int64(rec.Count)
+		a.foldHistogram(sl, rec.Extra)
+	case model.MetricTypeExponentialHistogram, model.MetricTypeSummary:
+		sl.sum += rec.Value
+		sl.obsCount += int64(rec.Count)
+		if rec.TimeUnixNano >= sl.lastNano {
+			sl.lastExtra = rec.Extra
+			sl.lastNano = rec.TimeUnixNano
+		}
+	}
+}
+
+// foldHistogram merges an explicit-bucket histogram's counts into the slot.
+// Buckets with matching bounds add elementwise; a differing shape replaces
+// (best effort — bounds are stable per series in practice).
+func (a *MetricAccumulator) foldHistogram(sl *metricSlot, extra json.RawMessage) {
+	var h struct {
+		Bounds []float64 `json:"bounds"`
+		Counts []float64 `json:"counts"`
+	}
+	if len(extra) == 0 || json.Unmarshal(extra, &h) != nil {
+		return
+	}
+	if !sl.haveHist || len(sl.histCounts) != len(h.Counts) {
+		sl.histBounds = append([]float64(nil), h.Bounds...)
+		sl.histCounts = append([]float64(nil), h.Counts...)
+		sl.haveHist = true
+		return
+	}
+	for i := range h.Counts {
+		sl.histCounts[i] += h.Counts[i]
+	}
+}
+
+// Flush writes all closed buckets to SQLite and removes them from memory. Open
+// buckets (those whose window has not yet elapsed) are kept so later points fold
+// into the same row.
+func (a *MetricAccumulator) Flush(ctx context.Context) error {
+	cutoff := a.now().Add(-a.interval)
+
+	a.mu.Lock()
+	var rollups []repository.MetricRollup
+	for k, sl := range a.slots {
+		if k.bucket.After(cutoff) {
+			continue // bucket still open
+		}
+		rollups = append(rollups, a.toRollup(k, sl))
+		delete(a.slots, k)
+	}
+	a.mu.Unlock()
+
+	if len(rollups) == 0 {
+		return nil
+	}
+	if err := a.repo.UpsertMetricRollups(rollups); err != nil {
+		return fmt.Errorf("metric accumulator flush: %w", err)
+	}
+	a.logger.Info("persisted metric rollups", "count", len(rollups))
+	return nil
+}
+
+func (a *MetricAccumulator) toRollup(k metricKey, sl *metricSlot) repository.MetricRollup {
+	var extra string
+	switch model.MetricType(sl.metricType) {
+	case model.MetricTypeHistogram:
+		if sl.haveHist {
+			if b, err := json.Marshal(map[string]any{"bounds": sl.histBounds, "counts": sl.histCounts}); err == nil {
+				extra = string(b)
+			}
+		}
+	case model.MetricTypeExponentialHistogram, model.MetricTypeSummary:
+		extra = string(sl.lastExtra)
+	}
+	return repository.MetricRollup{
+		ProjectID:       k.projectID,
+		Name:            k.name,
+		Type:            sl.metricType,
+		Unit:            sl.unit,
+		AttrFingerprint: k.fingerprint,
+		Attributes:      sl.attributes,
+		Bucket:          k.bucket,
+		Count:           sl.count,
+		Sum:             sl.sum,
+		Min:             sl.min,
+		Max:             sl.max,
+		Last:            sl.last,
+		ObsCount:        sl.obsCount,
+		Extra:           extra,
+	}
+}
+
+// Run flushes closed buckets on a ticker until ctx is cancelled, then performs a
+// final flush of everything still buffered.
+func (a *MetricAccumulator) Run(ctx context.Context) {
+	ticker := time.NewTicker(a.flushInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			a.flushAll(context.Background())
+			return
+		case <-ticker.C:
+			if err := a.Flush(ctx); err != nil {
+				a.logger.Warn("metric accumulator flush failed", "error", err)
+			}
+		}
+	}
+}
+
+// flushAll drains every slot regardless of whether its bucket is closed. Used on
+// shutdown so buffered data is not lost.
+func (a *MetricAccumulator) flushAll(ctx context.Context) {
+	a.mu.Lock()
+	var rollups []repository.MetricRollup
+	for k, sl := range a.slots {
+		rollups = append(rollups, a.toRollup(k, sl))
+	}
+	a.slots = make(map[metricKey]*metricSlot)
+	a.mu.Unlock()
+
+	if len(rollups) == 0 {
+		return
+	}
+	if err := a.repo.UpsertMetricRollups(rollups); err != nil {
+		a.logger.Warn("metric accumulator final flush failed", "error", err)
+	}
+}

--- a/internal/aggregation/metric_accumulator_test.go
+++ b/internal/aggregation/metric_accumulator_test.go
@@ -1,0 +1,147 @@
+package aggregation
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/model"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type fakeRollupWriter struct{ got []repository.MetricRollup }
+
+func (f *fakeRollupWriter) UpsertMetricRollups(r []repository.MetricRollup) error {
+	f.got = append(f.got, r...)
+	return nil
+}
+
+func gaugeRec(name string, attrs string, tNano uint64, v float64) model.MetricRecord {
+	return model.MetricRecord{
+		ProjectID: 1, Name: name, Type: model.MetricTypeGauge,
+		TimeUnixNano: tNano, Value: v, Attributes: json.RawMessage(attrs),
+	}
+}
+
+func TestMetricAccumulatorGaugeFold(t *testing.T) {
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	w := &fakeRollupWriter{}
+	acc := NewMetricAccumulator(w, time.Minute, time.Minute, nil)
+	now := base.Add(90 * time.Second)
+	acc.now = func() time.Time { return now }
+
+	acc.AddMetric(gaugeRec("g", `{"a":"1"}`, uint64(base.Add(10*time.Second).UnixNano()), 10))
+	acc.AddMetric(gaugeRec("g", `{"a":"1"}`, uint64(base.Add(20*time.Second).UnixNano()), 30))
+	acc.AddMetric(gaugeRec("g", `{"a":"1"}`, uint64(base.Add(30*time.Second).UnixNano()), 20))
+
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(w.got) != 1 {
+		t.Fatalf("want 1 rollup, got %d", len(w.got))
+	}
+	r := w.got[0]
+	if r.Count != 3 || r.Sum != 60 || r.Min != 10 || r.Max != 30 || r.Last != 20 {
+		t.Errorf("gauge fold wrong: %+v", r)
+	}
+	if r.Bucket.UTC() != base {
+		t.Errorf("bucket = %v, want %v", r.Bucket.UTC(), base)
+	}
+}
+
+func TestMetricAccumulatorKeepsOpenBucket(t *testing.T) {
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	w := &fakeRollupWriter{}
+	acc := NewMetricAccumulator(w, time.Minute, time.Minute, nil)
+	now := base.Add(90 * time.Second)
+	acc.now = func() time.Time { return now }
+
+	// Closed bucket (base..base+1m) and an open bucket (base+1m..base+2m).
+	acc.AddMetric(gaugeRec("g", `{}`, uint64(base.Add(10*time.Second).UnixNano()), 5))
+	acc.AddMetric(gaugeRec("g", `{}`, uint64(base.Add(75*time.Second).UnixNano()), 9))
+
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(w.got) != 1 {
+		t.Fatalf("want only the closed bucket flushed, got %d", len(w.got))
+	}
+	if w.got[0].Bucket.UTC() != base {
+		t.Errorf("flushed wrong bucket %v", w.got[0].Bucket.UTC())
+	}
+
+	// The open bucket is still buffered; advancing time closes it.
+	now = base.Add(150 * time.Second)
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("flush 2: %v", err)
+	}
+	if len(w.got) != 2 {
+		t.Fatalf("want 2 rollups after time advances, got %d", len(w.got))
+	}
+	if w.got[1].Last != 9 {
+		t.Errorf("open-bucket value wrong: %+v", w.got[1])
+	}
+}
+
+func TestMetricAccumulatorHistogramMerge(t *testing.T) {
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	w := &fakeRollupWriter{}
+	acc := NewMetricAccumulator(w, time.Minute, time.Minute, nil)
+	acc.now = func() time.Time { return base.Add(90 * time.Second) }
+
+	hist := func(tNano uint64, counts string, obs uint64, sum float64) model.MetricRecord {
+		return model.MetricRecord{
+			ProjectID: 1, Name: "h", Type: model.MetricTypeHistogram,
+			TimeUnixNano: tNano, Value: sum, Count: obs,
+			Attributes: json.RawMessage(`{}`),
+			Extra:      json.RawMessage(`{"bounds":[10,20],"counts":` + counts + `}`),
+		}
+	}
+	acc.AddMetric(hist(uint64(base.Add(5*time.Second).UnixNano()), `[1,2,0]`, 3, 30))
+	acc.AddMetric(hist(uint64(base.Add(15*time.Second).UnixNano()), `[3,1,1]`, 5, 55))
+
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(w.got) != 1 {
+		t.Fatalf("want 1 rollup, got %d", len(w.got))
+	}
+	r := w.got[0]
+	if r.ObsCount != 8 || r.Sum != 85 {
+		t.Errorf("histogram totals wrong: obs=%d sum=%v", r.ObsCount, r.Sum)
+	}
+	var merged struct {
+		Bounds []float64 `json:"bounds"`
+		Counts []float64 `json:"counts"`
+	}
+	if err := json.Unmarshal([]byte(r.Extra), &merged); err != nil {
+		t.Fatalf("unmarshal extra: %v", err)
+	}
+	want := []float64{4, 3, 1}
+	for i, c := range want {
+		if merged.Counts[i] != c {
+			t.Errorf("merged counts[%d] = %v, want %v (%v)", i, merged.Counts[i], c, merged.Counts)
+		}
+	}
+}
+
+func TestMetricAccumulatorSplitsByAttributes(t *testing.T) {
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	w := &fakeRollupWriter{}
+	acc := NewMetricAccumulator(w, time.Minute, time.Minute, nil)
+	acc.now = func() time.Time { return base.Add(90 * time.Second) }
+
+	acc.AddMetric(gaugeRec("g", `{"svc":"a"}`, uint64(base.Add(5*time.Second).UnixNano()), 1))
+	acc.AddMetric(gaugeRec("g", `{"svc":"b"}`, uint64(base.Add(6*time.Second).UnixNano()), 2))
+
+	if err := acc.Flush(context.Background()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if len(w.got) != 2 {
+		t.Fatalf("want 2 series rollups, got %d", len(w.got))
+	}
+	if w.got[0].AttrFingerprint == w.got[1].AttrFingerprint {
+		t.Error("distinct attribute sets should have distinct fingerprints")
+	}
+}

--- a/internal/alert/evaluator.go
+++ b/internal/alert/evaluator.go
@@ -20,6 +20,7 @@ var alertTracer = otel.Tracer("spanbarn/alert")
 type AlertRepository interface {
 	ListAlerts(projectID int64) ([]repository.Alert, error)
 	QueryAggregates(filter repository.AggregateFilter) ([]repository.Aggregate, error)
+	QueryMetricRollups(ctx context.Context, f repository.MetricRollupFilter) ([]repository.MetricRollup, error)
 	UpdateAlertLastTriggered(alertID int64, at time.Time) error
 }
 
@@ -148,6 +149,10 @@ func (e *Evaluator) evaluateAlert(ctx context.Context, a repository.Alert, now t
 	)
 	defer span.End()
 
+	if a.Type == "metric_threshold" {
+		return e.evaluateMetricAlert(ctx, a, now)
+	}
+
 	// Query the current (most recent) bucket aggregate.
 	currentAggs, err := e.repo.QueryAggregates(repository.AggregateFilter{
 		ProjectID: a.ProjectID,
@@ -208,6 +213,13 @@ func (e *Evaluator) evaluateAlert(ctx context.Context, a repository.Alert, now t
 		return fmt.Errorf("unknown alert type: %s", a.Type)
 	}
 
+	return e.maybeTrigger(ctx, span, a, currentVal, avgVal, len(historyAggs) > 0, now)
+}
+
+// maybeTrigger applies the shared threshold + significant-increase gate and, if
+// crossed, sends notifications and records the trigger time. hasHistory tells it
+// whether a rolling baseline was available for the >20% increase check.
+func (e *Evaluator) maybeTrigger(ctx context.Context, span trace.Span, a repository.Alert, currentVal, avgVal float64, hasHistory bool, now time.Time) error {
 	// Check if current exceeds threshold.
 	if currentVal < a.Threshold {
 		return nil
@@ -215,11 +227,16 @@ func (e *Evaluator) evaluateAlert(ctx context.Context, a repository.Alert, now t
 
 	// Check if current is significantly higher than average (>20% increase).
 	// If there's no history, we still alert if threshold is exceeded.
-	if len(historyAggs) > 0 && avgVal > 0 {
+	if hasHistory && avgVal > 0 {
 		increase := (currentVal - avgVal) / avgVal
 		if increase <= 0.20 {
 			return nil
 		}
+	}
+
+	target := a.Service
+	if a.Type == "metric_threshold" {
+		target = a.MetricName
 	}
 
 	span.AddEvent("alert.triggered", trace.WithAttributes(
@@ -246,10 +263,10 @@ func (e *Evaluator) evaluateAlert(ctx context.Context, a repository.Alert, now t
 	}
 
 	if a.Email != "" {
-		subject := fmt.Sprintf("[SpanBarn Alert] %s %s regression on %s", a.Type, a.Service, a.Operation)
+		subject := fmt.Sprintf("[SpanBarn Alert] %s regression on %s", a.Type, target)
 		body := fmt.Sprintf(
-			"Alert triggered for %s/%s\n\nType: %s\nCurrent: %.2f\nAverage: %.2f\nThreshold: %.2f\nTriggered at: %s",
-			a.Service, a.Operation, a.Type, currentVal, avgVal, a.Threshold, now.Format(time.RFC3339),
+			"Alert triggered for %s\n\nType: %s\nCurrent: %.2f\nAverage: %.2f\nThreshold: %.2f\nTriggered at: %s",
+			target, a.Type, currentVal, avgVal, a.Threshold, now.Format(time.RFC3339),
 		)
 		if err := e.notify.SendEmail(ctx, a.Email, subject, body); err != nil {
 			e.logger.Error("send email", "alertID", a.ID, "error", err)
@@ -264,8 +281,7 @@ func (e *Evaluator) evaluateAlert(ctx context.Context, a repository.Alert, now t
 	e.logger.Info("alert triggered",
 		"alertID", a.ID,
 		"type", a.Type,
-		"service", a.Service,
-		"operation", a.Operation,
+		"target", target,
 		"current", currentVal,
 		"average", avgVal,
 		"threshold", a.Threshold,

--- a/internal/alert/evaluator_test.go
+++ b/internal/alert/evaluator_test.go
@@ -41,6 +41,7 @@ func (m *mockNotifier) SendEmail(_ context.Context, to, subject, body string) er
 type mockAlertRepo struct {
 	alerts     []repository.Alert
 	aggregates []repository.Aggregate
+	rollups    []repository.MetricRollup
 	triggered  map[int64]time.Time
 }
 
@@ -94,9 +95,90 @@ func (m *mockAlertRepo) QueryAggregates(f repository.AggregateFilter) ([]reposit
 	return out, nil
 }
 
+func (m *mockAlertRepo) QueryMetricRollups(_ context.Context, f repository.MetricRollupFilter) ([]repository.MetricRollup, error) {
+	var out []repository.MetricRollup
+	for _, r := range m.rollups {
+		if f.ProjectID != 0 && r.ProjectID != f.ProjectID {
+			continue
+		}
+		if f.Name != "" && r.Name != f.Name {
+			continue
+		}
+		if !f.From.IsZero() && r.Bucket.Before(f.From) {
+			continue
+		}
+		if !f.To.IsZero() && r.Bucket.After(f.To) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
 func (m *mockAlertRepo) UpdateAlertLastTriggered(alertID int64, at time.Time) error {
 	m.triggered[alertID] = at
 	return nil
+}
+
+func TestEvaluateMetricThreshold(t *testing.T) {
+	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	repo := newMockRepo()
+	repo.alerts = []repository.Alert{{
+		ID: 1, ProjectID: 1, Type: "metric_threshold",
+		MetricName: "queue.depth", MetricAgg: "last", Threshold: 100,
+		ComparisonWindow: 10, CooldownMinutes: 30, Enabled: true,
+		WebhookURL: "https://hook", LabelFilters: "{}",
+	}}
+	// Flat baseline ~20, then a jump to 250 in the latest bucket.
+	vals := []float64{20, 20, 20, 250}
+	for i, v := range vals {
+		repo.rollups = append(repo.rollups, repository.MetricRollup{
+			ProjectID: 1, Name: "queue.depth", Type: "gauge", AttrFingerprint: "fp",
+			Bucket: now.Add(time.Duration(i-4) * time.Minute), Count: 1, Sum: v, Min: v, Max: v, Last: v,
+		})
+	}
+
+	notifier := &mockNotifier{}
+	eval := NewEvaluator(repo, notifier, slog.Default(), nil)
+	eval.now = func() time.Time { return now }
+
+	if err := eval.Evaluate(context.Background(), 1); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(notifier.webhooks) != 1 {
+		t.Fatalf("expected 1 webhook for breaching metric alert, got %d", len(notifier.webhooks))
+	}
+	if _, ok := repo.triggered[1]; !ok {
+		t.Error("expected alert 1 to be marked triggered")
+	}
+}
+
+func TestEvaluateMetricThresholdBelow(t *testing.T) {
+	now := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+	repo := newMockRepo()
+	repo.alerts = []repository.Alert{{
+		ID: 2, ProjectID: 1, Type: "metric_threshold",
+		MetricName: "queue.depth", MetricAgg: "last", Threshold: 100,
+		ComparisonWindow: 10, CooldownMinutes: 30, Enabled: true,
+		WebhookURL: "https://hook", LabelFilters: "{}",
+	}}
+	for i, v := range []float64{20, 22, 19, 21} {
+		repo.rollups = append(repo.rollups, repository.MetricRollup{
+			ProjectID: 1, Name: "queue.depth", Type: "gauge", AttrFingerprint: "fp",
+			Bucket: now.Add(time.Duration(i-4) * time.Minute), Count: 1, Sum: v, Last: v,
+		})
+	}
+
+	notifier := &mockNotifier{}
+	eval := NewEvaluator(repo, notifier, slog.Default(), nil)
+	eval.now = func() time.Time { return now }
+
+	if err := eval.Evaluate(context.Background(), 1); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if len(notifier.webhooks) != 0 {
+		t.Errorf("expected no webhook below threshold, got %d", len(notifier.webhooks))
+	}
 }
 
 func TestEvaluateNoAlerts(t *testing.T) {

--- a/internal/alert/metric_eval.go
+++ b/internal/alert/metric_eval.go
@@ -1,0 +1,176 @@
+package alert
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/metrics"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// metricEvalWindow is how far back, per comparison-window unit (one minute, the
+// default rollup bucket), the evaluator looks. The extra buckets give the
+// rolling baseline something to average over.
+const metricLookbackPadding = 2
+
+// evaluateMetricAlert checks a metric_threshold alert against the rollup table.
+// It reduces the matching series to one scalar per bucket using the configured
+// aggregation, treats the latest bucket as the current value and the earlier
+// buckets as the rolling baseline, then applies the shared trigger gate.
+func (e *Evaluator) evaluateMetricAlert(ctx context.Context, a repository.Alert, now time.Time) error {
+	_, span := alertTracer.Start(ctx, "alert.evaluate_metric")
+	defer span.End()
+
+	if a.MetricName == "" {
+		return fmt.Errorf("metric_threshold alert %d has no metric name", a.ID)
+	}
+
+	window := a.ComparisonWindow
+	if window <= 0 {
+		window = 10
+	}
+	from := now.Add(-time.Duration(window+metricLookbackPadding) * time.Minute)
+
+	rows, err := e.repo.QueryMetricRollups(ctx, repository.MetricRollupFilter{
+		ProjectID:  a.ProjectID,
+		Name:       a.MetricName,
+		From:       from,
+		To:         now,
+		Attributes: parseLabelFilters(a.LabelFilters),
+	})
+	if err != nil {
+		return fmt.Errorf("query metric rollups: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil // no data yet
+	}
+
+	metricType := rows[0].Type
+	points := mergeRollupsByBucket(rows)
+	derived := metrics.Derive(metricType, points)
+	if len(derived) == 0 {
+		return nil
+	}
+
+	render := metrics.RenderFor(metricType)
+	scalars := make([]float64, len(derived))
+	for i, d := range derived {
+		scalars[i] = metricScalar(a.MetricAgg, render, d)
+	}
+
+	currentVal := scalars[len(scalars)-1]
+	var avgVal float64
+	hasHistory := len(scalars) > 1
+	if hasHistory {
+		var sum float64
+		for _, v := range scalars[:len(scalars)-1] {
+			sum += v
+		}
+		avgVal = sum / float64(len(scalars)-1)
+	}
+
+	return e.maybeTrigger(ctx, span, a, currentVal, avgVal, hasHistory, now)
+}
+
+// metricScalar reduces a derived point to the value the alert compares against.
+// "p95" reads the reconstructed 95th percentile; everything else (rate/avg/last)
+// reads the derived value, which Derive already computed per the metric type.
+func metricScalar(agg string, render metrics.RenderKind, d metrics.DerivedPoint) float64 {
+	if agg == "p95" || render == metrics.RenderPercentile {
+		if d.P95 != nil {
+			return *d.P95
+		}
+		return 0
+	}
+	return d.Value
+}
+
+// bucketAgg accumulates all series for one bucket while merging.
+type bucketAgg struct {
+	count, obs int64
+	sum, last  float64
+	typ        string
+	histBounds []float64
+	histCounts []float64
+	lastExtra  string
+	haveHist   bool
+}
+
+// mergeRollupsByBucket collapses all matching series into one logical series:
+// one InputPoint per bucket, summing counts/sums/last/obs and merging histogram
+// bucket counts. For a single-series alert this is a pass-through.
+func mergeRollupsByBucket(rows []repository.MetricRollup) []metrics.InputPoint {
+	byBucket := map[int64]*bucketAgg{}
+	var order []int64
+	for _, r := range rows {
+		t := r.Bucket.UnixNano()
+		g := byBucket[t]
+		if g == nil {
+			g = &bucketAgg{typ: r.Type}
+			byBucket[t] = g
+			order = append(order, t)
+		}
+		g.count += r.Count
+		g.obs += r.ObsCount
+		g.sum += r.Sum
+		g.last += r.Last
+		g.mergeExtra(r)
+	}
+	sort.Slice(order, func(i, j int) bool { return order[i] < order[j] })
+
+	out := make([]metrics.InputPoint, 0, len(order))
+	for _, t := range order {
+		g := byBucket[t]
+		value := g.last
+		if g.typ == "gauge" && g.count > 0 {
+			value = g.sum / float64(g.count)
+		}
+		var extra json.RawMessage
+		if g.haveHist {
+			if b, err := json.Marshal(map[string]any{"bounds": g.histBounds, "counts": g.histCounts}); err == nil {
+				extra = b
+			}
+		} else if g.lastExtra != "" {
+			extra = json.RawMessage(g.lastExtra)
+		}
+		out = append(out, metrics.InputPoint{T: t, Value: value, Count: g.obs, Extra: extra})
+	}
+	return out
+}
+
+func (g *bucketAgg) mergeExtra(r repository.MetricRollup) {
+	if r.Extra == "" {
+		return
+	}
+	if r.Type != "histogram" {
+		g.lastExtra = r.Extra
+		return
+	}
+	var h struct {
+		Bounds []float64 `json:"bounds"`
+		Counts []float64 `json:"counts"`
+	}
+	if json.Unmarshal([]byte(r.Extra), &h) != nil {
+		return
+	}
+	if !g.haveHist || len(g.histCounts) != len(h.Counts) {
+		g.histBounds = append([]float64(nil), h.Bounds...)
+		g.histCounts = append([]float64(nil), h.Counts...)
+		g.haveHist = true
+		return
+	}
+	for i := range h.Counts {
+		g.histCounts[i] += h.Counts[i]
+	}
+}
+
+// parseLabelFilters decodes the alert's stored label-filter JSON into a map.
+func parseLabelFilters(raw string) map[string]string {
+	if raw == "" {
+		return nil
+	}
+	return metrics.ParseAttributes([]byte(raw))
+}

--- a/internal/api/alerts.go
+++ b/internal/api/alerts.go
@@ -8,8 +8,29 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/wiebe-xyz/spanbarn/internal/metrics"
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
+
+// validMetricAggs are the supported metric-threshold aggregations.
+var validMetricAggs = map[string]bool{"rate": true, "avg": true, "p95": true, "last": true}
+
+// marshalLabelFilters serialises request label filters to the stored JSON string.
+func marshalLabelFilters(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}
+
+// validateAlertType reports whether t is a known alert type.
+func validateAlertType(t string) bool {
+	return t == "latency" || t == "error_rate" || t == "metric_threshold"
+}
 
 // alertHandlers holds session-authenticated alert endpoint handlers.
 type alertHandlers struct {
@@ -17,32 +38,38 @@ type alertHandlers struct {
 }
 
 type alertRequest struct {
-	ProjectID        int64   `json:"projectId"`
-	Service          string  `json:"service"`
-	Operation        string  `json:"operation"`
-	Type             string  `json:"type"`
-	Threshold        float64 `json:"threshold"`
-	ComparisonWindow int     `json:"comparisonWindow"`
-	CooldownMinutes  int     `json:"cooldownMinutes"`
-	WebhookURL       string  `json:"webhookUrl"`
-	Email            string  `json:"email"`
-	Enabled          bool    `json:"enabled"`
+	ProjectID        int64             `json:"projectId"`
+	Service          string            `json:"service"`
+	Operation        string            `json:"operation"`
+	Type             string            `json:"type"`
+	Threshold        float64           `json:"threshold"`
+	ComparisonWindow int               `json:"comparisonWindow"`
+	CooldownMinutes  int               `json:"cooldownMinutes"`
+	WebhookURL       string            `json:"webhookUrl"`
+	Email            string            `json:"email"`
+	Enabled          bool              `json:"enabled"`
+	MetricName       string            `json:"metricName"`
+	MetricAgg        string            `json:"metricAgg"`
+	LabelFilters     map[string]string `json:"labelFilters"`
 }
 
 type alertResponse struct {
-	ID               int64   `json:"id"`
-	ProjectID        int64   `json:"projectId"`
-	Service          string  `json:"service"`
-	Operation        string  `json:"operation"`
-	Type             string  `json:"type"`
-	Threshold        float64 `json:"threshold"`
-	ComparisonWindow int     `json:"comparisonWindow"`
-	CooldownMinutes  int     `json:"cooldownMinutes"`
-	WebhookURL       string  `json:"webhookUrl"`
-	Email            string  `json:"email"`
-	Enabled          bool    `json:"enabled"`
-	LastTriggeredAt  *string `json:"lastTriggeredAt,omitempty"`
-	CreatedAt        string  `json:"createdAt"`
+	ID               int64             `json:"id"`
+	ProjectID        int64             `json:"projectId"`
+	Service          string            `json:"service"`
+	Operation        string            `json:"operation"`
+	Type             string            `json:"type"`
+	Threshold        float64           `json:"threshold"`
+	ComparisonWindow int               `json:"comparisonWindow"`
+	CooldownMinutes  int               `json:"cooldownMinutes"`
+	WebhookURL       string            `json:"webhookUrl"`
+	Email            string            `json:"email"`
+	Enabled          bool              `json:"enabled"`
+	MetricName       string            `json:"metricName,omitempty"`
+	MetricAgg        string            `json:"metricAgg,omitempty"`
+	LabelFilters     map[string]string `json:"labelFilters,omitempty"`
+	LastTriggeredAt  *string           `json:"lastTriggeredAt,omitempty"`
+	CreatedAt        string            `json:"createdAt"`
 }
 
 func toAlertResponse(a repository.Alert) alertResponse {
@@ -58,6 +85,9 @@ func toAlertResponse(a repository.Alert) alertResponse {
 		WebhookURL:       a.WebhookURL,
 		Email:            a.Email,
 		Enabled:          a.Enabled,
+		MetricName:       a.MetricName,
+		MetricAgg:        a.MetricAgg,
+		LabelFilters:     metrics.ParseAttributes([]byte(a.LabelFilters)),
 		CreatedAt:        a.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 	if a.LastTriggeredAt.Valid {
@@ -136,12 +166,28 @@ func (h *alertHandlers) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.ProjectID == 0 || req.Service == "" || req.Type == "" {
-		writeError(w, http.StatusBadRequest, "projectId, service, and type are required", "")
+	if req.ProjectID == 0 || req.Type == "" {
+		writeError(w, http.StatusBadRequest, "projectId and type are required", "")
 		return
 	}
-	if req.Type != "latency" && req.Type != "error_rate" {
-		writeError(w, http.StatusBadRequest, "type must be 'latency' or 'error_rate'", "")
+	if !validateAlertType(req.Type) {
+		writeError(w, http.StatusBadRequest, "type must be 'latency', 'error_rate', or 'metric_threshold'", "")
+		return
+	}
+	if req.Type == "metric_threshold" {
+		if req.MetricName == "" {
+			writeError(w, http.StatusBadRequest, "metricName is required for metric_threshold alerts", "")
+			return
+		}
+		if req.MetricAgg == "" {
+			req.MetricAgg = "last"
+		}
+		if !validMetricAggs[req.MetricAgg] {
+			writeError(w, http.StatusBadRequest, "metricAgg must be one of rate, avg, p95, last", "")
+			return
+		}
+	} else if req.Service == "" {
+		writeError(w, http.StatusBadRequest, "service is required for this alert type", "")
 		return
 	}
 	if req.ComparisonWindow <= 0 {
@@ -162,6 +208,9 @@ func (h *alertHandlers) handleCreate(w http.ResponseWriter, r *http.Request) {
 		WebhookURL:       req.WebhookURL,
 		Email:            req.Email,
 		Enabled:          req.Enabled,
+		MetricName:       req.MetricName,
+		MetricAgg:        req.MetricAgg,
+		LabelFilters:     marshalLabelFilters(req.LabelFilters),
 	}
 
 	id, err := h.repo.CreateAlert(alert)
@@ -197,9 +246,18 @@ func (h *alertHandlers) handleUpdate(w http.ResponseWriter, r *http.Request, id 
 		return
 	}
 
-	if req.Type != "" && req.Type != "latency" && req.Type != "error_rate" {
-		writeError(w, http.StatusBadRequest, "type must be 'latency' or 'error_rate'", "")
+	if req.Type != "" && !validateAlertType(req.Type) {
+		writeError(w, http.StatusBadRequest, "type must be 'latency', 'error_rate', or 'metric_threshold'", "")
 		return
+	}
+	if req.Type == "metric_threshold" {
+		if req.MetricAgg == "" {
+			req.MetricAgg = "last"
+		}
+		if !validMetricAggs[req.MetricAgg] {
+			writeError(w, http.StatusBadRequest, "metricAgg must be one of rate, avg, p95, last", "")
+			return
+		}
 	}
 
 	alert := repository.Alert{
@@ -213,6 +271,9 @@ func (h *alertHandlers) handleUpdate(w http.ResponseWriter, r *http.Request, id 
 		WebhookURL:       req.WebhookURL,
 		Email:            req.Email,
 		Enabled:          req.Enabled,
+		MetricName:       req.MetricName,
+		MetricAgg:        req.MetricAgg,
+		LabelFilters:     marshalLabelFilters(req.LabelFilters),
 	}
 
 	if err := h.repo.UpdateAlert(alert); err != nil {

--- a/internal/api/metrics_insights.go
+++ b/internal/api/metrics_insights.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/metrics"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type metricInsightsResponse struct {
+	Insights []metrics.Insight `json:"insights"`
+}
+
+// maxInsights caps how many notable changes are returned.
+const maxInsights = 20
+
+// handleMetricInsights scans every metric series in the range (via rollups) and
+// returns the most notable changes — spikes, drops, percentile regressions, and
+// newly-appeared series — so users don't have to eyeball every graph.
+//
+// GET /api/v1/metrics/insights?project_id=1&from=<rfc3339>&to=<rfc3339>
+func (h *metricsQueryHandlers) handleMetricInsights(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	projectID := parseInt64Param(r, "project_id", 0)
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+	if from.IsZero() {
+		from = time.Now().Add(-24 * time.Hour)
+	}
+	if to.IsZero() {
+		to = time.Now()
+	}
+
+	rows, err := h.repo.QueryProjectRollups(r.Context(), projectID, from, to, 0)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed", err.Error())
+		return
+	}
+
+	// Recent window = last 30% of the range; the rest is the baseline.
+	splitNano := from.Add(time.Duration(float64(to.Sub(from)) * 0.7)).UnixNano()
+
+	insights := detectInsights(rows, splitNano)
+	sort.SliceStable(insights, func(i, j int) bool {
+		return insights[i].Magnitude() > insights[j].Magnitude()
+	})
+	if len(insights) > maxInsights {
+		insights = insights[:maxInsights]
+	}
+	if insights == nil {
+		insights = []metrics.Insight{}
+	}
+
+	writeJSON(w, http.StatusOK, metricInsightsResponse{Insights: insights})
+}
+
+// detectInsights groups rollup rows into series (by name + fingerprint) and runs
+// change detection on each. Rows are already ordered by name, fingerprint and
+// bucket, so a series is a contiguous run.
+func detectInsights(rows []repository.MetricRollup, splitNano int64) []metrics.Insight {
+	var out []metrics.Insight
+
+	flush := func(name, typ string, attrs string, pts []metrics.InputPoint) {
+		if len(pts) == 0 {
+			return
+		}
+		if in, ok := metrics.DetectSeries(name, typ, metrics.ParseAttributes([]byte(attrs)), pts, splitNano); ok {
+			out = append(out, in)
+		}
+	}
+
+	var (
+		curName, curType, curAttrs string
+		curFP                      string
+		pts                        []metrics.InputPoint
+	)
+	for _, row := range rows {
+		if row.Name != curName || row.AttrFingerprint != curFP {
+			flush(curName, curType, curAttrs, pts)
+			curName, curType, curAttrs, curFP = row.Name, row.Type, row.Attributes, row.AttrFingerprint
+			pts = pts[:0]
+		}
+		pts = append(pts, rollupToInput(row))
+	}
+	flush(curName, curType, curAttrs, pts)
+	return out
+}

--- a/internal/api/metrics_query.go
+++ b/internal/api/metrics_query.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/wiebe-xyz/spanbarn/internal/metrics"
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
 
@@ -18,19 +19,16 @@ type metricNamesResponse struct {
 	Names []string `json:"names"`
 }
 
-type metricPoint struct {
-	T          int64           `json:"t"`
-	Value      float64         `json:"value"`
-	Count      int64           `json:"count"`
-	Attributes json.RawMessage `json:"attributes"`
-	Extra      json.RawMessage `json:"extra,omitempty"`
-}
-
+// metricSeriesResponse is the shape-aware series response. Raw OTLP points are
+// split into one series per label set and transformed per metric type (rate for
+// cumulative sums, p50/p95/p99 for distributions). Render tells the frontend
+// how to draw them; see metrics.RenderFor.
 type metricSeriesResponse struct {
-	Name   string        `json:"name"`
-	Type   string        `json:"type"`
-	Unit   string        `json:"unit"`
-	Points []metricPoint `json:"points"`
+	Name   string           `json:"name"`
+	Type   string           `json:"type"`
+	Unit   string           `json:"unit"`
+	Render string           `json:"render"`
+	Series []metrics.Series `json:"series"`
 }
 
 // handleMetricNames returns distinct metric names for a project within a time range.
@@ -66,6 +64,81 @@ func (h *metricsQueryHandlers) handleMetricNames(w http.ResponseWriter, r *http.
 	writeJSON(w, http.StatusOK, metricNamesResponse{Names: names})
 }
 
+type catalogMetric struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Unit   string `json:"unit"`
+	Series int64  `json:"series"`
+}
+
+type catalogGroup struct {
+	Name    string          `json:"name"`
+	Metrics []catalogMetric `json:"metrics"`
+}
+
+type metricCatalogResponse struct {
+	Groups []catalogGroup `json:"groups"`
+}
+
+// handleMetricCatalog returns metric names grouped by their semantic prefix
+// (the segment before the first '.', e.g. http, db, system), each with type,
+// unit, and series count, so the UI can present organised, collapsible groups
+// instead of one flat list.
+//
+// GET /api/v1/metrics/catalog?project_id=1&from=<rfc3339>&to=<rfc3339>
+func (h *metricsQueryHandlers) handleMetricCatalog(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
+	projectID := parseInt64Param(r, "project_id", 0)
+	from, to, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+	if from.IsZero() {
+		from = time.Now().Add(-24 * time.Hour)
+	}
+	if to.IsZero() {
+		to = time.Now()
+	}
+
+	entries, err := h.repo.ListMetricCatalog(r.Context(), projectID, from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, metricCatalogResponse{Groups: groupCatalog(entries)})
+}
+
+// groupCatalog buckets entries by semantic prefix, preserving the alphabetical
+// metric order within each group and ordering groups by first appearance.
+func groupCatalog(entries []repository.MetricCatalogEntry) []catalogGroup {
+	order := []string{}
+	byPrefix := map[string]*catalogGroup{}
+	for _, e := range entries {
+		prefix := "other"
+		if i := strings.IndexByte(e.Name, '.'); i > 0 {
+			prefix = e.Name[:i]
+		}
+		g := byPrefix[prefix]
+		if g == nil {
+			g = &catalogGroup{Name: prefix}
+			byPrefix[prefix] = g
+			order = append(order, prefix)
+		}
+		g.Metrics = append(g.Metrics, catalogMetric{Name: e.Name, Type: e.Type, Unit: e.Unit, Series: e.Series})
+	}
+	groups := make([]catalogGroup, 0, len(order))
+	for _, p := range order {
+		groups = append(groups, *byPrefix[p])
+	}
+	return groups
+}
+
 // handleMetricSeries returns data points for a named metric.
 //
 // GET /api/v1/metrics/series?name=<name>&project_id=1&from=<rfc3339>&to=<rfc3339>&limit=1000&label[service.name]=foo
@@ -96,42 +169,126 @@ func (h *metricsQueryHandlers) handleMetricSeries(w http.ResponseWriter, r *http
 	}
 
 	labels := parseLabelParams(r)
+	groupBy := parseGroupBy(r)
 
-	rows, err := h.repo.QueryMetricSeries(r.Context(), repository.MetricFilter{
-		ProjectID:  projectID,
-		Name:       name,
-		From:       from,
-		To:         to,
-		Attributes: labels,
-		Limit:      limit,
-	})
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "query failed", err.Error())
+	// Long ranges read the downsampled rollups instead of scanning raw points.
+	var (
+		metricType, unit string
+		in               []metrics.InputPoint
+		queryErr         error
+	)
+	if to.Sub(from) > rollupQueryThreshold {
+		metricType, unit, in, queryErr = h.rollupInput(r, projectID, name, from, to, labels, limit)
+	} else {
+		metricType, unit, in, queryErr = h.rawInput(r, projectID, name, from, to, labels, limit)
+	}
+	if queryErr != nil {
+		writeError(w, http.StatusInternalServerError, "query failed", queryErr.Error())
 		return
 	}
 
-	var metricType, unit string
-	points := make([]metricPoint, 0, len(rows))
-	for _, row := range rows {
-		if metricType == "" {
-			metricType = row.Type
-			unit = row.Unit
-		}
-		points = append(points, metricPoint{
-			T:          row.TimeUnixNano,
-			Value:      row.Value,
-			Count:      row.Count,
-			Attributes: json.RawMessage(row.Attributes),
-			Extra:      repository.MarshalMetricExtra(row),
-		})
+	series := metrics.BuildSeries(metricType, in, groupBy)
+	if series == nil {
+		series = []metrics.Series{}
 	}
 
 	writeJSON(w, http.StatusOK, metricSeriesResponse{
 		Name:   name,
 		Type:   metricType,
 		Unit:   unit,
-		Points: points,
+		Render: string(metrics.RenderFor(metricType)),
+		Series: series,
 	})
+}
+
+// rollupQueryThreshold is the range width above which the series query reads
+// pre-aggregated rollups rather than raw data points.
+const rollupQueryThreshold = 6 * time.Hour
+
+// rawInput loads raw metric data points and maps them to derivation input.
+func (h *metricsQueryHandlers) rawInput(r *http.Request, projectID int64, name string, from, to time.Time, labels map[string]string, limit int) (string, string, []metrics.InputPoint, error) {
+	rows, err := h.repo.QueryMetricSeries(r.Context(), repository.MetricFilter{
+		ProjectID: projectID, Name: name, From: from, To: to, Attributes: labels, Limit: limit,
+	})
+	if err != nil {
+		return "", "", nil, err
+	}
+	var metricType, unit string
+	in := make([]metrics.InputPoint, 0, len(rows))
+	for _, row := range rows {
+		if metricType == "" {
+			metricType, unit = row.Type, row.Unit
+		}
+		in = append(in, metrics.InputPoint{
+			T:          row.TimeUnixNano,
+			Value:      row.Value,
+			Count:      row.Count,
+			Extra:      repository.MarshalMetricExtra(row),
+			Attributes: parseAttrs(row.Attributes),
+		})
+	}
+	return metricType, unit, in, nil
+}
+
+// rollupInput loads downsampled rollup buckets and maps them to derivation
+// input. The per-type value choice keeps metrics.Derive working unchanged:
+// gauges use the bucket average, counters use the bucket-end cumulative value
+// (so rate is derived across buckets), distributions carry their merged extra.
+func (h *metricsQueryHandlers) rollupInput(r *http.Request, projectID int64, name string, from, to time.Time, labels map[string]string, limit int) (string, string, []metrics.InputPoint, error) {
+	rows, err := h.repo.QueryMetricRollups(r.Context(), repository.MetricRollupFilter{
+		ProjectID: projectID, Name: name, From: from, To: to, Attributes: labels, Limit: limit,
+	})
+	if err != nil {
+		return "", "", nil, err
+	}
+	var metricType, unit string
+	in := make([]metrics.InputPoint, 0, len(rows))
+	for _, row := range rows {
+		if metricType == "" {
+			metricType, unit = row.Type, row.Unit
+		}
+		in = append(in, rollupToInput(row))
+	}
+	return metricType, unit, in, nil
+}
+
+// rollupToInput maps a rollup bucket to a derivation input point. The per-type
+// value choice keeps metrics.Derive working unchanged: gauges use the bucket
+// average, counters use the bucket-end cumulative value (so rate is derived
+// across buckets), distributions carry their merged extra.
+func rollupToInput(row repository.MetricRollup) metrics.InputPoint {
+	value := row.Last
+	if row.Type == "gauge" && row.Count > 0 {
+		value = row.Sum / float64(row.Count)
+	}
+	return metrics.InputPoint{
+		T:          row.Bucket.UnixNano(),
+		Value:      value,
+		Count:      row.ObsCount,
+		Extra:      json.RawMessage(row.Extra),
+		Attributes: parseAttrs(row.Attributes),
+	}
+}
+
+// parseGroupBy reads the comma-separated group_by attribute keys. When empty,
+// series are split by their full attribute set.
+func parseGroupBy(r *http.Request) []string {
+	raw := r.URL.Query().Get("group_by")
+	if raw == "" {
+		return nil
+	}
+	var keys []string
+	for _, k := range strings.Split(raw, ",") {
+		if k = strings.TrimSpace(k); k != "" {
+			keys = append(keys, k)
+		}
+	}
+	return keys
+}
+
+// parseAttrs decodes a stored attributes JSON object into string labels.
+func parseAttrs(raw string) map[string]string {
+	return metrics.ParseAttributes([]byte(raw))
 }
 
 // parseLabelParams extracts label[key]=value query parameters.

--- a/internal/api/metrics_query_test.go
+++ b/internal/api/metrics_query_test.go
@@ -151,8 +151,17 @@ func TestMetricSeriesQuery(t *testing.T) {
 	if resp.Unit != "ms" {
 		t.Errorf("unit: want ms, got %q", resp.Unit)
 	}
-	if len(resp.Points) != 2 {
-		t.Errorf("points: want 2, got %d", len(resp.Points))
+	if resp.Render != "line" {
+		t.Errorf("render: want line, got %q", resp.Render)
+	}
+	// Two distinct service.name label sets -> two gauge series, one point each.
+	if len(resp.Series) != 2 {
+		t.Fatalf("series: want 2, got %d", len(resp.Series))
+	}
+	for _, s := range resp.Series {
+		if len(s.Points) != 1 {
+			t.Errorf("series %v: want 1 point, got %d", s.Labels, len(s.Points))
+		}
 	}
 }
 
@@ -190,11 +199,141 @@ func TestMetricSeriesLabelFilter(t *testing.T) {
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(resp.Points) != 1 {
-		t.Errorf("label filter: want 1 point, got %d", len(resp.Points))
+	// Label filter keeps only svc-a, leaving a single series for that label.
+	if len(resp.Series) != 1 {
+		t.Fatalf("label filter: want 1 series, got %d", len(resp.Series))
 	}
-	if len(resp.Points) > 0 && resp.Points[0].Value != 10 {
-		t.Errorf("label filter: want value 10, got %v", resp.Points[0].Value)
+	if resp.Series[0].Labels["service.name"] != "svc-a" {
+		t.Errorf("label filter: want service.name=svc-a, got %v", resp.Series[0].Labels)
+	}
+}
+
+func TestMetricSeriesRollupRouting(t *testing.T) {
+	srv, sm, repo := setupMetricsQueryServer(t)
+	base := time.Date(2026, 6, 16, 6, 0, 0, 0, time.UTC)
+
+	// Two gauge rollup buckets one hour apart for a single series.
+	if err := repo.UpsertMetricRollups([]repository.MetricRollup{
+		{ProjectID: 1, Name: "mem.used", Type: "gauge", Unit: "By", AttrFingerprint: "fp", Attributes: `{"host":"h1"}`, Bucket: base, Count: 2, Sum: 200, Min: 90, Max: 110, Last: 110},
+		{ProjectID: 1, Name: "mem.used", Type: "gauge", Unit: "By", AttrFingerprint: "fp", Attributes: `{"host":"h1"}`, Bucket: base.Add(time.Hour), Count: 1, Sum: 150, Min: 150, Max: 150, Last: 150},
+	}); err != nil {
+		t.Fatalf("seed rollups: %v", err)
+	}
+
+	// A >6h range routes the query to the rollup table.
+	from := base.Add(-time.Hour).Format(time.RFC3339)
+	to := base.Add(8 * time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/metrics/series?project_id=1&name=mem.used&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp metricSeriesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Render != "line" {
+		t.Errorf("render: want line, got %q", resp.Render)
+	}
+	if len(resp.Series) != 1 {
+		t.Fatalf("want 1 series from rollups, got %d", len(resp.Series))
+	}
+	if len(resp.Series[0].Points) != 2 {
+		t.Fatalf("want 2 rollup points, got %d", len(resp.Series[0].Points))
+	}
+	// Gauge value is the bucket average: 200/2 = 100 for the first bucket.
+	if resp.Series[0].Points[0].Value != 100 {
+		t.Errorf("first bucket avg = %v, want 100", resp.Series[0].Points[0].Value)
+	}
+}
+
+func TestMetricCatalogGrouping(t *testing.T) {
+	srv, sm, repo := setupMetricsQueryServer(t)
+	now := time.Now().UTC()
+
+	insertTestMetrics(t, repo, []model.MetricRecord{
+		{ProjectID: 1, Name: "http.server.duration", Type: model.MetricTypeHistogram, Unit: "ms", TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{"route":"/a"}`)},
+		{ProjectID: 1, Name: "http.server.duration", Type: model.MetricTypeHistogram, Unit: "ms", TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{"route":"/b"}`)},
+		{ProjectID: 1, Name: "db.client.calls", Type: model.MetricTypeSum, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+		{ProjectID: 1, Name: "uptime", Type: model.MetricTypeGauge, TimeUnixNano: uint64(now.UnixNano()), Attributes: []byte(`{}`)},
+	})
+
+	from := now.Add(-time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/catalog?project_id=1&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp metricCatalogResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	byName := map[string]catalogGroup{}
+	for _, g := range resp.Groups {
+		byName[g.Name] = g
+	}
+	if g, ok := byName["http"]; !ok || len(g.Metrics) != 1 || g.Metrics[0].Series != 2 {
+		t.Errorf("http group wrong: %+v", byName["http"])
+	}
+	if _, ok := byName["db"]; !ok {
+		t.Errorf("missing db group: %+v", resp.Groups)
+	}
+	if g, ok := byName["other"]; !ok || g.Metrics[0].Name != "uptime" {
+		t.Errorf("dotless metric should fall in 'other': %+v", byName["other"])
+	}
+}
+
+func TestMetricInsightsSpike(t *testing.T) {
+	srv, sm, repo := setupMetricsQueryServer(t)
+	base := time.Date(2026, 6, 16, 0, 0, 0, 0, time.UTC)
+
+	// Six hourly gauge buckets: flat ~10 then a jump to ~50 in the recent window.
+	vals := []float64{10, 10, 10, 10, 50, 52}
+	rollups := make([]repository.MetricRollup, len(vals))
+	for i, v := range vals {
+		rollups[i] = repository.MetricRollup{
+			ProjectID: 1, Name: "cpu.load", Type: "gauge", AttrFingerprint: "fp", Attributes: `{"host":"h1"}`,
+			Bucket: base.Add(time.Duration(i) * time.Hour), Count: 1, Sum: v, Min: v, Max: v, Last: v,
+		}
+	}
+	if err := repo.UpsertMetricRollups(rollups); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	from := base.Format(time.RFC3339)
+	to := base.Add(6 * time.Hour).Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics/insights?project_id=1&from="+from+"&to="+to, nil)
+	req.AddCookie(sessionCookie(t, sm))
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp metricInsightsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Insights) == 0 {
+		t.Fatal("expected at least one insight")
+	}
+	found := false
+	for _, in := range resp.Insights {
+		if in.Metric == "cpu.load" && in.Kind == "spike" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a cpu.load spike insight, got %+v", resp.Insights)
 	}
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -118,6 +118,8 @@ func (s *Server) registerRoutes() {
 		readAuth := SessionOrReadKey(s.sessionMgr, s.authorizer)
 
 		s.mux.Handle("/api/v1/metrics/names", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricNames))))
+		s.mux.Handle("/api/v1/metrics/catalog", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricCatalog))))
+		s.mux.Handle("/api/v1/metrics/insights", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricInsights))))
 		s.mux.Handle("/api/v1/metrics/series", apiRL(readAuth(http.HandlerFunc(mqh.handleMetricSeries))))
 	}
 

--- a/internal/ingest/metrics_handler.go
+++ b/internal/ingest/metrics_handler.go
@@ -20,12 +20,19 @@ type MetricsRepository interface {
 	InsertMetrics(ctx context.Context, recs []model.MetricRecord) error
 }
 
+// MetricRollupSink receives every ingested metric data point so it can fold it
+// into downsampled rollups. Optional; nil disables rollups.
+type MetricRollupSink interface {
+	AddMetric(rec model.MetricRecord)
+}
+
 // MetricsHandler buffers incoming OTLP metric data points and writes them to
 // SQLite in batches. It does not use the spool — losing a flush on crash is
 // acceptable for metrics.
 type MetricsHandler struct {
 	ch     chan []model.MetricRecord
 	repo   MetricsRepository
+	sink   MetricRollupSink
 	logger *slog.Logger
 }
 
@@ -38,6 +45,21 @@ func NewMetricsHandler(repo MetricsRepository, logger *slog.Logger) *MetricsHand
 		ch:     make(chan []model.MetricRecord, metricsChannelSize),
 		repo:   repo,
 		logger: logger,
+	}
+}
+
+// SetRollupSink registers a sink fed every ingested data point. Call before Run.
+func (h *MetricsHandler) SetRollupSink(sink MetricRollupSink) {
+	h.sink = sink
+}
+
+// feed forwards a batch to the rollup sink, if one is registered.
+func (h *MetricsHandler) feed(recs []model.MetricRecord) {
+	if h.sink == nil {
+		return
+	}
+	for _, rec := range recs {
+		h.sink.AddMetric(rec)
 	}
 }
 
@@ -76,6 +98,7 @@ func (h *MetricsHandler) Run(ctx context.Context) {
 	for {
 		select {
 		case recs := <-h.ch:
+			h.feed(recs)
 			pending = append(pending, recs...)
 			if len(pending) >= metricsFlushSize {
 				flush()
@@ -87,6 +110,7 @@ func (h *MetricsHandler) Run(ctx context.Context) {
 			for {
 				select {
 				case recs := <-h.ch:
+					h.feed(recs)
 					pending = append(pending, recs...)
 				default:
 					flush()

--- a/internal/metrics/attributes.go
+++ b/internal/metrics/attributes.go
@@ -1,0 +1,70 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"sort"
+)
+
+// ParseAttributes decodes a stored OTLP attributes JSON object into string
+// labels. Non-string values (numbers, bools) are stringified so they can still
+// identify and group a series. Invalid or empty input yields an empty map.
+func ParseAttributes(raw []byte) map[string]string {
+	out := map[string]string{}
+	if len(raw) == 0 {
+		return out
+	}
+	s := string(raw)
+	if s == "{}" || s == "null" {
+		return out
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return out
+	}
+	for k, v := range m {
+		switch t := v.(type) {
+		case string:
+			out[k] = t
+		case nil:
+			out[k] = ""
+		default:
+			out[k] = fmt.Sprintf("%v", t)
+		}
+	}
+	return out
+}
+
+// Fingerprint returns a stable identifier for a label set, independent of map
+// iteration order. Two attribute maps with the same key/value pairs always
+// produce the same fingerprint.
+func Fingerprint(attrs map[string]string) string {
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	h := fnv.New64a()
+	for _, k := range keys {
+		_, _ = h.Write([]byte(k))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(attrs[k]))
+		_, _ = h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// CanonicalAttributes serialises a label set to a JSON object with keys in
+// sorted order (Go's json.Marshal already sorts map keys), suitable for storage.
+func CanonicalAttributes(attrs map[string]string) string {
+	if len(attrs) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(attrs)
+	if err != nil {
+		return "{}"
+	}
+	return string(b)
+}

--- a/internal/metrics/derive.go
+++ b/internal/metrics/derive.go
@@ -1,0 +1,339 @@
+// Package metrics turns raw OTLP metric data points into render-ready series.
+//
+// Plotting raw stored values is wrong for most OTLP shapes: a cumulative Sum is
+// an ever-rising ramp (the useful view is a per-second rate), and a Histogram's
+// distribution lives in its bucket counts (the useful view is p50/p95/p99), not
+// in the observation count. This package centralises that shape-aware transform
+// so both the live query path and the rollup path render metrics the same way.
+package metrics
+
+import (
+	"encoding/json"
+	"math"
+	"sort"
+)
+
+// RenderKind tells the frontend how a metric series should be drawn.
+type RenderKind string
+
+const (
+	// RenderLine plots the raw value over time (gauges).
+	RenderLine RenderKind = "line"
+	// RenderRate plots the per-second rate of a cumulative counter (sums).
+	RenderRate RenderKind = "rate"
+	// RenderPercentile plots p50/p95/p99 reconstructed from a distribution
+	// (histogram, exponential histogram, summary).
+	RenderPercentile RenderKind = "percentile"
+)
+
+// RenderFor maps an OTLP metric type to how it should be rendered.
+func RenderFor(metricType string) RenderKind {
+	switch metricType {
+	case "sum":
+		return RenderRate
+	case "histogram", "exp_histogram", "summary":
+		return RenderPercentile
+	default: // gauge and anything unrecognised
+		return RenderLine
+	}
+}
+
+// InputPoint is one raw stored data point of a metric, with its attributes
+// already parsed into string labels.
+type InputPoint struct {
+	T          int64 // time_unix_nano
+	Value      float64
+	Count      int64
+	Extra      json.RawMessage
+	Attributes map[string]string
+}
+
+// DerivedPoint is a render-ready point. Which fields are populated depends on
+// the metric's RenderKind: Value for line/rate, the P* fields for percentile.
+type DerivedPoint struct {
+	T     int64    `json:"t"`
+	Value float64  `json:"value"`
+	P50   *float64 `json:"p50,omitempty"`
+	P95   *float64 `json:"p95,omitempty"`
+	P99   *float64 `json:"p99,omitempty"`
+	Count int64    `json:"count"`
+}
+
+// Series is one line in a chart: a label set plus its derived points.
+type Series struct {
+	Labels map[string]string `json:"labels"`
+	Points []DerivedPoint    `json:"points"`
+}
+
+// BuildSeries splits raw points into one Series per distinct label set (or per
+// distinct combination of groupBy keys when groupBy is non-empty), then derives
+// render-ready points for each according to metricType. Input order is
+// preserved within each series; callers should pass points sorted by time.
+func BuildSeries(metricType string, in []InputPoint, groupBy []string) []Series {
+	type bucket struct {
+		labels map[string]string
+		points []InputPoint
+	}
+	order := []string{}
+	groups := map[string]*bucket{}
+
+	for _, p := range in {
+		key, labels := seriesKey(p.Attributes, groupBy)
+		b := groups[key]
+		if b == nil {
+			b = &bucket{labels: labels}
+			groups[key] = b
+			order = append(order, key)
+		}
+		b.points = append(b.points, p)
+	}
+
+	out := make([]Series, 0, len(order))
+	for _, key := range order {
+		b := groups[key]
+		out = append(out, Series{
+			Labels: b.labels,
+			Points: Derive(metricType, b.points),
+		})
+	}
+	return out
+}
+
+// seriesKey computes a stable grouping key and the label set to display for a
+// point. With groupBy set, only those keys participate; otherwise the full
+// attribute set defines the series.
+func seriesKey(attrs map[string]string, groupBy []string) (string, map[string]string) {
+	labels := map[string]string{}
+	if len(groupBy) > 0 {
+		for _, k := range groupBy {
+			if v, ok := attrs[k]; ok {
+				labels[k] = v
+			}
+		}
+	} else {
+		for k, v := range attrs {
+			labels[k] = v
+		}
+	}
+
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var sb []byte
+	for _, k := range keys {
+		sb = append(sb, k...)
+		sb = append(sb, '\x00')
+		sb = append(sb, labels[k]...)
+		sb = append(sb, '\x00')
+	}
+	return string(sb), labels
+}
+
+// Derive converts the raw points of a single series into render-ready points.
+// points must be sorted ascending by T.
+func Derive(metricType string, points []InputPoint) []DerivedPoint {
+	switch RenderFor(metricType) {
+	case RenderRate:
+		return deriveRate(points)
+	case RenderPercentile:
+		return derivePercentiles(metricType, points)
+	default:
+		return deriveGauge(points)
+	}
+}
+
+func deriveGauge(points []InputPoint) []DerivedPoint {
+	out := make([]DerivedPoint, 0, len(points))
+	for _, p := range points {
+		out = append(out, DerivedPoint{T: p.T, Value: p.Value, Count: p.Count})
+	}
+	return out
+}
+
+// deriveRate converts a cumulative counter into a per-second rate. It assumes
+// cumulative temporality (the OTLP default): the rate at point i is the
+// increase since point i-1 divided by the elapsed seconds. A decrease is
+// treated as a counter reset, so the new value itself is taken as the increase.
+func deriveRate(points []InputPoint) []DerivedPoint {
+	out := make([]DerivedPoint, 0, len(points))
+	for i := 1; i < len(points); i++ {
+		prev, cur := points[i-1], points[i]
+		dtSec := float64(cur.T-prev.T) / 1e9
+		if dtSec <= 0 {
+			continue
+		}
+		delta := cur.Value - prev.Value
+		if delta < 0 { // counter reset
+			delta = cur.Value
+		}
+		out = append(out, DerivedPoint{T: cur.T, Value: delta / dtSec, Count: cur.Count})
+	}
+	return out
+}
+
+func derivePercentiles(metricType string, points []InputPoint) []DerivedPoint {
+	out := make([]DerivedPoint, 0, len(points))
+	for _, p := range points {
+		var p50, p95, p99 float64
+		switch metricType {
+		case "histogram":
+			p50, p95, p99 = histogramPercentiles(p.Extra)
+		case "exp_histogram":
+			p50, p95, p99 = expHistogramPercentiles(p.Extra)
+		case "summary":
+			p50, p95, p99 = summaryPercentiles(p.Extra)
+		}
+		dp := DerivedPoint{T: p.T, Count: p.Count}
+		dp.P50, dp.P95, dp.P99 = &p50, &p95, &p99
+		out = append(out, dp)
+	}
+	return out
+}
+
+// --- Histogram (explicit bucket) reconstruction ---
+
+type histExtra struct {
+	Bounds []float64 `json:"bounds"`
+	Counts []float64 `json:"counts"`
+}
+
+func histogramPercentiles(extra json.RawMessage) (p50, p95, p99 float64) {
+	var h histExtra
+	if len(extra) == 0 || json.Unmarshal(extra, &h) != nil {
+		return 0, 0, 0
+	}
+	return histogramQuantile(h.Bounds, h.Counts, 0.50),
+		histogramQuantile(h.Bounds, h.Counts, 0.95),
+		histogramQuantile(h.Bounds, h.Counts, 0.99)
+}
+
+// histogramQuantile estimates the q-quantile (0..1) of an OTLP explicit-bucket
+// histogram using linear interpolation within the matching bucket, the same
+// approach Prometheus uses. bounds has N entries; counts has N+1 (the final
+// entry is the +Inf overflow bucket). The first bucket is assumed to start at 0.
+func histogramQuantile(bounds, counts []float64, q float64) float64 {
+	if len(counts) == 0 {
+		return 0
+	}
+	var total float64
+	for _, c := range counts {
+		total += c
+	}
+	if total == 0 {
+		return 0
+	}
+
+	target := q * total
+	var cum float64
+	for i, c := range counts {
+		if cum+c < target {
+			cum += c
+			continue
+		}
+		lower := 0.0
+		if i > 0 && i-1 < len(bounds) {
+			lower = bounds[i-1]
+		}
+		// Overflow bucket (no upper bound): best estimate is its lower edge.
+		if i >= len(bounds) {
+			return lower
+		}
+		upper := bounds[i]
+		if c <= 0 {
+			return lower
+		}
+		frac := (target - cum) / c
+		return lower + frac*(upper-lower)
+	}
+	// Numerical edge: target == total. Return the largest finite bound.
+	if len(bounds) > 0 {
+		return bounds[len(bounds)-1]
+	}
+	return 0
+}
+
+// --- Exponential histogram reconstruction (positive buckets + zero) ---
+
+type expBuckets struct {
+	Offset       int     `json:"offset"`
+	BucketCounts []int64 `json:"bucket_counts"`
+}
+
+type expExtra struct {
+	Scale     int        `json:"scale"`
+	ZeroCount int64      `json:"zero_count"`
+	Positive  expBuckets `json:"positive"`
+	Negative  expBuckets `json:"negative"`
+}
+
+func expHistogramPercentiles(extra json.RawMessage) (p50, p95, p99 float64) {
+	var e expExtra
+	if len(extra) == 0 || json.Unmarshal(extra, &e) != nil {
+		return 0, 0, 0
+	}
+	bounds, counts := expToExplicit(e)
+	return histogramQuantile(bounds, counts, 0.50),
+		histogramQuantile(bounds, counts, 0.95),
+		histogramQuantile(bounds, counts, 0.99)
+}
+
+// expToExplicit flattens an exponential histogram's positive buckets and zero
+// bucket into explicit (bounds, counts) form so the shared quantile routine can
+// be reused. Negative buckets are uncommon for the latency/size metrics this
+// targets and are not represented. The base of the scale is 2^(2^-scale); a
+// positive bucket at index i covers (base^i, base^(i+1)].
+func expToExplicit(e expExtra) (bounds, counts []float64) {
+	base := math.Pow(2, math.Pow(2, float64(-e.Scale)))
+
+	// Zero bucket: values at (or near) zero, upper bound ~0.
+	if e.ZeroCount > 0 {
+		bounds = append(bounds, 0)
+		counts = append(counts, float64(e.ZeroCount))
+	}
+	for j, c := range e.Positive.BucketCounts {
+		idx := e.Positive.Offset + j
+		upper := math.Pow(base, float64(idx+1))
+		bounds = append(bounds, upper)
+		counts = append(counts, float64(c))
+	}
+	// Trailing overflow bucket expected by histogramQuantile (empty).
+	counts = append(counts, 0)
+	return bounds, counts
+}
+
+// --- Summary (stored quantiles) ---
+
+type summaryQuantile struct {
+	Quantile float64 `json:"quantile"`
+	Value    float64 `json:"value"`
+}
+
+type summaryExtra struct {
+	Quantiles []summaryQuantile `json:"quantiles"`
+}
+
+func summaryPercentiles(extra json.RawMessage) (p50, p95, p99 float64) {
+	var s summaryExtra
+	if len(extra) == 0 || json.Unmarshal(extra, &s) != nil {
+		return 0, 0, 0
+	}
+	return nearestQuantile(s.Quantiles, 0.50),
+		nearestQuantile(s.Quantiles, 0.95),
+		nearestQuantile(s.Quantiles, 0.99)
+}
+
+// nearestQuantile returns the value of the stored quantile closest to q.
+func nearestQuantile(qs []summaryQuantile, q float64) float64 {
+	best := 0.0
+	bestDist := math.MaxFloat64
+	for _, sq := range qs {
+		if d := math.Abs(sq.Quantile - q); d < bestDist {
+			bestDist = d
+			best = sq.Value
+		}
+	}
+	return best
+}

--- a/internal/metrics/derive_test.go
+++ b/internal/metrics/derive_test.go
@@ -1,0 +1,196 @@
+package metrics
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func approx(a, b, tol float64) bool { return math.Abs(a-b) <= tol }
+
+func TestRenderFor(t *testing.T) {
+	cases := map[string]RenderKind{
+		"gauge":         RenderLine,
+		"sum":           RenderRate,
+		"histogram":     RenderPercentile,
+		"exp_histogram": RenderPercentile,
+		"summary":       RenderPercentile,
+		"weird":         RenderLine,
+	}
+	for typ, want := range cases {
+		if got := RenderFor(typ); got != want {
+			t.Errorf("RenderFor(%q) = %q, want %q", typ, got, want)
+		}
+	}
+}
+
+func TestDeriveGauge(t *testing.T) {
+	pts := []InputPoint{{T: 1, Value: 42.5}, {T: 2, Value: 55}}
+	got := Derive("gauge", pts)
+	if len(got) != 2 || got[0].Value != 42.5 || got[1].Value != 55 {
+		t.Fatalf("gauge derive wrong: %+v", got)
+	}
+}
+
+func TestDeriveRate(t *testing.T) {
+	// Cumulative counter increasing by 100 over 10s -> 10/sec.
+	pts := []InputPoint{
+		{T: 0, Value: 0},
+		{T: 10e9, Value: 100},
+		{T: 20e9, Value: 250}, // +150 over 10s -> 15/sec
+	}
+	got := Derive("sum", pts)
+	if len(got) != 2 {
+		t.Fatalf("want 2 rate points (n-1), got %d", len(got))
+	}
+	if !approx(got[0].Value, 10, 1e-9) {
+		t.Errorf("first rate = %v, want 10", got[0].Value)
+	}
+	if !approx(got[1].Value, 15, 1e-9) {
+		t.Errorf("second rate = %v, want 15", got[1].Value)
+	}
+}
+
+func TestDeriveRateCounterReset(t *testing.T) {
+	// Counter resets (300 -> 50): treat 50 as the increase over the interval.
+	pts := []InputPoint{
+		{T: 0, Value: 300},
+		{T: 10e9, Value: 50},
+	}
+	got := Derive("sum", pts)
+	if len(got) != 1 {
+		t.Fatalf("want 1 point, got %d", len(got))
+	}
+	if !approx(got[0].Value, 5, 1e-9) { // 50 / 10s
+		t.Errorf("reset rate = %v, want 5", got[0].Value)
+	}
+}
+
+func TestDeriveRateZeroInterval(t *testing.T) {
+	// Duplicate timestamp must not divide by zero; point is skipped.
+	pts := []InputPoint{{T: 5e9, Value: 1}, {T: 5e9, Value: 2}}
+	if got := Derive("sum", pts); len(got) != 0 {
+		t.Errorf("want 0 points for zero interval, got %d", len(got))
+	}
+}
+
+func TestHistogramQuantile(t *testing.T) {
+	// Buckets: <=10 (5 obs), <=20 (5), <=50 (5), +Inf (0). Total 15.
+	bounds := []float64{10, 20, 50}
+	counts := []float64{5, 5, 5, 0}
+
+	// p50 -> target 7.5, lands in 2nd bucket (10,20], cumBefore=5, frac=2.5/5=0.5 -> 15.
+	if v := histogramQuantile(bounds, counts, 0.50); !approx(v, 15, 1e-9) {
+		t.Errorf("p50 = %v, want 15", v)
+	}
+	// p95 -> target 14.25, 3rd bucket (20,50], cumBefore=10, frac=4.25/5=0.85 -> 20+0.85*30=45.5
+	if v := histogramQuantile(bounds, counts, 0.95); !approx(v, 45.5, 1e-9) {
+		t.Errorf("p95 = %v, want 45.5", v)
+	}
+}
+
+func TestHistogramQuantileFirstBucket(t *testing.T) {
+	// First bucket starts at 0: <=100 holds everything.
+	bounds := []float64{100}
+	counts := []float64{10, 0}
+	// p50 target 5 -> bucket 0 [0,100], frac=5/10=0.5 -> 50.
+	if v := histogramQuantile(bounds, counts, 0.50); !approx(v, 50, 1e-9) {
+		t.Errorf("p50 = %v, want 50", v)
+	}
+}
+
+func TestHistogramQuantileEmpty(t *testing.T) {
+	if v := histogramQuantile(nil, nil, 0.5); v != 0 {
+		t.Errorf("empty histogram quantile = %v, want 0", v)
+	}
+	if v := histogramQuantile([]float64{10}, []float64{0, 0}, 0.5); v != 0 {
+		t.Errorf("all-zero histogram quantile = %v, want 0", v)
+	}
+}
+
+func TestDeriveHistogramFromExtra(t *testing.T) {
+	extra := json.RawMessage(`{"bounds":[10,20,50],"counts":[5,5,5,0]}`)
+	got := Derive("histogram", []InputPoint{{T: 1, Extra: extra, Count: 15}})
+	if len(got) != 1 || got[0].P50 == nil || got[0].P95 == nil {
+		t.Fatalf("histogram derive missing percentiles: %+v", got)
+	}
+	if !approx(*got[0].P50, 15, 1e-9) {
+		t.Errorf("p50 = %v, want 15", *got[0].P50)
+	}
+}
+
+func TestExpHistogramPercentiles(t *testing.T) {
+	// scale 0 -> base 2. Positive buckets at offset 0: index0 (1,2], index1 (2,4], index2 (4,8].
+	// 10 obs in each. zero_count 0.
+	extra := json.RawMessage(`{"scale":0,"zero_count":0,"positive":{"offset":0,"bucket_counts":[10,10,10]}}`)
+	p50, p95, p99 := expHistogramPercentiles(extra)
+	// p50 -> target 15 of 30, lands in 2nd bucket upper bound 4, lower 2 -> within (2,4].
+	if p50 < 2 || p50 > 4 {
+		t.Errorf("p50 = %v, want in (2,4]", p50)
+	}
+	// p95/p99 land in the top bucket (4,8].
+	if p95 < 4 || p95 > 8 {
+		t.Errorf("p95 = %v, want in (4,8]", p95)
+	}
+	if p99 < 4 || p99 > 8 {
+		t.Errorf("p99 = %v, want in (4,8]", p99)
+	}
+}
+
+func TestSummaryPercentiles(t *testing.T) {
+	extra := json.RawMessage(`{"quantiles":[{"quantile":0.5,"value":12},{"quantile":0.95,"value":88},{"quantile":0.99,"value":120}]}`)
+	got := Derive("summary", []InputPoint{{T: 1, Extra: extra}})
+	if len(got) != 1 {
+		t.Fatalf("want 1 point")
+	}
+	if *got[0].P50 != 12 || *got[0].P95 != 88 || *got[0].P99 != 120 {
+		t.Errorf("summary quantiles wrong: %v %v %v", *got[0].P50, *got[0].P95, *got[0].P99)
+	}
+}
+
+func TestSummaryNearestQuantile(t *testing.T) {
+	// Only 0.5 and 0.9 stored; p95 should snap to nearest (0.9 -> 80), p99 too.
+	extra := json.RawMessage(`{"quantiles":[{"quantile":0.5,"value":10},{"quantile":0.9,"value":80}]}`)
+	got := Derive("summary", []InputPoint{{T: 1, Extra: extra}})
+	if *got[0].P95 != 80 || *got[0].P99 != 80 {
+		t.Errorf("nearest-quantile snap wrong: p95=%v p99=%v", *got[0].P95, *got[0].P99)
+	}
+}
+
+func TestBuildSeriesSplitByAttributes(t *testing.T) {
+	// Two gauges with different service labels -> two series.
+	in := []InputPoint{
+		{T: 1, Value: 1, Attributes: map[string]string{"service.name": "web"}},
+		{T: 2, Value: 2, Attributes: map[string]string{"service.name": "api"}},
+		{T: 3, Value: 3, Attributes: map[string]string{"service.name": "web"}},
+	}
+	got := BuildSeries("gauge", in, nil)
+	if len(got) != 2 {
+		t.Fatalf("want 2 series, got %d", len(got))
+	}
+	// First-seen order preserved: web first.
+	if got[0].Labels["service.name"] != "web" || len(got[0].Points) != 2 {
+		t.Errorf("web series wrong: %+v", got[0])
+	}
+	if got[1].Labels["service.name"] != "api" || len(got[1].Points) != 1 {
+		t.Errorf("api series wrong: %+v", got[1])
+	}
+}
+
+func TestBuildSeriesGroupBy(t *testing.T) {
+	// Group by route only; service is ignored so both points merge into one series.
+	in := []InputPoint{
+		{T: 1, Value: 1, Attributes: map[string]string{"route": "/a", "service.name": "web"}},
+		{T: 2, Value: 2, Attributes: map[string]string{"route": "/a", "service.name": "api"}},
+		{T: 3, Value: 3, Attributes: map[string]string{"route": "/b", "service.name": "web"}},
+	}
+	got := BuildSeries("gauge", in, []string{"route"})
+	if len(got) != 2 {
+		t.Fatalf("want 2 series (one per route), got %d", len(got))
+	}
+	for _, s := range got {
+		if _, ok := s.Labels["service.name"]; ok {
+			t.Errorf("group-by should drop non-grouped labels, got %+v", s.Labels)
+		}
+	}
+}

--- a/internal/metrics/insights.go
+++ b/internal/metrics/insights.go
@@ -1,0 +1,123 @@
+package metrics
+
+import "math"
+
+// Insight describes a notable change in a single metric series: a spike, a drop,
+// a percentile regression, or a newly-appeared series. It lets the UI surface
+// what changed instead of making the user eyeball every graph.
+type Insight struct {
+	Metric    string            `json:"metric"`
+	Labels    map[string]string `json:"labels"`
+	Kind      string            `json:"kind"`   // spike | drop | regression | new_series
+	Render    string            `json:"render"` // how to chart the metric (see RenderFor)
+	Baseline  float64           `json:"baseline"`
+	Recent    float64           `json:"recent"`
+	ChangePct float64           `json:"changePct"` // signed fractional change (0.5 = +50%); 0 for new_series
+}
+
+// Detection thresholds.
+const (
+	insightMinBaseline = 3   // baseline buckets required to judge a change
+	insightMinNew      = 2   // recent buckets required to call a series "new"
+	insightThreshold   = 0.5 // minimum |change| (50%) to report a spike/drop
+	insightCappedPct   = 10  // sentinel change when the baseline mean is ~0
+	insightEpsilon     = 1e-9
+)
+
+// DetectSeries compares a series' recent window (buckets at or after splitNano)
+// to its baseline (buckets before splitNano) and returns an Insight when the
+// change is notable. points must be sorted ascending by time.
+func DetectSeries(name, metricType string, labels map[string]string, points []InputPoint, splitNano int64) (Insight, bool) {
+	render := RenderFor(metricType)
+	derived := Derive(metricType, points)
+
+	var base, recent []float64
+	for _, d := range derived {
+		v := scalarOf(render, d)
+		if d.T < splitNano {
+			base = append(base, v)
+		} else {
+			recent = append(recent, v)
+		}
+	}
+	if len(recent) == 0 {
+		return Insight{}, false
+	}
+	recentMean := mean(recent)
+
+	if len(base) < insightMinBaseline {
+		// No real baseline: report as a newly-appeared series if it has enough
+		// recent activity, otherwise stay quiet.
+		if len(base) == 0 && len(recent) >= insightMinNew {
+			return Insight{Metric: name, Labels: labels, Kind: "new_series", Render: string(render), Recent: recentMean}, true
+		}
+		return Insight{}, false
+	}
+
+	baseMean := mean(base)
+	var pct float64
+	if math.Abs(baseMean) < insightEpsilon {
+		if math.Abs(recentMean) < insightEpsilon {
+			return Insight{}, false
+		}
+		pct = insightCappedPct
+		if recentMean < 0 {
+			pct = -insightCappedPct
+		}
+	} else {
+		pct = (recentMean - baseMean) / math.Abs(baseMean)
+	}
+
+	if math.Abs(pct) < insightThreshold {
+		return Insight{}, false
+	}
+
+	kind := "spike"
+	if pct < 0 {
+		kind = "drop"
+	} else if render == RenderPercentile {
+		// A rising distribution is a latency/size regression.
+		kind = "regression"
+	}
+
+	return Insight{
+		Metric:    name,
+		Labels:    labels,
+		Kind:      kind,
+		Render:    string(render),
+		Baseline:  baseMean,
+		Recent:    recentMean,
+		ChangePct: pct,
+	}, true
+}
+
+// Magnitude ranks insights: new series first, then by the size of the change.
+func (i Insight) Magnitude() float64 {
+	if i.Kind == "new_series" {
+		return math.MaxFloat64
+	}
+	return math.Abs(i.ChangePct)
+}
+
+// scalarOf reduces a derived point to the single value used for comparison:
+// p95 for distributions, the value/rate otherwise.
+func scalarOf(render RenderKind, d DerivedPoint) float64 {
+	if render == RenderPercentile {
+		if d.P95 != nil {
+			return *d.P95
+		}
+		return 0
+	}
+	return d.Value
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var s float64
+	for _, x := range xs {
+		s += x
+	}
+	return s / float64(len(xs))
+}

--- a/internal/metrics/insights_test.go
+++ b/internal/metrics/insights_test.go
@@ -1,0 +1,89 @@
+package metrics
+
+import "testing"
+
+// gaugePoints builds evenly-spaced gauge input points starting at t0 (nanos),
+// one per minute.
+func gaugePoints(t0 int64, vals ...float64) []InputPoint {
+	const minute = int64(60_000_000_000)
+	pts := make([]InputPoint, len(vals))
+	for i, v := range vals {
+		pts[i] = InputPoint{T: t0 + int64(i)*minute, Value: v}
+	}
+	return pts
+}
+
+func TestDetectSeriesSpike(t *testing.T) {
+	pts := gaugePoints(0, 10, 10, 10, 10, 50, 52) // baseline ~10, recent ~51
+	split := pts[4].T
+	in, ok := DetectSeries("cpu.load", "gauge", nil, pts, split)
+	if !ok {
+		t.Fatal("expected a spike insight")
+	}
+	if in.Kind != "spike" {
+		t.Errorf("kind = %q, want spike", in.Kind)
+	}
+	if in.ChangePct < 0.5 {
+		t.Errorf("changePct = %v, want >= 0.5", in.ChangePct)
+	}
+}
+
+func TestDetectSeriesDrop(t *testing.T) {
+	pts := gaugePoints(0, 100, 100, 100, 100, 20, 18)
+	in, ok := DetectSeries("cpu.load", "gauge", nil, pts, pts[4].T)
+	if !ok || in.Kind != "drop" {
+		t.Fatalf("expected drop, got %+v ok=%v", in, ok)
+	}
+	if in.ChangePct >= 0 {
+		t.Errorf("drop changePct should be negative, got %v", in.ChangePct)
+	}
+}
+
+func TestDetectSeriesStableNoInsight(t *testing.T) {
+	pts := gaugePoints(0, 50, 51, 49, 50, 50, 51)
+	if _, ok := DetectSeries("cpu.load", "gauge", nil, pts, pts[4].T); ok {
+		t.Error("stable series should produce no insight")
+	}
+}
+
+func TestDetectSeriesNew(t *testing.T) {
+	// All points are in the recent window (no baseline).
+	pts := gaugePoints(1000, 5, 6, 7)
+	in, ok := DetectSeries("new.metric", "gauge", nil, pts, 0)
+	if !ok || in.Kind != "new_series" {
+		t.Fatalf("expected new_series, got %+v ok=%v", in, ok)
+	}
+	if in.Magnitude() <= 1e9 {
+		t.Error("new_series should rank above ordinary changes")
+	}
+}
+
+func TestDetectSeriesHistogramRegression(t *testing.T) {
+	const minute = int64(60_000_000_000)
+	mk := func(i int, p95 float64) InputPoint {
+		// Single-bucket histogram whose only bucket upper bound is p95, so the
+		// reconstructed p95 tracks that bound.
+		return InputPoint{T: int64(i) * minute, Count: 10,
+			Extra: []byte(`{"bounds":[` + ftoa(p95) + `],"counts":[10,0]}`)}
+	}
+	pts := []InputPoint{mk(0, 100), mk(1, 100), mk(2, 100), mk(3, 100), mk(4, 400), mk(5, 400)}
+	in, ok := DetectSeries("http.server.duration", "histogram", nil, pts, pts[4].T)
+	if !ok {
+		t.Fatal("expected a regression insight")
+	}
+	if in.Kind != "regression" {
+		t.Errorf("kind = %q, want regression", in.Kind)
+	}
+}
+
+// ftoa is a tiny float formatter to keep the test JSON literals readable.
+func ftoa(f float64) string {
+	switch f {
+	case 100:
+		return "100"
+	case 400:
+		return "400"
+	default:
+		return "0"
+	}
+}

--- a/internal/repository/migrations/025_metric_rollups.go
+++ b/internal/repository/migrations/025_metric_rollups.go
@@ -1,0 +1,57 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up025, down025)
+}
+
+func up025(ctx context.Context, tx *sql.Tx) error {
+	stmts := []string{
+		// metric_rollups stores per-series, per-bucket downsampled metrics so that
+		// long-range queries do not scan the raw metrics table. One row per
+		// (project, name, attribute set, time bucket). Columns are type-agnostic:
+		//   gauge        — sum/count gives the bucket average; min/max/last carry detail
+		//   sum          — last is the cumulative value at bucket end (rate derived across buckets)
+		//   histogram    — extra holds merged {bounds,counts}; obs_count/sum the totals
+		//   exp_histogram— extra holds the last merged exponential buckets
+		//   summary      — extra holds the last quantiles
+		`CREATE TABLE metric_rollups (
+			id               INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id       INTEGER NOT NULL,
+			name             TEXT    NOT NULL,
+			type             TEXT    NOT NULL,
+			unit             TEXT    NOT NULL DEFAULT '',
+			attr_fingerprint TEXT    NOT NULL,
+			attributes       TEXT    NOT NULL DEFAULT '{}',
+			bucket           DATETIME NOT NULL,
+			count            INTEGER NOT NULL DEFAULT 0,
+			sum              REAL    NOT NULL DEFAULT 0,
+			min              REAL    NOT NULL DEFAULT 0,
+			max              REAL    NOT NULL DEFAULT 0,
+			last             REAL    NOT NULL DEFAULT 0,
+			obs_count        INTEGER NOT NULL DEFAULT 0,
+			extra            TEXT,
+			ingested_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE UNIQUE INDEX idx_metric_rollups_lookup ON metric_rollups(project_id, name, attr_fingerprint, bucket)`,
+		`CREATE INDEX idx_metric_rollups_bucket ON metric_rollups(project_id, bucket)`,
+		`CREATE INDEX idx_metric_rollups_name ON metric_rollups(project_id, name, bucket)`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down025(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS metric_rollups`)
+	return err
+}

--- a/internal/repository/migrations/026_metric_alerts.go
+++ b/internal/repository/migrations/026_metric_alerts.go
@@ -1,0 +1,42 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up026, down026)
+}
+
+func up026(ctx context.Context, tx *sql.Tx) error {
+	// Extend alerts with metric-threshold fields. Existing latency/error_rate
+	// alerts leave these empty.
+	stmts := []string{
+		`ALTER TABLE alerts ADD COLUMN metric_name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE alerts ADD COLUMN metric_agg TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE alerts ADD COLUMN label_filters TEXT NOT NULL DEFAULT '{}'`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down026(ctx context.Context, tx *sql.Tx) error {
+	stmts := []string{
+		`ALTER TABLE alerts DROP COLUMN metric_name`,
+		`ALTER TABLE alerts DROP COLUMN metric_agg`,
+		`ALTER TABLE alerts DROP COLUMN label_filters`,
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -172,6 +172,12 @@ type Alert struct {
 	WebhookURL       string       `json:"webhookUrl"`
 	Email            string       `json:"email"`
 	Enabled          bool         `json:"enabled"`
-	LastTriggeredAt  sql.NullTime `json:"lastTriggeredAt"`
-	CreatedAt        time.Time    `json:"createdAt"`
+	// Metric-threshold fields (type == "metric_threshold"). MetricName is the
+	// OTLP metric, MetricAgg one of rate/avg/p95/last, LabelFilters a JSON object
+	// of attribute equality filters scoping which series the alert watches.
+	MetricName      string `json:"metricName"`
+	MetricAgg       string `json:"metricAgg"`
+	LabelFilters    string `json:"labelFilters"`
+	LastTriggeredAt sql.NullTime `json:"lastTriggeredAt"`
+	CreatedAt       time.Time    `json:"createdAt"`
 }

--- a/internal/repository/repo_alerts.go
+++ b/internal/repository/repo_alerts.go
@@ -16,14 +16,14 @@ func (r *Repository) ListAlerts(projectID int64) ([]Alert, error) {
 		rows, err = r.db.Query(
 			`SELECT id, project_id, service, operation, type, threshold,
 				comparison_window, cooldown_minutes, COALESCE(webhook_url,''), COALESCE(email,''),
-				enabled, last_triggered_at, created_at
+				enabled, metric_name, metric_agg, label_filters, last_triggered_at, created_at
 			FROM alerts ORDER BY id`,
 		)
 	} else {
 		rows, err = r.db.Query(
 			`SELECT id, project_id, service, operation, type, threshold,
 				comparison_window, cooldown_minutes, COALESCE(webhook_url,''), COALESCE(email,''),
-				enabled, last_triggered_at, created_at
+				enabled, metric_name, metric_agg, label_filters, last_triggered_at, created_at
 			FROM alerts WHERE project_id = ? ORDER BY id`,
 			projectID,
 		)
@@ -39,7 +39,7 @@ func (r *Repository) ListAlerts(projectID int64) ([]Alert, error) {
 		if err := rows.Scan(
 			&a.ID, &a.ProjectID, &a.Service, &a.Operation, &a.Type, &a.Threshold,
 			&a.ComparisonWindow, &a.CooldownMinutes, &a.WebhookURL, &a.Email,
-			&enabled, &a.LastTriggeredAt, &a.CreatedAt,
+			&enabled, &a.MetricName, &a.MetricAgg, &a.LabelFilters, &a.LastTriggeredAt, &a.CreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -49,6 +49,15 @@ func (r *Repository) ListAlerts(projectID int64) ([]Alert, error) {
 	return out, rows.Err()
 }
 
+// normalizeLabelFilters defaults empty/blank label filters to an empty object so
+// the NOT NULL column always holds valid JSON.
+func normalizeLabelFilters(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "{}"
+	}
+	return s
+}
+
 func (r *Repository) CreateAlert(a Alert) (int64, error) {
 	enabled := 0
 	if a.Enabled {
@@ -56,10 +65,12 @@ func (r *Repository) CreateAlert(a Alert) (int64, error) {
 	}
 	res, err := r.db.Exec(
 		`INSERT INTO alerts (project_id, service, operation, type, threshold,
-			comparison_window, cooldown_minutes, webhook_url, email, enabled)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			comparison_window, cooldown_minutes, webhook_url, email, enabled,
+			metric_name, metric_agg, label_filters)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ProjectID, a.Service, a.Operation, a.Type, a.Threshold,
 		a.ComparisonWindow, a.CooldownMinutes, a.WebhookURL, a.Email, enabled,
+		a.MetricName, a.MetricAgg, normalizeLabelFilters(a.LabelFilters),
 	)
 	if err != nil {
 		return 0, err
@@ -74,10 +85,12 @@ func (r *Repository) UpdateAlert(a Alert) error {
 	}
 	res, err := r.db.Exec(
 		`UPDATE alerts SET service = ?, operation = ?, type = ?, threshold = ?,
-			comparison_window = ?, cooldown_minutes = ?, webhook_url = ?, email = ?, enabled = ?
+			comparison_window = ?, cooldown_minutes = ?, webhook_url = ?, email = ?, enabled = ?,
+			metric_name = ?, metric_agg = ?, label_filters = ?
 		WHERE id = ?`,
 		a.Service, a.Operation, a.Type, a.Threshold,
 		a.ComparisonWindow, a.CooldownMinutes, a.WebhookURL, a.Email, enabled,
+		a.MetricName, a.MetricAgg, normalizeLabelFilters(a.LabelFilters),
 		a.ID,
 	)
 	if err != nil {

--- a/internal/repository/repo_metric_rollups.go
+++ b/internal/repository/repo_metric_rollups.go
@@ -1,0 +1,200 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// MetricRollup is one downsampled metric series bucket. See migration 025 for
+// how the columns map onto each OTLP metric type.
+type MetricRollup struct {
+	ProjectID       int64
+	Name            string
+	Type            string
+	Unit            string
+	AttrFingerprint string
+	Attributes      string // canonical JSON of the label set
+	Bucket          time.Time
+	Count           int64
+	Sum             float64
+	Min             float64
+	Max             float64
+	Last            float64
+	ObsCount        int64
+	Extra           string // merged histogram / last summary quantiles
+}
+
+// MetricRollupFilter scopes a rollup query.
+type MetricRollupFilter struct {
+	ProjectID  int64
+	Name       string
+	From       time.Time
+	To         time.Time
+	Attributes map[string]string // label equality filters via JSON_EXTRACT
+	Limit      int
+}
+
+// UpsertMetricRollups persists a batch of rollup buckets in a single
+// transaction. Counts and sums accumulate on conflict (so a late straggler for
+// an already-written bucket still folds in); min/max take the extreme; last and
+// extra are replaced by the newest flush, which is correct because the
+// accumulator only emits a bucket once it is closed.
+func (r *Repository) UpsertMetricRollups(rollups []MetricRollup) error {
+	if len(rollups) == 0 {
+		return nil
+	}
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`INSERT INTO metric_rollups
+		(project_id, name, type, unit, attr_fingerprint, attributes, bucket,
+		 count, sum, min, max, last, obs_count, extra)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project_id, name, attr_fingerprint, bucket)
+		DO UPDATE SET
+			count = count + excluded.count,
+			sum = sum + excluded.sum,
+			min = MIN(min, excluded.min),
+			max = MAX(max, excluded.max),
+			last = excluded.last,
+			obs_count = obs_count + excluded.obs_count,
+			extra = excluded.extra`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, m := range rollups {
+		attrs := m.Attributes
+		if attrs == "" {
+			attrs = "{}"
+		}
+		var extra *string
+		if m.Extra != "" {
+			extra = &m.Extra
+		}
+		if _, err := stmt.Exec(
+			m.ProjectID, m.Name, m.Type, m.Unit, m.AttrFingerprint, attrs, m.Bucket,
+			m.Count, m.Sum, m.Min, m.Max, m.Last, m.ObsCount, extra,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+// QueryMetricRollups returns rollup buckets for a metric name, ordered by bucket
+// ascending so the derivation layer can compute rates across consecutive buckets.
+func (r *Repository) QueryMetricRollups(ctx context.Context, f MetricRollupFilter) ([]MetricRollup, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
+	where := []string{"project_id = ?", "name = ?", "bucket >= ?", "bucket <= ?"}
+	args := []any{f.ProjectID, f.Name, f.From, f.To}
+	for k, v := range f.Attributes {
+		where = append(where, fmt.Sprintf(`JSON_EXTRACT(attributes, '$."%s"') = ?`, k))
+		args = append(args, v)
+	}
+
+	limit := f.Limit
+	if limit <= 0 || limit > 50000 {
+		limit = 10000
+	}
+	args = append(args, limit)
+
+	q := fmt.Sprintf(`SELECT project_id, name, type, unit, attr_fingerprint, attributes, bucket,
+		count, sum, min, max, last, obs_count, extra
+		FROM metric_rollups WHERE %s ORDER BY bucket ASC LIMIT ?`,
+		strings.Join(where, " AND "))
+
+	rows, err := r.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []MetricRollup
+	for rows.Next() {
+		var m MetricRollup
+		var extra sql.NullString
+		if err := rows.Scan(
+			&m.ProjectID, &m.Name, &m.Type, &m.Unit, &m.AttrFingerprint, &m.Attributes, &m.Bucket,
+			&m.Count, &m.Sum, &m.Min, &m.Max, &m.Last, &m.ObsCount, &extra,
+		); err != nil {
+			return nil, err
+		}
+		if extra.Valid {
+			m.Extra = extra.String
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// QueryProjectRollups returns every rollup bucket for a project within a time
+// range, across all metric names, ordered by name then bucket ascending. Used
+// by insight detection to scan all series at once.
+func (r *Repository) QueryProjectRollups(ctx context.Context, projectID int64, from, to time.Time, limit int) ([]MetricRollup, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
+	if limit <= 0 || limit > 200000 {
+		limit = 50000
+	}
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT project_id, name, type, unit, attr_fingerprint, attributes, bucket,
+			count, sum, min, max, last, obs_count, extra
+		 FROM metric_rollups
+		 WHERE project_id = ? AND bucket >= ? AND bucket <= ?
+		 ORDER BY name ASC, attr_fingerprint ASC, bucket ASC LIMIT ?`,
+		projectID, from, to, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []MetricRollup
+	for rows.Next() {
+		var m MetricRollup
+		var extra sql.NullString
+		if err := rows.Scan(
+			&m.ProjectID, &m.Name, &m.Type, &m.Unit, &m.AttrFingerprint, &m.Attributes, &m.Bucket,
+			&m.Count, &m.Sum, &m.Min, &m.Max, &m.Last, &m.ObsCount, &extra,
+		); err != nil {
+			return nil, err
+		}
+		if extra.Valid {
+			m.Extra = extra.String
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// DeleteMetricRollupsOlderThan removes rollup buckets older than cutoff, in
+// bounded chunks so the write lock is never held long enough to block ingest.
+func (r *Repository) DeleteMetricRollupsOlderThan(cutoff time.Time) (int64, error) {
+	var total int64
+	for {
+		res, err := r.db.Exec(
+			"DELETE FROM metric_rollups WHERE rowid IN (SELECT rowid FROM metric_rollups WHERE bucket < ? LIMIT 1000)",
+			cutoff,
+		)
+		if err != nil {
+			return total, err
+		}
+		n, _ := res.RowsAffected()
+		total += n
+		if n == 0 {
+			break
+		}
+	}
+	return total, nil
+}

--- a/internal/repository/repo_metric_rollups_test.go
+++ b/internal/repository/repo_metric_rollups_test.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestUpsertAndQueryMetricRollups(t *testing.T) {
+	repo := setupTestDB(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	rollups := []MetricRollup{
+		{ProjectID: 1, Name: "g", Type: "gauge", Unit: "ms", AttrFingerprint: "fp1", Attributes: `{"svc":"a"}`, Bucket: base, Count: 2, Sum: 30, Min: 10, Max: 20, Last: 20},
+		{ProjectID: 1, Name: "g", Type: "gauge", Unit: "ms", AttrFingerprint: "fp1", Attributes: `{"svc":"a"}`, Bucket: base.Add(time.Minute), Count: 1, Sum: 40, Min: 40, Max: 40, Last: 40},
+	}
+	if err := repo.UpsertMetricRollups(rollups); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := repo.QueryMetricRollups(context.Background(), MetricRollupFilter{
+		ProjectID: 1, Name: "g", From: base.Add(-time.Hour), To: base.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 rollups, got %d", len(got))
+	}
+	// Ordered by bucket ascending.
+	if !got[0].Bucket.Before(got[1].Bucket) {
+		t.Errorf("rollups not ordered ascending: %v then %v", got[0].Bucket, got[1].Bucket)
+	}
+	if got[0].Sum != 30 || got[0].Max != 20 {
+		t.Errorf("first rollup wrong: %+v", got[0])
+	}
+}
+
+func TestUpsertMetricRollupsConflictMerge(t *testing.T) {
+	repo := setupTestDB(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	r := MetricRollup{ProjectID: 1, Name: "c", Type: "sum", AttrFingerprint: "fp", Attributes: "{}", Bucket: base, Count: 1, Sum: 10, Min: 10, Max: 10, Last: 10, ObsCount: 1}
+	if err := repo.UpsertMetricRollups([]MetricRollup{r}); err != nil {
+		t.Fatalf("upsert 1: %v", err)
+	}
+	// Same key again (a late straggler): counts/sum/obs add, max takes the larger, last replaced.
+	r2 := r
+	r2.Count = 2
+	r2.Sum = 25
+	r2.Max = 30
+	r2.Last = 30
+	r2.ObsCount = 2
+	if err := repo.UpsertMetricRollups([]MetricRollup{r2}); err != nil {
+		t.Fatalf("upsert 2: %v", err)
+	}
+
+	got, err := repo.QueryMetricRollups(context.Background(), MetricRollupFilter{ProjectID: 1, Name: "c", From: base.Add(-time.Hour), To: base.Add(time.Hour)})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged rollup, got %d", len(got))
+	}
+	m := got[0]
+	if m.Count != 3 || m.Sum != 35 || m.Max != 30 || m.Last != 30 || m.ObsCount != 3 {
+		t.Errorf("conflict merge wrong: %+v", m)
+	}
+}
+
+func TestQueryMetricRollupsLabelFilter(t *testing.T) {
+	repo := setupTestDB(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertMetricRollups([]MetricRollup{
+		{ProjectID: 1, Name: "g", Type: "gauge", AttrFingerprint: "a", Attributes: `{"svc":"a"}`, Bucket: base, Count: 1, Last: 1},
+		{ProjectID: 1, Name: "g", Type: "gauge", AttrFingerprint: "b", Attributes: `{"svc":"b"}`, Bucket: base, Count: 1, Last: 2},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := repo.QueryMetricRollups(context.Background(), MetricRollupFilter{
+		ProjectID: 1, Name: "g", From: base.Add(-time.Hour), To: base.Add(time.Hour),
+		Attributes: map[string]string{"svc": "b"},
+	})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(got) != 1 || got[0].Last != 2 {
+		t.Fatalf("label filter wrong: %+v", got)
+	}
+}
+
+func TestDeleteMetricRollupsOlderThan(t *testing.T) {
+	repo := setupTestDB(t)
+	base := time.Date(2026, 6, 16, 12, 0, 0, 0, time.UTC)
+
+	if err := repo.UpsertMetricRollups([]MetricRollup{
+		{ProjectID: 1, Name: "g", Type: "gauge", AttrFingerprint: "a", Attributes: "{}", Bucket: base.Add(-48 * time.Hour), Count: 1},
+		{ProjectID: 1, Name: "g", Type: "gauge", AttrFingerprint: "b", Attributes: "{}", Bucket: base, Count: 1},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	deleted, err := repo.DeleteMetricRollupsOlderThan(base.Add(-24 * time.Hour))
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("want 1 deleted, got %d", deleted)
+	}
+	got, _ := repo.QueryMetricRollups(context.Background(), MetricRollupFilter{ProjectID: 1, Name: "g", From: base.Add(-72 * time.Hour), To: base.Add(time.Hour)})
+	if len(got) != 1 {
+		t.Errorf("want 1 remaining, got %d", len(got))
+	}
+}

--- a/internal/repository/repo_metrics.go
+++ b/internal/repository/repo_metrics.go
@@ -107,6 +107,45 @@ func (r *Repository) ListMetricNames(ctx context.Context, projectID int64, from,
 	return names, rows.Err()
 }
 
+// MetricCatalogEntry summarises one metric name within a time range: its OTLP
+// type, unit, and the number of distinct label sets (series) seen.
+type MetricCatalogEntry struct {
+	Name   string
+	Type   string
+	Unit   string
+	Series int64
+}
+
+// ListMetricCatalog returns one entry per metric name for a project within a
+// time range, with its type, unit, and distinct-series count.
+func (r *Repository) ListMetricCatalog(ctx context.Context, projectID int64, from, to time.Time) ([]MetricCatalogEntry, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
+	defer cancel()
+
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT name, type, unit, COUNT(DISTINCT attributes) AS series
+		 FROM metrics
+		 WHERE project_id = ? AND ingested_at >= ? AND ingested_at <= ?
+		 GROUP BY name, type, unit
+		 ORDER BY name LIMIT 2000`,
+		projectID, from, to,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []MetricCatalogEntry
+	for rows.Next() {
+		var e MetricCatalogEntry
+		if err := rows.Scan(&e.Name, &e.Type, &e.Unit, &e.Series); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // QueryMetricSeries returns data points for a specific metric name.
 func (r *Repository) QueryMetricSeries(ctx context.Context, f MetricFilter) ([]MetricRow, error) {
 	ctx, cancel := context.WithTimeout(ctx, r.queryTimeout)
@@ -157,14 +196,25 @@ func (r *Repository) QueryMetricSeries(ctx context.Context, f MetricFilter) ([]M
 	return result, rows.Err()
 }
 
-// DeleteMetricsOlderThan removes metric data points ingested before the cutoff.
+// DeleteMetricsOlderThan removes metric data points ingested before the cutoff,
+// in bounded chunks so a large backlog never holds the write lock long enough to
+// block ingest (an unbatched DELETE here previously stalled writes for minutes).
 func (r *Repository) DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	res, err := r.db.ExecContext(ctx,
-		`DELETE FROM metrics WHERE ingested_at < ?`, cutoff)
-	if err != nil {
-		return 0, err
+	var total int64
+	for {
+		res, err := r.db.ExecContext(ctx,
+			`DELETE FROM metrics WHERE rowid IN (SELECT rowid FROM metrics WHERE ingested_at < ? LIMIT 1000)`,
+			cutoff)
+		if err != nil {
+			return total, err
+		}
+		n, _ := res.RowsAffected()
+		total += n
+		if n == 0 {
+			break
+		}
 	}
-	return res.RowsAffected()
+	return total, nil
 }
 
 // MarshalMetricExtra serialises the Extra field of a MetricRow for JSON responses.

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -47,6 +47,7 @@ type Repository interface {
 	DeleteAggregatesOlderThan(cutoff time.Time) (int64, error)
 	DeleteExpiredE2EUsers(now time.Time) (int64, error)
 	DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteMetricRollupsOlderThan(cutoff time.Time) (int64, error)
 	DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error)
 	GetSetting(key string) (string, error)
 }
@@ -59,6 +60,7 @@ type Config struct {
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
 	MetricsRetentionDays      int           // days to keep raw metric data points (default 90)
+	MetricRollupRetentionDays int           // days to keep downsampled metric rollups (default 365)
 	LogRetentionHours         int           // hours to keep log records (default 24)
 	ErrorLogRetentionDays     int           // days to keep logs for error-sampled traces (default 30)
 	SlowThresholdUS           int64         // microseconds above which a span is "slow"
@@ -87,6 +89,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.MetricsRetentionDays <= 0 {
 		c.MetricsRetentionDays = 90
+	}
+	if c.MetricRollupRetentionDays <= 0 {
+		c.MetricRollupRetentionDays = 365
 	}
 	if c.LogRetentionHours <= 0 {
 		c.LogRetentionHours = 24
@@ -239,6 +244,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	errorCutoff := now.Add(-time.Duration(cfg.ErrorRetentionDays) * 24 * time.Hour)
 	aggCutoff := now.Add(-time.Duration(cfg.AggregateRetentionDays) * 24 * time.Hour)
 	metricsCutoff := now.Add(-time.Duration(cfg.MetricsRetentionDays) * 24 * time.Hour)
+	metricRollupCutoff := now.Add(-time.Duration(cfg.MetricRollupRetentionDays) * 24 * time.Hour)
 	logCutoff := now.Add(-time.Duration(cfg.LogRetentionHours) * time.Hour)
 	errorLogCutoff := now.Add(-time.Duration(cfg.ErrorLogRetentionDays) * 24 * time.Hour)
 
@@ -356,6 +362,10 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	metricRollupsDeleted, err := w.repo.DeleteMetricRollupsOlderThan(metricRollupCutoff)
+	if err != nil {
+		return err
+	}
 	logsDeleted, err := w.repo.DeleteLogsOlderThan(ctx, logCutoff, errorLogCutoff)
 	if err != nil {
 		return err
@@ -373,6 +383,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Int64("error_samples_deleted", errorSamplesDeleted),
 		attribute.Int64("aggregates_deleted", aggregatesDeleted),
 		attribute.Int64("metrics_deleted", metricsDeleted),
+		attribute.Int64("metric_rollups_deleted", metricRollupsDeleted),
 		attribute.Int64("logs_deleted", logsDeleted),
 		attribute.Int64("e2e_users_deleted", e2eUsersDeleted),
 		attribute.Bool("backlog_remains", backlogRemains),
@@ -385,6 +396,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"error_samples_deleted", errorSamplesDeleted,
 		"aggregates_deleted", aggregatesDeleted,
 		"metrics_deleted", metricsDeleted,
+		"metric_rollups_deleted", metricRollupsDeleted,
 		"logs_deleted", logsDeleted,
 		"e2e_users_deleted", e2eUsersDeleted,
 		"backlog_remains", backlogRemains,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,6 +18,8 @@ import type {
   WebVitalSummary,
   WebVitalTimeseriesBucket,
   MetricNamesResponse,
+  MetricCatalogResponse,
+  MetricInsightsResponse,
   MetricSeriesResponse,
   LogsResponse,
   LogsHistogramResponse,
@@ -222,6 +224,12 @@ export const api = {
   getMetricNames: (from: string, to: string, projectId = 0) =>
     fetchJSON<MetricNamesResponse>(`/api/v1/metrics/names${qs({ from, to, project_id: projectId || undefined })}`),
 
+  getMetricCatalog: (from: string, to: string, projectId = 0) =>
+    fetchJSON<MetricCatalogResponse>(`/api/v1/metrics/catalog${qs({ from, to, project_id: projectId || undefined })}`),
+
+  getMetricInsights: (from: string, to: string, projectId = 0) =>
+    fetchJSON<MetricInsightsResponse>(`/api/v1/metrics/insights${qs({ from, to, project_id: projectId || undefined })}`),
+
   getMetricSeries: (
     name: string,
     from: string,
@@ -229,6 +237,7 @@ export const api = {
     labels?: Record<string, string>,
     limit?: number,
     projectId = 0,
+    groupBy?: string[],
   ) => {
     const params: Record<string, string | number | undefined> = {
       name,
@@ -236,6 +245,7 @@ export const api = {
       to,
       limit,
       project_id: projectId || undefined,
+      group_by: groupBy && groupBy.length > 0 ? groupBy.join(',') : undefined,
     }
     let query = qs(params)
     if (labels && Object.keys(labels).length > 0) {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -225,13 +225,16 @@ export type Alert = {
   projectId: number
   service: string
   operation: string
-  type: 'latency' | 'error_rate'
+  type: 'latency' | 'error_rate' | 'metric_threshold'
   threshold: number
   comparisonWindow: number
   cooldownMinutes: number
   webhookUrl: string
   email: string
   enabled: boolean
+  metricName?: string
+  metricAgg?: string
+  labelFilters?: Record<string, string>
   lastTriggeredAt?: string
   createdAt: string
 }
@@ -278,13 +281,24 @@ export type WebVitalTimeseriesBucket = {
   poor: number
 }
 
-/** A single metric data point returned by the series query API. */
+/** How a metric series should be rendered (mirrors metrics.RenderKind). */
+export type MetricRender = 'line' | 'rate' | 'percentile'
+
+/** A render-ready point. Which fields are set depends on the render kind:
+ * value for line/rate, p50/p95/p99 for percentile. */
 export type MetricPoint = {
   t: number
   value: number
   count: number
-  attributes: Record<string, unknown>
-  extra?: Record<string, unknown> | null
+  p50?: number
+  p95?: number
+  p99?: number
+}
+
+/** One line in a chart: a label set plus its derived points. */
+export type MetricSeries = {
+  labels: Record<string, string>
+  points: MetricPoint[]
 }
 
 /** Response from GET /api/v1/metrics/names */
@@ -292,12 +306,48 @@ export type MetricNamesResponse = {
   names: string[]
 }
 
+/** One metric in the catalog, with its type, unit and distinct-series count. */
+export type MetricCatalogEntry = {
+  name: string
+  type: string
+  unit: string
+  series: number
+}
+
+/** Metrics grouped by semantic prefix (http, db, system, …). */
+export type MetricCatalogGroup = {
+  name: string
+  metrics: MetricCatalogEntry[]
+}
+
+/** Response from GET /api/v1/metrics/catalog */
+export type MetricCatalogResponse = {
+  groups: MetricCatalogGroup[]
+}
+
+/** A notable change in a metric series. */
+export type MetricInsight = {
+  metric: string
+  labels: Record<string, string>
+  kind: 'spike' | 'drop' | 'regression' | 'new_series'
+  render: MetricRender
+  baseline: number
+  recent: number
+  changePct: number
+}
+
+/** Response from GET /api/v1/metrics/insights */
+export type MetricInsightsResponse = {
+  insights: MetricInsight[]
+}
+
 /** Response from GET /api/v1/metrics/series */
 export type MetricSeriesResponse = {
   name: string
   type: string
   unit: string
-  points: MetricPoint[]
+  render: MetricRender
+  series: MetricSeries[]
 }
 
 /** A single log entry returned by the logs query API. */

--- a/web/src/pages/AlertsPage.tsx
+++ b/web/src/pages/AlertsPage.tsx
@@ -5,16 +5,21 @@ import type { Alert } from '../api/types'
 import { ServiceSelect } from '../components/ServiceSelect'
 import { useTimeRange } from '../contexts/useTimeRange'
 
+type AlertType = 'latency' | 'error_rate' | 'metric_threshold'
+
 type AlertFormState = {
   service: string
   operation: string
-  type: 'latency' | 'error_rate'
+  type: AlertType
   threshold: string
   comparisonWindow: string
   cooldownMinutes: string
   webhookUrl: string
   email: string
   enabled: boolean
+  metricName: string
+  metricAgg: string
+  labelFilters: string // "key=value, key2=value2"
 }
 
 const emptyForm = (): AlertFormState => ({
@@ -27,7 +32,27 @@ const emptyForm = (): AlertFormState => ({
   webhookUrl: '',
   email: '',
   enabled: true,
+  metricName: '',
+  metricAgg: 'last',
+  labelFilters: '',
 })
+
+// formatLabelFilters renders a label map as "k=v, k2=v2" for the text input.
+function formatLabelFilters(m?: Record<string, string>): string {
+  if (!m) return ''
+  return Object.entries(m).map(([k, v]) => `${k}=${v}`).join(', ')
+}
+
+// parseLabelFilters parses "k=v, k2=v2" back into a label map.
+function parseLabelFilters(s: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const part of s.split(',')) {
+    const [k, ...rest] = part.split('=')
+    const key = k.trim()
+    if (key && rest.length > 0) out[key] = rest.join('=').trim()
+  }
+  return out
+}
 
 function alertToForm(a: Alert): AlertFormState {
   return {
@@ -40,16 +65,22 @@ function alertToForm(a: Alert): AlertFormState {
     webhookUrl: a.webhookUrl,
     email: a.email,
     enabled: a.enabled,
+    metricName: a.metricName ?? '',
+    metricAgg: a.metricAgg || 'last',
+    labelFilters: formatLabelFilters(a.labelFilters),
   }
 }
 
-function thresholdLabel(type: 'latency' | 'error_rate') {
-  return type === 'latency' ? 'Threshold (ms)' : 'Threshold (%)'
+function thresholdLabel(type: AlertType) {
+  if (type === 'latency') return 'Threshold (ms)'
+  if (type === 'error_rate') return 'Threshold (%)'
+  return 'Threshold'
 }
 
 function thresholdDisplay(a: Alert) {
   if (a.type === 'latency') return `> ${a.threshold} ms`
-  return `> ${a.threshold}%`
+  if (a.type === 'error_rate') return `> ${a.threshold}%`
+  return `${a.metricAgg ?? ''} > ${a.threshold}`
 }
 
 function relativeTime(iso: string) {
@@ -117,7 +148,12 @@ export function AlertsPage(): ReactElement {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError('')
-    if (!form.service) { setError('Service is required'); return }
+    const isMetric = form.type === 'metric_threshold'
+    if (isMetric) {
+      if (!form.metricName) { setError('Metric name is required'); return }
+    } else if (!form.service) {
+      setError('Service is required'); return
+    }
     if (!form.threshold) { setError('Threshold is required'); return }
     if (!defaultProjectId) { setError('Projects still loading — please wait a moment and try again'); return }
 
@@ -132,6 +168,9 @@ export function AlertsPage(): ReactElement {
       webhookUrl: form.webhookUrl,
       email: form.email,
       enabled: form.enabled,
+      metricName: isMetric ? form.metricName : '',
+      metricAgg: isMetric ? form.metricAgg : '',
+      labelFilters: isMetric ? parseLabelFilters(form.labelFilters) : {},
     }
 
     setSaving(true)
@@ -169,10 +208,11 @@ export function AlertsPage(): ReactElement {
     }
   }
 
-  const typeBadge = (type: 'latency' | 'error_rate') =>
-    type === 'latency'
-      ? { bg: 'rgba(99,102,241,0.15)', color: '#818cf8', label: 'Latency' }
-      : { bg: 'rgba(239,68,68,0.15)', color: '#f87171', label: 'Error rate' }
+  const typeBadge = (type: AlertType) => {
+    if (type === 'latency') return { bg: 'rgba(99,102,241,0.15)', color: '#818cf8', label: 'Latency' }
+    if (type === 'error_rate') return { bg: 'rgba(239,68,68,0.15)', color: '#f87171', label: 'Error rate' }
+    return { bg: 'rgba(34,197,94,0.15)', color: '#4ade80', label: 'Metric' }
+  }
 
   const inputStyle: React.CSSProperties = {
     width: '100%',
@@ -256,11 +296,17 @@ export function AlertsPage(): ReactElement {
                   return (
                     <tr key={a.id}>
                       <td>
-                        <span style={{ fontWeight: 600 }}>{a.service}</span>
-                        {a.operation && (
-                          <span style={{ color: 'var(--text-muted)', fontSize: '0.8125rem' }}>
-                            {' '}/ {a.operation}
-                          </span>
+                        {a.type === 'metric_threshold' ? (
+                          <span style={{ fontWeight: 600, fontFamily: 'monospace', fontSize: '0.8125rem' }}>{a.metricName}</span>
+                        ) : (
+                          <>
+                            <span style={{ fontWeight: 600 }}>{a.service}</span>
+                            {a.operation && (
+                              <span style={{ color: 'var(--text-muted)', fontSize: '0.8125rem' }}>
+                                {' '}/ {a.operation}
+                              </span>
+                            )}
+                          </>
                         )}
                       </td>
                       <td>
@@ -379,53 +425,96 @@ export function AlertsPage(): ReactElement {
 
             <form onSubmit={(e) => { void handleSubmit(e) }}>
               <div style={{ display: 'grid', gap: '1rem' }}>
-                {/* Service */}
+                {/* Alert type selector first — it switches the rest of the form. */}
                 <div>
-                  <label style={labelStyle}>Service *</label>
-                  <ServiceSelect
-                    value={form.service}
-                    onChange={(v) => setForm((f) => ({ ...f, service: v }))}
-                    range={range}
-                  />
+                  <label style={labelStyle}>Alert type *</label>
+                  <select
+                    style={{ ...inputStyle, appearance: 'auto' }}
+                    value={form.type}
+                    onChange={(e) => setForm((f) => ({ ...f, type: e.target.value as AlertType }))}
+                  >
+                    <option value="latency">Latency (p99)</option>
+                    <option value="error_rate">Error rate</option>
+                    <option value="metric_threshold">Metric threshold</option>
+                  </select>
                 </div>
 
-                {/* Operation */}
+                {form.type === 'metric_threshold' ? (
+                  <>
+                    {/* Metric name + aggregation */}
+                    <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr', gap: '0.75rem' }}>
+                      <div>
+                        <label style={labelStyle}>Metric name *</label>
+                        <input
+                          style={inputStyle}
+                          placeholder="e.g. http.server.active_requests"
+                          value={form.metricName}
+                          onChange={(e) => setForm((f) => ({ ...f, metricName: e.target.value }))}
+                        />
+                      </div>
+                      <div>
+                        <label style={labelStyle}>Aggregation</label>
+                        <select
+                          style={{ ...inputStyle, appearance: 'auto' }}
+                          value={form.metricAgg}
+                          onChange={(e) => setForm((f) => ({ ...f, metricAgg: e.target.value }))}
+                        >
+                          <option value="last">Last value</option>
+                          <option value="avg">Average</option>
+                          <option value="rate">Rate /s (counters)</option>
+                          <option value="p95">p95 (histograms)</option>
+                        </select>
+                      </div>
+                    </div>
+                    {/* Label filters */}
+                    <div>
+                      <label style={labelStyle}>Label filters (optional)</label>
+                      <input
+                        style={inputStyle}
+                        placeholder="e.g. service.name=api, route=/checkout"
+                        value={form.labelFilters}
+                        onChange={(e) => setForm((f) => ({ ...f, labelFilters: e.target.value }))}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    {/* Service */}
+                    <div>
+                      <label style={labelStyle}>Service *</label>
+                      <ServiceSelect
+                        value={form.service}
+                        onChange={(v) => setForm((f) => ({ ...f, service: v }))}
+                        range={range}
+                      />
+                    </div>
+
+                    {/* Operation */}
+                    <div>
+                      <label style={labelStyle}>Operation (optional)</label>
+                      <input
+                        style={inputStyle}
+                        placeholder="e.g. GET /api/users — leave blank for all operations"
+                        value={form.operation}
+                        onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))}
+                      />
+                    </div>
+                  </>
+                )}
+
+                {/* Threshold */}
                 <div>
-                  <label style={labelStyle}>Operation (optional)</label>
+                  <label style={labelStyle}>{thresholdLabel(form.type)} *</label>
                   <input
                     style={inputStyle}
-                    placeholder="e.g. GET /api/users — leave blank for all operations"
-                    value={form.operation}
-                    onChange={(e) => setForm((f) => ({ ...f, operation: e.target.value }))}
+                    type="number"
+                    min="0"
+                    step={form.type === 'error_rate' ? '0.1' : '1'}
+                    placeholder={form.type === 'latency' ? '500' : form.type === 'error_rate' ? '5' : '100'}
+                    value={form.threshold}
+                    onChange={(e) => setForm((f) => ({ ...f, threshold: e.target.value }))}
+                    required
                   />
-                </div>
-
-                {/* Type + threshold side by side */}
-                <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
-                  <div>
-                    <label style={labelStyle}>Alert type *</label>
-                    <select
-                      style={{ ...inputStyle, appearance: 'auto' }}
-                      value={form.type}
-                      onChange={(e) => setForm((f) => ({ ...f, type: e.target.value as 'latency' | 'error_rate' }))}
-                    >
-                      <option value="latency">Latency (p99)</option>
-                      <option value="error_rate">Error rate</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label style={labelStyle}>{thresholdLabel(form.type)} *</label>
-                    <input
-                      style={inputStyle}
-                      type="number"
-                      min="0"
-                      step={form.type === 'latency' ? '1' : '0.1'}
-                      placeholder={form.type === 'latency' ? '500' : '5'}
-                      value={form.threshold}
-                      onChange={(e) => setForm((f) => ({ ...f, threshold: e.target.value }))}
-                      required
-                    />
-                  </div>
                 </div>
 
                 {/* Windows */}

--- a/web/src/pages/MetricsPage.tsx
+++ b/web/src/pages/MetricsPage.tsx
@@ -463,7 +463,7 @@ function MetricChart({
                 borderRadius: 8,
                 color: 'var(--text)',
               }}
-              formatter={(value: number | string) => [`${Number(value).toLocaleString()}${unit ? ` ${unit}` : ''}`]}
+              formatter={(value) => [`${Number(value).toLocaleString()}${unit ? ` ${unit}` : ''}`]}
             />
             <Legend verticalAlign="top" align="right" iconType="line" wrapperStyle={{ fontSize: 11, paddingBottom: 4 }} />
             {lines.map((l) => (

--- a/web/src/pages/MetricsPage.tsx
+++ b/web/src/pages/MetricsPage.tsx
@@ -1,18 +1,33 @@
-import { useState, useEffect, useCallback, useRef, type ReactElement } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, type ReactElement } from 'react'
+import {
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
 import { api } from '../api/client'
-import type { MetricPoint, MetricSeriesResponse } from '../api/types'
+import type { MetricCatalogGroup, MetricInsight, MetricSeries, MetricSeriesResponse } from '../api/types'
 import { TimeRangeSelector } from '../components/TimeRangeSelector'
 import { AutoRefresh } from '../components/AutoRefresh'
 import { getTimeRange } from '../utils/timeRange'
 import { useTimeRange } from '../contexts/useTimeRange'
 
+const PALETTE = ['#3b82f6', '#22c55e', '#eab308', '#ef4444', '#a855f7', '#06b6d4', '#f97316', '#ec4899']
+
 export function MetricsPage(): ReactElement {
   const { range, setRange } = useTimeRange()
   const [refreshInterval, setRefreshInterval] = useState(0)
-  const [names, setNames] = useState<string[]>([])
+  const [catalog, setCatalog] = useState<MetricCatalogGroup[]>([])
+  const [insights, setInsights] = useState<MetricInsight[]>([])
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [nameFilter, setNameFilter] = useState('')
   const [selectedName, setSelectedName] = useState<string | null>(null)
   const [series, setSeries] = useState<MetricSeriesResponse | null>(null)
+  const [groupBy, setGroupBy] = useState<string[]>([])
   const [loadingNames, setLoadingNames] = useState(true)
   const [loadingSeries, setLoadingSeries] = useState(false)
   const namesIdRef = useRef(0)
@@ -22,9 +37,10 @@ export function MetricsPage(): ReactElement {
     const id = ++namesIdRef.current
     const { from, to } = getTimeRange(range)
     try {
-      const resp = await api.getMetricNames(from, to)
+      const [cat, ins] = await Promise.all([api.getMetricCatalog(from, to), api.getMetricInsights(from, to)])
       if (id === namesIdRef.current) {
-        setNames(resp?.names ?? [])
+        setCatalog(cat?.groups ?? [])
+        setInsights(ins?.insights ?? [])
       }
     } catch {
       // handled by client
@@ -33,18 +49,21 @@ export function MetricsPage(): ReactElement {
     }
   }, [range])
 
-  const fetchSeries = useCallback(async (name: string) => {
-    const id = ++seriesIdRef.current
-    const { from, to } = getTimeRange(range)
-    try {
-      const resp = await api.getMetricSeries(name, from, to)
-      if (id === seriesIdRef.current) setSeries(resp ?? null)
-    } catch {
-      // handled by client
-    } finally {
-      if (id === seriesIdRef.current) setLoadingSeries(false)
-    }
-  }, [range])
+  const fetchSeries = useCallback(
+    async (name: string, gb: string[]) => {
+      const id = ++seriesIdRef.current
+      const { from, to } = getTimeRange(range)
+      try {
+        const resp = await api.getMetricSeries(name, from, to, undefined, undefined, 0, gb)
+        if (id === seriesIdRef.current) setSeries(resp ?? null)
+      } catch {
+        // handled by client
+      } finally {
+        if (id === seriesIdRef.current) setLoadingSeries(false)
+      }
+    },
+    [range],
+  )
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset loading when range changes
@@ -54,18 +73,26 @@ export function MetricsPage(): ReactElement {
   // eslint-disable-next-line react-hooks/set-state-in-effect -- data fetching is a valid effect pattern
   useEffect(() => { void fetchNames() }, [fetchNames])
 
+  // Reset group-by when switching metric so keys from a previous metric don't leak.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset on selection change
+    setGroupBy([])
+  }, [selectedName])
+
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- reset series on selection change
     setSeries(null)
     if (selectedName) {
       setLoadingSeries(true)
-      void fetchSeries(selectedName)
+      void fetchSeries(selectedName, groupBy)
     }
-  }, [selectedName, fetchSeries])
+  }, [selectedName, groupBy, fetchSeries])
 
-  const filteredNames = nameFilter
-    ? names.filter((n) => n.toLowerCase().includes(nameFilter.toLowerCase()))
-    : names
+  // Filter metrics within each group by the search box, dropping empty groups.
+  const q = nameFilter.toLowerCase()
+  const filteredGroups = catalog
+    .map((g) => ({ ...g, metrics: q ? g.metrics.filter((m) => m.name.toLowerCase().includes(q)) : g.metrics }))
+    .filter((g) => g.metrics.length > 0)
 
   return (
     <div>
@@ -75,6 +102,8 @@ export function MetricsPage(): ReactElement {
         <AutoRefresh value={refreshInterval} onChange={setRefreshInterval} onRefresh={fetchNames} />
         <TimeRangeSelector value={range} onChange={setRange} />
       </div>
+
+      {insights.length > 0 && <InsightsPanel insights={insights} onSelect={setSelectedName} />}
 
       <div style={{ display: 'flex', gap: '1rem', alignItems: 'flex-start' }}>
         {/* Left panel: metric names */}
@@ -110,33 +139,71 @@ export function MetricsPage(): ReactElement {
           <div style={{ maxHeight: 480, overflowY: 'auto' }}>
             {loadingNames ? (
               <div style={{ padding: '1rem', color: 'var(--text-muted)', fontSize: '0.8125rem' }}>Loading…</div>
-            ) : filteredNames.length === 0 ? (
+            ) : filteredGroups.length === 0 ? (
               <div style={{ padding: '1rem', color: 'var(--text-muted)', fontSize: '0.8125rem' }}>No metrics found</div>
             ) : (
-              filteredNames.map((name) => (
-                <button
-                  key={name}
-                  onClick={() => setSelectedName(name)}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '0.5rem 0.75rem',
-                    fontSize: '0.8125rem',
-                    fontFamily: 'monospace',
-                    background: selectedName === name ? 'var(--surface-hover)' : 'transparent',
-                    color: selectedName === name ? 'var(--text)' : 'var(--text-muted)',
-                    border: 'none',
-                    borderLeft: selectedName === name ? '2px solid var(--accent)' : '2px solid transparent',
-                    cursor: 'pointer',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap',
-                  }}
-                >
-                  {name}
-                </button>
-              ))
+              filteredGroups.map((g) => {
+                // While filtering, expand all so matches are visible.
+                const isCollapsed = !q && collapsed[g.name]
+                return (
+                  <div key={g.name}>
+                    <button
+                      onClick={() => setCollapsed((c) => ({ ...c, [g.name]: !c[g.name] }))}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.4rem',
+                        width: '100%',
+                        textAlign: 'left',
+                        padding: '0.4rem 0.75rem',
+                        fontSize: '0.6875rem',
+                        fontWeight: 600,
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.04em',
+                        background: 'var(--surface-hover)',
+                        color: 'var(--text-muted)',
+                        border: 'none',
+                        borderTop: '1px solid var(--border)',
+                        cursor: 'pointer',
+                      }}
+                    >
+                      <span style={{ fontSize: '0.625rem' }}>{isCollapsed ? '▸' : '▾'}</span>
+                      {g.name}
+                      <span style={{ marginLeft: 'auto', fontWeight: 400 }}>{g.metrics.length}</span>
+                    </button>
+                    {!isCollapsed &&
+                      g.metrics.map((m) => (
+                        <button
+                          key={m.name}
+                          onClick={() => setSelectedName(m.name)}
+                          title={`${m.type}${m.unit ? ` · ${m.unit}` : ''} · ${m.series} series`}
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.4rem',
+                            width: '100%',
+                            textAlign: 'left',
+                            padding: '0.5rem 0.75rem',
+                            fontSize: '0.8125rem',
+                            fontFamily: 'monospace',
+                            background: selectedName === m.name ? 'var(--surface-hover)' : 'transparent',
+                            color: selectedName === m.name ? 'var(--text)' : 'var(--text-muted)',
+                            border: 'none',
+                            borderLeft: selectedName === m.name ? '2px solid var(--accent)' : '2px solid transparent',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{m.name}</span>
+                          {m.series > 1 && (
+                            <span style={{ marginLeft: 'auto', fontSize: '0.6875rem', color: 'var(--text-muted)', flexShrink: 0 }}>
+                              {m.series}×
+                            </span>
+                          )}
+                        </button>
+                      ))}
+                  </div>
+                )
+              })
             )}
           </div>
         </div>
@@ -144,35 +211,17 @@ export function MetricsPage(): ReactElement {
         {/* Right panel: time series chart */}
         <div style={{ flex: 1, minWidth: 0 }}>
           {!selectedName ? (
-            <div
-              style={{
-                background: 'var(--surface)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                padding: '3rem',
-                textAlign: 'center',
-                color: 'var(--text-muted)',
-                fontSize: '0.875rem',
-              }}
-            >
-              Select a metric to view its time series
-            </div>
+            <Placeholder>Select a metric to view its time series</Placeholder>
           ) : loadingSeries ? (
-            <div
-              style={{
-                background: 'var(--surface)',
-                border: '1px solid var(--border)',
-                borderRadius: '0.5rem',
-                padding: '3rem',
-                textAlign: 'center',
-                color: 'var(--text-muted)',
-                fontSize: '0.875rem',
-              }}
-            >
-              Loading…
-            </div>
+            <Placeholder>Loading…</Placeholder>
           ) : series ? (
-            <MetricChart series={series} />
+            <MetricChart
+              series={series}
+              groupBy={groupBy}
+              onToggleGroupBy={(key) =>
+                setGroupBy((cur) => (cur.includes(key) ? cur.filter((k) => k !== key) : [...cur, key]))
+              }
+            />
           ) : null}
         </div>
       </div>
@@ -180,64 +229,176 @@ export function MetricsPage(): ReactElement {
   )
 }
 
-function MetricChart({ series }: { series: MetricSeriesResponse }): ReactElement {
-  const { name, type, unit, points } = series
+function Placeholder({ children }: { children: React.ReactNode }): ReactElement {
+  return (
+    <div
+      style={{
+        background: 'var(--surface)',
+        border: '1px solid var(--border)',
+        borderRadius: '0.5rem',
+        padding: '3rem',
+        textAlign: 'center',
+        color: 'var(--text-muted)',
+        fontSize: '0.875rem',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
 
-  if (points.length === 0) {
-    return (
-      <div
-        style={{
-          background: 'var(--surface)',
-          border: '1px solid var(--border)',
-          borderRadius: '0.5rem',
-          padding: '3rem',
-          textAlign: 'center',
-          color: 'var(--text-muted)',
-          fontSize: '0.875rem',
-        }}
-      >
-        No data points in selected range
+const INSIGHT_STYLE: Record<MetricInsight['kind'], { label: string; color: string }> = {
+  spike: { label: 'Spike', color: '#ef4444' },
+  drop: { label: 'Drop', color: '#3b82f6' },
+  regression: { label: 'p95 ↑', color: '#eab308' },
+  new_series: { label: 'New', color: '#22c55e' },
+}
+
+function labelSuffix(labels: Record<string, string>): string {
+  const entries = Object.entries(labels)
+  if (entries.length === 0) return ''
+  return ` {${entries.map(([k, v]) => `${k}=${v}`).join(', ')}}`
+}
+
+function InsightsPanel({
+  insights,
+  onSelect,
+}: {
+  insights: MetricInsight[]
+  onSelect: (name: string) => void
+}): ReactElement {
+  return (
+    <div style={{ marginBottom: '1.25rem' }}>
+      <div style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.04em', marginBottom: '0.5rem' }}>
+        Notable changes
       </div>
+      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        {insights.map((ins, i) => {
+          const s = INSIGHT_STYLE[ins.kind]
+          const pct = ins.kind === 'new_series' ? '' : `${ins.changePct > 0 ? '+' : ''}${Math.round(ins.changePct * 100)}%`
+          return (
+            <button
+              key={`${ins.metric}-${i}`}
+              onClick={() => onSelect(ins.metric)}
+              title={ins.kind === 'new_series' ? 'Newly appeared' : `${ins.baseline.toLocaleString()} → ${ins.recent.toLocaleString()}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '0.5rem',
+                padding: '0.4rem 0.6rem',
+                background: 'var(--surface)',
+                border: '1px solid var(--border)',
+                borderLeft: `3px solid ${s.color}`,
+                borderRadius: '0.375rem',
+                cursor: 'pointer',
+                textAlign: 'left',
+              }}
+            >
+              <span style={{ fontSize: '0.625rem', fontWeight: 700, color: s.color, textTransform: 'uppercase' }}>{s.label}</span>
+              <span style={{ fontSize: '0.8125rem', fontFamily: 'monospace', color: 'var(--text)' }}>
+                {ins.metric}
+                <span style={{ color: 'var(--text-muted)' }}>{labelSuffix(ins.labels)}</span>
+              </span>
+              {pct && <span style={{ fontSize: '0.75rem', fontWeight: 600, color: s.color }}>{pct}</span>}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const RENDER_HINT: Record<string, string> = {
+  line: 'Current value over time',
+  rate: 'Per-second rate (counter increase ÷ elapsed time)',
+  percentile: 'p50 / p95 / p99 reconstructed from the distribution',
+}
+
+function labelText(labels: Record<string, string>): string {
+  const entries = Object.entries(labels)
+  if (entries.length === 0) return 'value'
+  return entries.map(([k, v]) => `${k}=${v}`).join(', ')
+}
+
+function fmtTime(nanos: number): string {
+  const d = new Date(nanos / 1_000_000)
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+type ChartRow = { t: number; time: string; [key: string]: number | string }
+type LineDef = { key: string; name: string; color: string }
+
+// buildChart flattens the per-series points into a single recharts dataset keyed
+// by timestamp, and decides which lines to draw based on the render kind.
+function buildChart(resp: MetricSeriesResponse): { rows: ChartRow[]; lines: LineDef[] } {
+  const { render, series } = resp
+
+  const tset = new Set<number>()
+  series.forEach((s) => s.points.forEach((p) => tset.add(p.t)))
+  const times = [...tset].sort((a, b) => a - b)
+  const rowByT = new Map<number, ChartRow>()
+  times.forEach((t) => rowByT.set(t, { t, time: fmtTime(t) }))
+
+  const lines: LineDef[] = []
+
+  if (render === 'percentile' && series.length === 1) {
+    // Single distribution: show the three percentile bands.
+    lines.push(
+      { key: 'p99', name: 'p99', color: '#ef4444' },
+      { key: 'p95', name: 'p95', color: '#eab308' },
+      { key: 'p50', name: 'p50', color: '#3b82f6' },
     )
+    series[0].points.forEach((p) => {
+      const row = rowByT.get(p.t)!
+      if (p.p50 != null) row.p50 = p.p50
+      if (p.p95 != null) row.p95 = p.p95
+      if (p.p99 != null) row.p99 = p.p99
+    })
+  } else if (render === 'percentile') {
+    // Multiple distributions: one p95 line per series to keep it legible.
+    series.forEach((s, i) => {
+      const key = `s${i}`
+      lines.push({ key, name: `${labelText(s.labels)} · p95`, color: PALETTE[i % PALETTE.length] })
+      s.points.forEach((p) => {
+        if (p.p95 != null) rowByT.get(p.t)![key] = p.p95
+      })
+    })
+  } else {
+    // Gauge value or counter rate: one line per series.
+    series.forEach((s, i) => {
+      const key = `s${i}`
+      lines.push({ key, name: labelText(s.labels), color: PALETTE[i % PALETTE.length] })
+      s.points.forEach((p) => {
+        rowByT.get(p.t)![key] = p.value
+      })
+    })
   }
 
-  const useCount = type === 'histogram' || type === 'exp_histogram' || type === 'summary'
-  const values = points.map((p) => (useCount ? p.count : p.value))
-  const minVal = Math.min(...values)
-  const maxVal = Math.max(...values)
-  const minT = points[0].t
-  const maxT = points[points.length - 1].t
+  return { rows: times.map((t) => rowByT.get(t)!), lines }
+}
 
-  const W = 600
-  const H = 160
-  const pad = { top: 8, right: 8, bottom: 24, left: 48 }
-  const chartW = W - pad.left - pad.right
-  const chartH = H - pad.top - pad.bottom
+// availableKeys returns the union of attribute keys across the series labels,
+// so the user can pick which one to group by.
+function availableKeys(series: MetricSeries[]): string[] {
+  const keys = new Set<string>()
+  series.forEach((s) => Object.keys(s.labels).forEach((k) => keys.add(k)))
+  return [...keys].sort()
+}
 
-  const tRange = maxT - minT || 1
-  const vRange = maxVal - minVal || 1
+function MetricChart({
+  series: resp,
+  groupBy,
+  onToggleGroupBy,
+}: {
+  series: MetricSeriesResponse
+  groupBy: string[]
+  onToggleGroupBy: (key: string) => void
+}): ReactElement {
+  const { name, type, unit, render, series } = resp
+  const { rows, lines } = useMemo(() => buildChart(resp), [resp])
+  const keys = useMemo(() => availableKeys(series), [series])
 
-  const toX = (t: number) => pad.left + ((t - minT) / tRange) * chartW
-  const toY = (v: number) => pad.top + chartH - ((v - minVal) / vRange) * chartH
-
-  const polylinePoints = points.map((p) => `${toX(p.t)},${toY(useCount ? p.count : p.value)}`).join(' ')
-
-  // Y-axis ticks: 3 evenly spaced
-  const yTicks = [minVal, minVal + vRange / 2, maxVal]
-  // X-axis ticks: first and last timestamp
-  const xTicks = [minT, maxT]
-
-  const formatVal = (v: number) => {
-    if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`
-    if (Math.abs(v) >= 1_000) return `${(v / 1_000).toFixed(1)}k`
-    return v % 1 === 0 ? String(v) : v.toFixed(2)
-  }
-
-  const formatTime = (nanos: number) => {
-    const ms = nanos / 1_000_000
-    const d = new Date(ms)
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-  }
+  const totalPoints = series.reduce((n, s) => n + s.points.length, 0)
 
   return (
     <div
@@ -248,108 +409,78 @@ function MetricChart({ series }: { series: MetricSeriesResponse }): ReactElement
         padding: '1rem',
       }}
     >
-      <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.5rem', marginBottom: '0.25rem', flexWrap: 'wrap' }}>
         <span style={{ fontFamily: 'monospace', fontSize: '0.875rem', fontWeight: 600 }}>{name}</span>
-        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{type}{unit ? ` · ${unit}` : ''}</span>
-        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginLeft: 'auto' }}>{points.length} points</span>
+        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>
+          {type}
+          {unit ? ` · ${unit}` : ''}
+        </span>
+        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginLeft: 'auto' }}>
+          {series.length} series · {totalPoints} points
+        </span>
       </div>
-      <svg
-        viewBox={`0 0 ${W} ${H}`}
-        style={{ width: '100%', height: 'auto', display: 'block' }}
-        aria-label={`Time series chart for ${name}`}
-      >
-        {/* Y-axis ticks */}
-        {yTicks.map((v, i) => (
-          <g key={i}>
-            <line
-              x1={pad.left}
-              y1={toY(v)}
-              x2={pad.left + chartW}
-              y2={toY(v)}
-              stroke="var(--border)"
-              strokeWidth={0.5}
-              strokeDasharray="3 3"
-            />
-            <text
-              x={pad.left - 4}
-              y={toY(v) + 4}
-              textAnchor="end"
-              fontSize={9}
-              fill="var(--text-muted)"
-            >
-              {formatVal(v)}
-            </text>
-          </g>
-        ))}
+      <p style={{ margin: '0 0 0.75rem', fontSize: '0.75rem', color: 'var(--text-muted)' }}>{RENDER_HINT[render]}</p>
 
-        {/* X-axis ticks */}
-        {xTicks.map((t, i) => (
-          <text
-            key={i}
-            x={toX(t)}
-            y={H - 4}
-            textAnchor={i === 0 ? 'start' : 'end'}
-            fontSize={9}
-            fill="var(--text-muted)"
-          >
-            {formatTime(t)}
-          </text>
-        ))}
-
-        {/* Series line */}
-        <polyline
-          points={polylinePoints}
-          fill="none"
-          stroke="var(--accent)"
-          strokeWidth={1.5}
-          strokeLinejoin="round"
-          strokeLinecap="round"
-        />
-
-        {/* Dots for sparse data */}
-        {points.length <= 30 &&
-          points.map((p, i) => (
-            <circle
-              key={i}
-              cx={toX(p.t)}
-              cy={toY(useCount ? p.count : p.value)}
-              r={2.5}
-              fill="var(--accent)"
-            />
-          ))}
-      </svg>
-      {useCount && (
-        <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: 'var(--text-muted)' }}>
-          Showing observation count over time (type: {type})
-        </p>
+      {keys.length > 0 && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Group by:</span>
+          {keys.map((k) => {
+            const active = groupBy.includes(k)
+            return (
+              <button
+                key={k}
+                onClick={() => onToggleGroupBy(k)}
+                style={{
+                  fontSize: '0.75rem',
+                  fontFamily: 'monospace',
+                  padding: '0.2rem 0.5rem',
+                  borderRadius: '0.375rem',
+                  border: `1px solid ${active ? 'var(--accent)' : 'var(--border)'}`,
+                  background: active ? 'var(--accent)' : 'transparent',
+                  color: active ? '#fff' : 'var(--text-muted)',
+                  cursor: 'pointer',
+                }}
+              >
+                {k}
+              </button>
+            )
+          })}
+        </div>
       )}
-      <LatestValues points={points} useCount={useCount} />
-    </div>
-  )
-}
 
-function LatestValues({ points, useCount }: { points: MetricPoint[]; useCount: boolean }): ReactElement {
-  const latest = points[points.length - 1]
-  const displayValue = useCount ? latest.count : latest.value
-  const attrs = latest.attributes as Record<string, string>
-  const attrEntries = Object.entries(attrs ?? {})
-
-  return (
-    <div style={{ marginTop: '0.75rem', display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
-      <div>
-        <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Latest value</span>
-        <div style={{ fontSize: '1.125rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
-          {typeof displayValue === 'number' && displayValue % 1 !== 0
-            ? displayValue.toFixed(3)
-            : String(displayValue)}
-        </div>
-      </div>
-      {attrEntries.slice(0, 4).map(([k, v]) => (
-        <div key={k}>
-          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{k}</span>
-          <div style={{ fontSize: '0.875rem', fontFamily: 'monospace' }}>{v}</div>
-        </div>
-      ))}
+      {rows.length === 0 ? (
+        <Placeholder>No data points in selected range</Placeholder>
+      ) : (
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={rows} margin={{ top: 4, right: 8, bottom: 0, left: -8 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis dataKey="time" tick={{ fontSize: 11, fill: 'var(--text-muted)' }} />
+            <YAxis tick={{ fontSize: 11, fill: 'var(--text-muted)' }} width={48} />
+            <Tooltip
+              contentStyle={{
+                background: 'var(--surface)',
+                border: '1px solid var(--border)',
+                borderRadius: 8,
+                color: 'var(--text)',
+              }}
+              formatter={(value: number | string) => [`${Number(value).toLocaleString()}${unit ? ` ${unit}` : ''}`]}
+            />
+            <Legend verticalAlign="top" align="right" iconType="line" wrapperStyle={{ fontSize: 11, paddingBottom: 4 }} />
+            {lines.map((l) => (
+              <Line
+                key={l.key}
+                type="monotone"
+                dataKey={l.key}
+                name={l.name}
+                stroke={l.color}
+                dot={false}
+                strokeWidth={2}
+                connectNulls
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Why

SpanBarn already ingested FunnelBarn's full OTLP suite (gauge/sum/histogram/exp_histogram/summary) but treated metrics naively: raw values plotted as a line, all label sets merged into one nonsensical series, and no downsampling (raw kept 90d → long-range reads scan huge point counts). This makes metrics a first-class, shape-aware product.

## What

**Phase 1 — shape-aware query + rendering**
- `internal/metrics` derivation: cumulative Sums → per-second rate (reset-aware), Histograms/exp-histograms → reconstructed p50/p95/p99 from bucket counts, Summaries → stored quantiles, gauges pass through.
- Series split by attribute set, with a `group_by` control; `MetricsPage` renders the right chart per shape (recharts).

**Phase 2 — rollup pipeline**
- `metric_rollups` table (migration 025) + a type-aware in-memory accumulator mirroring the spans path, flushing only *closed* buckets so the stored distribution is complete.
- Wired into standalone + writer ingest; queries over 6h auto-route to rollups.
- Retention keeps rollups long, shortens raw, and the previously **unbatched raw-metrics DELETE is now chunked** (prior write-stall incident).

**Phase 3 — capabilities**
- Catalog (`/api/v1/metrics/catalog`): names grouped by semantic prefix with type/unit/series counts → collapsible groups.
- Insights (`/api/v1/metrics/insights`): surfaces spikes, drops, p95 regressions, new series as a "Notable changes" panel.
- Metric alerting (migration 026): `metric_threshold` alert type evaluated against rollups, reusing the existing threshold/cooldown/notifier flow; AlertsPage gains metric name + aggregation + label-filter fields.

## Notes
- Migrations are light: 025 creates a fresh empty table + indexes; 026 is 3 `ADD COLUMN` on the small `alerts` table — no heavy backfill, safe for rolling update.
- Counter rate is derived at query time from each bucket's cumulative `last` (handles resets across bucket boundaries) rather than a stored delta column.

## Tests
Derivation math (rate reset, histogram/exp reconstruction, summary snapping), accumulator folding/closed-bucket/histogram-merge, rollup upsert + conflict-merge, rollup query routing, catalog grouping, insight detection, metric-alert fire/no-fire. Frontend tsc + eslint clean; production build succeeds.