### PR TITLE
fix(litestream): stop redundant PASSIVE checkpoints racing the writer

### DIFF
--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -1,5 +1,15 @@
 dbs:
   - path: /var/lib/spanbarn/spanbarn.db
+    # The writer process owns WAL truncation via explicit wal_checkpoint(TRUNCATE)
+    # on a connection with busy_timeout (see internal/repository/db.go). Litestream's
+    # own PASSIVE checkpoint uses a connection without busy_timeout, so it loses the
+    # race against the writer and logs "checkpoint: mode=PASSIVE err=database is
+    # locked" ~190x/hour — cosmetic noise that floods error tracking. Raising the
+    # PASSIVE trigger far above normal WAL size stops those attempts; the default
+    # max-checkpoint-page-count (10000 ≈ 40 MiB) remains as a safety backstop, and
+    # replication is unaffected (WAL frames are copied each sync regardless of
+    # checkpointing, and Litestream's read lock protects un-replicated frames).
+    min-checkpoint-page-count: 1000000
     replicas:
       - type: s3
         bucket: spanbarn-sqlite


### PR DESCRIPTION
## Why
The writer logs `checkpoint: mode=PASSIVE err=database is locked` ~190×/hour at ERROR level — it floods BugBarn self-reporting and buries real errors.

## Root cause
The app owns WAL truncation (`wal_checkpoint(TRUNCATE)` every 30s on a connection **with** `busy_timeout`, `internal/repository/db.go`). Litestream (v0.3.13, separate process) also runs its own PASSIVE checkpoint on a connection **without** busy_timeout, so it loses the race against the writer and logs the error every sync.

## Fix
Raise `min-checkpoint-page-count` so Litestream stops attempting routine PASSIVE checkpoints (the app already truncates the WAL). Default `max-checkpoint-page-count` (10000 ≈ 40 MiB) stays as a backstop. Config-only; one key in `deploy/docker/litestream.yml`.

## Safety
Replication is unaffected — Litestream copies WAL frames every sync independent of checkpointing, and its persistent read lock protects un-replicated frames before the app's TRUNCATE backfills (per the design note in `main.go`).

## Validation
Verified healthy on production today: replication working (WAL segments → S3, 0 auth errors), WAL bounded (~10 MB). Will trial on **staging** before any production rollout: confirm (a) the ERROR lines stop, (b) WAL segments still ship to S3, (c) WAL stays bounded.