### PR TITLE
chore(prod): add SPANBARN_OIDC_CLI_CLIENT_ID for sb OIDC login

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -23,6 +23,7 @@ stringData:
     SPANBARN_OIDC_CLIENT_SECRET: ENC[AES256_GCM,data:/El0hzdmtGxz4I/nOWU0ndLGvDlhTrSrqoxkL+n36I2vCgWANDOGEPA/TQ==,iv:RjjUy4tRt6KVUvBGVbh9p56jv8Rxq2QatncWfuTlXyc=,tag:oZID0V0DPp9AE2CRZzEzHA==,type:str]
     SPANBARN_OIDC_REDIRECT_URL: ENC[AES256_GCM,data:8TyCIBS9VFYtjaD1mAXcC3qflHGU5CUeoUoxdZQAIjhpjMc+SHAcVaUIyCyMe+Y=,iv:VZJP0rOJmHarCHfg+BPopb4GHq2Kz/r3HtOjOJeI9Hw=,tag:t/TilM42DuKoJofulaW6Lg==,type:str]
     SPANBARN_REDIS_QUEUE_URL: ENC[AES256_GCM,data:/FRYzQ2Fs4Iq21hqIKuFwyllTS1qcXOAbTXD3di+tp6r,iv:X0iTq2SAYpDrbzpHEu+Gqhr9YqqqvWKBCpWjBnrjwNk=,tag:KSWzuGK8bHBnTfS79qLEow==,type:str]
+    SPANBARN_OIDC_CLI_CLIENT_ID: ENC[AES256_GCM,data:wbKKOMhZaJA0p1Fripoy7PUS,iv:DTQWhGljvZYvJWVcVOPPuGklAvUFXEXNBwqqQS9EYms=,tag:fg8b5voSGhODuTwVZ0jSYg==,type:str]
 sops:
     age:
         - recipient: age1r7mrwf30q8g6glmngn2cnlzm9vrj6a9arz0t4mwxp6upc0m6tqwskvh295
@@ -34,7 +35,7 @@ sops:
             elo4cko3b01ZdTViOC9zNk5KZFY4RjgKlc1P892HWbmiCQ1iD+l0LXD4JDjmxJzN
             ppLLPXz3vwKSirpHk5wVQ2NAPKL28G+8Hcz2LaoXXO0akhxqRHxSiw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-13T11:50:02Z"
-    mac: ENC[AES256_GCM,data:dc/zKY9QTJsaCSmN3a6wgtDGdU4eGO6Gg+NwwNytzwGzZmdjMcARDtqvUfopOzqvhRghBn5ivPQAvrKAGs2WVyE90WaWVAHD4OZIq5N1a6iNd34H/IQ5Ql0iXfrvSjZKg0YRyKIM+EnSaZkced1TkzRo1WpygLp9tWOxDleaFPc=,iv:QqiIFN0zg7GWqoM7QX1wGqVcViJQYhS+g1uBWG2c2hA=,tag:zFuJxTeL4Tvl2FcYHtnlDw==,type:str]
+    lastmodified: "2026-06-16T16:57:26Z"
+    mac: ENC[AES256_GCM,data:pJKLxyF2B0PJ9/r8VlbkPHo+v56tncrneMf/sRQbuY4AcHDgOdMiIA2S606A+zSIobpXlwCjjRRm2mev+t1flAznKEgKvKOv1zSQJZ+3IjkcZBkWP2MU0PhO/x97boWOl9JgCk1wfizraFfdrUmanutzyUDyEsI/Qb4kfjb/TNo=,iv:8jRJoYxdm8SsFykvF1lh8R4dxq4VLJLb2uGrnjSCZRE=,tag:HfEpsTNmuqj0XrCoblN2Pg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Adds the `SPANBARN_OIDC_CLI_CLIENT_ID=ibc_v8R5-J3HuryIww` entry to the production SOPS secret so `sb login --oidc` works against https://spanbarn.wiebe.xyz. The server advertises this public IamBarn client via /api/v1/client-config and accepts its device-code access tokens (resource-server validation). Client already created in IamBarn (org wiebe workspace). Will be applied by the next production deploy.