### PR TITLE
revert(litestream): restore default checkpointing (revert #106, #107)

### DIFF
--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -1,19 +1,5 @@
 dbs:
   - path: /var/lib/spanbarn/spanbarn.db
-    # The writer process owns WAL truncation via explicit wal_checkpoint(TRUNCATE)
-    # on a connection with busy_timeout (see internal/repository/db.go). Litestream's
-    # own checkpoint uses a connection without busy_timeout, so it loses the race
-    # against the writer and logs "checkpoint: mode=PASSIVE err=database is locked"
-    # (retried each ~1s monitor tick while the lock is held) — cosmetic noise that
-    # floods error tracking. Litestream attempts a checkpoint both on a time interval
-    # (checkpoint-interval, default 1m) and by WAL page count (min-checkpoint-page-
-    # count, default 1000); disable BOTH so Litestream stops checkpointing entirely.
-    # The default max-checkpoint-page-count (10000 ≈ 40 MiB) remains as a safety
-    # backstop. Replication is unaffected: WAL frames are copied every sync regardless
-    # of checkpointing, and Litestream's read lock protects un-replicated frames
-    # before the writer's TRUNCATE backfills them.
-    checkpoint-interval: 8760h
-    min-checkpoint-page-count: 1000000
     replicas:
       - type: s3
         bucket: spanbarn-sqlite


### PR DESCRIPTION
Reverts the Litestream checkpoint-disabling config from #106 and #107. On production (v0.3.237) it caused the writer's `wal_checkpoint(TRUNCATE)` — which runs on the single writer connection (`MaxOpenConns=1`) — to deadlock against Litestream's read lock, stalling span/aggregate writes for minutes at a time and freezing the main DB file (stale reads; WAL pinned at the ~40 MiB backstop). Prod was rolled back to v0.3.235. Restoring the known-good config so main stays deployable; the checkpoint-noise fix needs a different approach (investigate on staging).