### PR TITLE
revert(litestream): roll back 0.5.12 upgrade (#110)

### DIFF
--- a/deploy/docker/litestream.yml
+++ b/deploy/docker/litestream.yml
@@ -1,14 +1,12 @@
-# Litestream 0.5.x config (single `replica` field; the 0.3.x `replicas:` array is
-# deprecated). `region` is set explicitly because the 0.5.x AWS SDK v2 expects one
-# even for custom S3-compatible endpoints; MinIO ignores the value.
 dbs:
   - path: /var/lib/spanbarn/spanbarn.db
-    replica:
-      type: s3
-      bucket: spanbarn-sqlite
-      path: ${LITESTREAM_REPLICA_PATH}
-      endpoint: https://s3.wiebe.xyz
-      region: us-east-1
-      force-path-style: true
-      access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
-      secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+    replicas:
+      - type: s3
+        bucket: spanbarn-sqlite
+        path: ${LITESTREAM_REPLICA_PATH}
+        endpoint: https://s3.wiebe.xyz
+        force-path-style: true
+        access-key-id: ${LITESTREAM_ACCESS_KEY_ID}
+        secret-access-key: ${LITESTREAM_SECRET_ACCESS_KEY}
+        retention: 24h
+        sync-interval: 1m

--- a/deploy/docker/service.Dockerfile
+++ b/deploy/docker/service.Dockerfile
@@ -13,12 +13,10 @@ ARG VERSION=dev BUILD_TIME=unknown
 RUN go build -ldflags "-X main.Version=${VERSION} -X main.BuildTime=${BUILD_TIME}" -o /out/spanbarn ./cmd/spanbarn
 
 FROM alpine:3.20 AS litestream
-# v0.5.x asset naming differs from 0.3.x: "litestream-${VERSION}-linux-x86_64.tar.gz"
-# (no "v" prefix, "x86_64" not "amd64"). Tag still carries the "v" prefix.
-ARG LITESTREAM_VERSION=0.5.12
+ARG LITESTREAM_VERSION=0.3.13
 RUN apk add --no-cache ca-certificates wget && \
     wget -qO /tmp/litestream.tar.gz \
-      "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-${LITESTREAM_VERSION}-linux-x86_64.tar.gz" && \
+      "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz" && \
     tar -C /usr/local/bin -xzf /tmp/litestream.tar.gz litestream
 
 FROM alpine:3.20


### PR DESCRIPTION
**0.5.12 fails regression testing on staging** and must not reach prod.

Litestream 0.5.12 (AWS SDK v2) cannot authenticate to our S3 endpoint (`s3.wiebe.xyz`, MinIO behind a proxy): **every request returns `SignatureDoesNotMatch` (403)**, so replication is fully broken. Confirmed the *same credentials* replicate fine on 0.3.13. Tried region / force-path-style / `sign-payload` true+false / AWS checksum env — all still fail. It's a SDK-v2 SigV4 incompatibility with this endpoint, needing deeper investigation (likely the proxy + SDK v2 header signing). Reverting to the working 0.3.13; its checkpoint log noise is cosmetic.