### PR TITLE
fix(k8s): accept ingest from any sb.* CNAME alias (fixes sb.brandtrace.net CORS)

### DIFF
--- a/deploy/k8s/production/ingress-forward-domains.yaml
+++ b/deploy/k8s/production/ingress-forward-domains.yaml
@@ -6,29 +6,57 @@ spec:
   entryPoints:
     - websecure
   routes:
-    - match: (Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`)) && PathPrefix(`/v1/traces`)
+    # Ingest paths for ANY "sb." CNAME alias — a new customer only has to point
+    # sb.<their-domain> at the cluster (proxied via Cloudflare) and OTLP/RUM
+    # ingest works with no ingress change. HostRegexp is Traefik v3 Go-regexp
+    # syntax. "spanbarn." does not match "^sb\." so the apex host is unaffected.
+    # priority: 101 ensures these beat the catch-all redirect (priority 1).
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/v1/traces`)
       kind: Rule
+      priority: 101
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: (Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`)) && PathPrefix(`/api/v1/spans`)
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/api/v1/spans`)
       kind: Rule
+      priority: 101
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: (Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`)) && PathPrefix(`/api/v1/telemetry`)
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/api/v1/telemetry`)
       kind: Rule
+      priority: 101
       services:
         - name: spanbarn-ingest
           port: 8080
-    - match: (Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`)) && PathPrefix(`/api/v1/client-errors`)
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/api/v1/client-errors`)
       kind: Rule
+      priority: 101
       services:
         - name: spanbarn-ingest
           port: 8080
-    # Any other request (including GET /) gets a 301 to the root domain
-    - match: Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`)
+
+    # Browser OTLP exporters configured with the bare host (e.g. brandtrace-web)
+    # POST spans — and the CORS preflight — to "/" instead of "/v1/traces".
+    # Rewrite those to the OTLP trace path and send them to the ingest pod, where
+    # the Go CORS middleware answers the preflight and handleOTLP accepts the
+    # batch. Method-scoped so GET / still falls through to the redirect below.
+    - match: HostRegexp(`^sb\..+$`) && Path(`/`) && (Method(`POST`) || Method(`OPTIONS`))
       kind: Rule
+      priority: 101
+      middlewares:
+        - name: otlp-root-to-traces
+      services:
+        - name: spanbarn-ingest
+          port: 8080
+
+    # Any other request (including GET /) gets a 301 to the root domain. Kept
+    # enumerated to the ingest-only aliases so the wildcard above never hijacks
+    # full-alias domains such as sb.bananasketch.nl, whose own Ingress serves the
+    # dashboard at "/".
+    - match: Host(`sb.pensioenfeest.nl`) || Host(`sb.scanoo.nl`) || Host(`sb.scanbarelinks.nl`) || Host(`sb.brandtrace.net`)
+      kind: Rule
+      priority: 1
       middlewares:
         - name: strip-sb-redirect
       services:

--- a/deploy/k8s/production/kustomization.yaml
+++ b/deploy/k8s/production/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ingress.yaml
   - ingress-forward-domains.yaml
   - middleware-sb-redirect.yaml
+  - middleware-otlp-root.yaml
 # Image tags are injected by the deploy workflow (sed-replaces __SHA__).
 # This avoids the ":latest" tag being applied — that tag isn't published.
 images:

--- a/deploy/k8s/production/middleware-otlp-root.yaml
+++ b/deploy/k8s/production/middleware-otlp-root.yaml
@@ -1,0 +1,9 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: otlp-root-to-traces
+spec:
+  # Forward-domain browser exporters configured with the bare host POST OTLP to
+  # "/". Rewrite to the canonical OTLP/HTTP trace path so it reaches handleOTLP.
+  replacePath:
+    path: /v1/traces


### PR DESCRIPTION
## Problem

Browser telemetry from `https://brandtrace.net` → `https://sb.brandtrace.net` was failing with CORS errors. `sb.brandtrace.net` was never onboarded into the production ingress, so its requests matched no `IngressRoute`, fell through, and came back with no `Access-Control-Allow-Origin` header — which the browser reports as a CORS failure.

The captured request also POSTs OTLP `resourceSpans` to the **bare host** (`/`) instead of `/v1/traces`, because the client's OTLP exporter `url` is set to the host root.

## Fix (ingress-only — no app code change)

- Generalise `ingress-forward-domains.yaml` from an enumerated host list to `HostRegexp(`^sb\..+$`)` for the ingest paths (`/v1/traces`, `/api/v1/spans`, `/api/v1/telemetry`, `/api/v1/client-errors`). **Any `sb.` CNAME alias now ingests with zero further ingress changes.**
- Add an `otlp-root-to-traces` `replacePath` middleware that rewrites `POST`/`OPTIONS` on `/` → `/v1/traces` for `sb.*` hosts, so bare-host-configured exporters (and their CORS preflight) reach `handleOTLP`. The Go CORS middleware already echoes the request origin on the OTLP path, so the preflight is answered correctly.
- The `GET /` → root-domain 301 redirect stays **enumerated** to the ingest-only aliases, so the wildcard never hijacks full-alias domains like `sb.bananasketch.nl` (which serves its own dashboard at `/`).
- `spanbarn.wiebe.xyz` is unaffected — `spanbarn.` does not match `^sb\.`.

## Validation

- `kubectl kustomize deploy/k8s/production` renders cleanly with the new wildcard route + middleware.
- `go build ./...` + `go test ./internal/api/` (CORS/OTLP) pass.

## Deploy prerequisite

`sb.brandtrace.net` must resolve to the cluster (CNAME, proxied via Cloudflare like the other `sb.*` aliases) and TLS must terminate at the Cloudflare edge / be covered by `spanbarn-forward-domains-tls`, same as the existing forward domains. Applied to prod via the manual `deploy-production` workflow.