### PR TITLE
fix(litestream): also disable time-based checkpoint-interval

### DIFF
--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -2,13 +2,17 @@ dbs:
   - path: /var/lib/spanbarn/spanbarn.db
     # The writer process owns WAL truncation via explicit wal_checkpoint(TRUNCATE)
     # on a connection with busy_timeout (see internal/repository/db.go). Litestream's
-    # own PASSIVE checkpoint uses a connection without busy_timeout, so it loses the
-    # race against the writer and logs "checkpoint: mode=PASSIVE err=database is
-    # locked" ~190x/hour — cosmetic noise that floods error tracking. Raising the
-    # PASSIVE trigger far above normal WAL size stops those attempts; the default
-    # max-checkpoint-page-count (10000 ≈ 40 MiB) remains as a safety backstop, and
-    # replication is unaffected (WAL frames are copied each sync regardless of
-    # checkpointing, and Litestream's read lock protects un-replicated frames).
+    # own checkpoint uses a connection without busy_timeout, so it loses the race
+    # against the writer and logs "checkpoint: mode=PASSIVE err=database is locked"
+    # (retried each ~1s monitor tick while the lock is held) — cosmetic noise that
+    # floods error tracking. Litestream attempts a checkpoint both on a time interval
+    # (checkpoint-interval, default 1m) and by WAL page count (min-checkpoint-page-
+    # count, default 1000); disable BOTH so Litestream stops checkpointing entirely.
+    # The default max-checkpoint-page-count (10000 ≈ 40 MiB) remains as a safety
+    # backstop. Replication is unaffected: WAL frames are copied every sync regardless
+    # of checkpointing, and Litestream's read lock protects un-replicated frames
+    # before the writer's TRUNCATE backfills them.
+    checkpoint-interval: 8760h
     min-checkpoint-page-count: 1000000
     replicas:
       - type: s3


### PR DESCRIPTION
Follow-up to #106. The staging trial showed the PASSIVE checkpoint errors continued in ~1-minute bursts even with `min-checkpoint-page-count` raised — because on a low-WAL node the trigger is Litestream's **time-based `checkpoint-interval`** (default 1m), not page count. This disables that too (`8760h`), so Litestream stops routine checkpointing entirely; `max-checkpoint-page-count` default remains a backstop. Replication is unaffected (frames copied each sync; read lock protects un-replicated frames). Will re-validate on staging before any prod rollout.