### PR TITLE
fix(retention): batch and yield secondary deletes to stop read starvation

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -191,6 +191,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		ErrorLogRetentionDays:     cfg.ErrorLogRetentionDays,
 		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
 	}
+	repo.SetDeleteBatchYield(time.Duration(cfg.RetentionDeleteBatchYieldMS) * time.Millisecond)
 	retentionWorker := retention.NewRetentionWorker(repo, aggregator, retentionCfg, logger)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)
 	defer retentionCancel()
@@ -802,6 +803,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionRepo := repository.NewRepository(db.DB)
 	retentionRepo.SetQueryTimeout(5 * time.Minute)
 	retentionRepo.SetWriteScheduler(scheduler)
+	retentionRepo.SetDeleteBatchYield(time.Duration(cfg.RetentionDeleteBatchYieldMS) * time.Millisecond)
 
 	retentionCfg := retention.Config{
 		FullRetentionHours:        cfg.RetentionFullHours,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,115 +8,117 @@ import (
 
 // Config holds all SPANBARN_* environment variables with sensible defaults.
 type Config struct {
-	Addr                      string
-	PublicURL                 string
-	DBPath                    string
-	SpoolDir                  string
-	APIKey                    string
-	APIKeySHA256              string
-	AdminUsername             string
-	AdminPassword             string
-	AdminPasswordBcrypt       string
-	SessionSecret             string
-	SessionTTLSeconds         int
-	MaxBodyBytes              int64
-	MaxSpoolBytes             int64
-	RetentionFullHours        int
-	RetentionAggregatedDays   int
-	RetentionErrorDays        int
-	RetentionInterestingHours int
-	BoringRetentionMinutes    int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
-	MetricsRetentionDays      int // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
-	LogRetentionHours         int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
-	ErrorLogRetentionDays     int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
-	IngestSampleRate          float64
-	SlowThresholdMS           int
-	AggregationInterval       string
-	AllowedOrigins            []string
-	SelfEndpoint              string
-	SelfAPIKey                string
-	SelfMetricsIntervalSec    int  // SPANBARN_SELF_METRICS_INTERVAL_SECONDS — self-metrics export cadence (default 30)
-	SelfMetricsDisabled       bool // SPANBARN_SELF_METRICS_DISABLED — disable self-metrics export
-	BugBarnEndpoint           string
-	BugBarnAPIKey             string
-	FunnelBarnEndpoint        string
-	FunnelBarnAPIKey          string
-	FunnelBarnProject         string
-	Environment               string
-	LoginRatePerMinute        int
-	IngestRatePerMinute       int
-	APIRatePerMinute          int
-	MetricsToken              string
-	QueryTimeoutSeconds       int
-	RedisURL                  string
-	RedisQueueURL             string // SPANBARN_REDIS_QUEUE_URL — write queue Redis (separate from cache)
-	CacheTTLSeconds           int
-	Mode                      string   // "standalone" (default), "reader", "writer", or "ingest" (legacy)
-	WriterURL                 string   // URL of writer pod, used when Mode=ingest (legacy)
-	OIDCIssuer                string   // SPANBARN_OIDC_ISSUER — when all four OIDC vars are set, OIDC login is offered alongside local auth
-	OIDCClientID              string   // SPANBARN_OIDC_CLIENT_ID
-	OIDCClientSecret          string   // SPANBARN_OIDC_CLIENT_SECRET
-	OIDCRedirectURL           string   // SPANBARN_OIDC_REDIRECT_URL
-	OIDCRequiredGroup         string   // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
-	OIDCResourceAudiences     []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
-	OIDCCLIClientID           string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
-	GRPCAddr                  string   // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
+	Addr                        string
+	PublicURL                   string
+	DBPath                      string
+	SpoolDir                    string
+	APIKey                      string
+	APIKeySHA256                string
+	AdminUsername               string
+	AdminPassword               string
+	AdminPasswordBcrypt         string
+	SessionSecret               string
+	SessionTTLSeconds           int
+	MaxBodyBytes                int64
+	MaxSpoolBytes               int64
+	RetentionFullHours          int
+	RetentionAggregatedDays     int
+	RetentionErrorDays          int
+	RetentionInterestingHours   int
+	BoringRetentionMinutes      int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
+	MetricsRetentionDays        int // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
+	LogRetentionHours           int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
+	ErrorLogRetentionDays       int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
+	RetentionDeleteBatchYieldMS int // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
+	IngestSampleRate            float64
+	SlowThresholdMS             int
+	AggregationInterval         string
+	AllowedOrigins              []string
+	SelfEndpoint                string
+	SelfAPIKey                  string
+	SelfMetricsIntervalSec      int  // SPANBARN_SELF_METRICS_INTERVAL_SECONDS — self-metrics export cadence (default 30)
+	SelfMetricsDisabled         bool // SPANBARN_SELF_METRICS_DISABLED — disable self-metrics export
+	BugBarnEndpoint             string
+	BugBarnAPIKey               string
+	FunnelBarnEndpoint          string
+	FunnelBarnAPIKey            string
+	FunnelBarnProject           string
+	Environment                 string
+	LoginRatePerMinute          int
+	IngestRatePerMinute         int
+	APIRatePerMinute            int
+	MetricsToken                string
+	QueryTimeoutSeconds         int
+	RedisURL                    string
+	RedisQueueURL               string // SPANBARN_REDIS_QUEUE_URL — write queue Redis (separate from cache)
+	CacheTTLSeconds             int
+	Mode                        string   // "standalone" (default), "reader", "writer", or "ingest" (legacy)
+	WriterURL                   string   // URL of writer pod, used when Mode=ingest (legacy)
+	OIDCIssuer                  string   // SPANBARN_OIDC_ISSUER — when all four OIDC vars are set, OIDC login is offered alongside local auth
+	OIDCClientID                string   // SPANBARN_OIDC_CLIENT_ID
+	OIDCClientSecret            string   // SPANBARN_OIDC_CLIENT_SECRET
+	OIDCRedirectURL             string   // SPANBARN_OIDC_REDIRECT_URL
+	OIDCRequiredGroup           string   // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
+	OIDCResourceAudiences       []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
+	OIDCCLIClientID             string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
+	GRPCAddr                    string   // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
 }
 
 // Load reads configuration from SPANBARN_* environment variables with defaults.
 func Load() Config {
 	cfg := Config{
-		Addr:                      getenv("SPANBARN_ADDR", ":8080"),
-		PublicURL:                 os.Getenv("SPANBARN_PUBLIC_URL"),
-		DBPath:                    getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
-		SpoolDir:                  getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
-		APIKey:                    os.Getenv("SPANBARN_API_KEY"),
-		APIKeySHA256:              os.Getenv("SPANBARN_API_KEY_SHA256"),
-		AdminUsername:             os.Getenv("SPANBARN_ADMIN_USERNAME"),
-		AdminPassword:             os.Getenv("SPANBARN_ADMIN_PASSWORD"),
-		AdminPasswordBcrypt:       os.Getenv("SPANBARN_ADMIN_PASSWORD_BCRYPT"),
-		SessionSecret:             os.Getenv("SPANBARN_SESSION_SECRET"),
-		SessionTTLSeconds:         getenvInt("SPANBARN_SESSION_TTL_SECONDS", 43200),
-		MaxBodyBytes:              getenvInt64("SPANBARN_MAX_BODY_BYTES", 1<<20),
-		MaxSpoolBytes:             getenvInt64("SPANBARN_MAX_SPOOL_BYTES", 0),
-		RetentionFullHours:        getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
-		RetentionAggregatedDays:   getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
-		RetentionErrorDays:        getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
-		RetentionInterestingHours: getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
-		BoringRetentionMinutes:    getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
-		MetricsRetentionDays:      getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
-		LogRetentionHours:         getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
-		ErrorLogRetentionDays:     getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
-		IngestSampleRate:          getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
-		SlowThresholdMS:           getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
-		AggregationInterval:       getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),
-		SelfEndpoint:              os.Getenv("SPANBARN_SELF_ENDPOINT"),
-		SelfAPIKey:                os.Getenv("SPANBARN_SELF_API_KEY"),
-		SelfMetricsIntervalSec:    getenvInt("SPANBARN_SELF_METRICS_INTERVAL_SECONDS", 30),
-		SelfMetricsDisabled:       getenvInt("SPANBARN_SELF_METRICS_DISABLED", 0) != 0,
-		BugBarnEndpoint:           os.Getenv("SPANBARN_BUGBARN_ENDPOINT"),
-		BugBarnAPIKey:             os.Getenv("SPANBARN_BUGBARN_API_KEY"),
-		FunnelBarnEndpoint:        os.Getenv("SPANBARN_FUNNELBARN_ENDPOINT"),
-		FunnelBarnAPIKey:          os.Getenv("SPANBARN_FUNNELBARN_API_KEY"),
-		FunnelBarnProject:         getenv("SPANBARN_FUNNELBARN_PROJECT", "spanbarn"),
-		Environment:               getenv("SPANBARN_ENVIRONMENT", "development"),
-		LoginRatePerMinute:        getenvInt("SPANBARN_LOGIN_RATE_PER_MINUTE", 10),
-		IngestRatePerMinute:       getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),
-		APIRatePerMinute:          getenvInt("SPANBARN_API_RATE_PER_MINUTE", 300),
-		MetricsToken:              os.Getenv("SPANBARN_METRICS_TOKEN"),
-		QueryTimeoutSeconds:       getenvInt("SPANBARN_QUERY_TIMEOUT_SECONDS", 30),
-		RedisURL:                  os.Getenv("SPANBARN_REDIS_URL"),
-		RedisQueueURL:             os.Getenv("SPANBARN_REDIS_QUEUE_URL"),
-		CacheTTLSeconds:           getenvInt("SPANBARN_CACHE_TTL_SECONDS", 30),
-		Mode:                      getenv("SPANBARN_MODE", "standalone"),
-		WriterURL:                 os.Getenv("SPANBARN_WRITER_URL"),
-		OIDCIssuer:                os.Getenv("SPANBARN_OIDC_ISSUER"),
-		OIDCClientID:              os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
-		OIDCClientSecret:          os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
-		OIDCRedirectURL:           os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
-		OIDCRequiredGroup:         getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
-		OIDCCLIClientID:           os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
-		GRPCAddr:                  getenv("SPANBARN_GRPC_ADDR", ":4317"),
+		Addr:                        getenv("SPANBARN_ADDR", ":8080"),
+		PublicURL:                   os.Getenv("SPANBARN_PUBLIC_URL"),
+		DBPath:                      getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
+		SpoolDir:                    getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
+		APIKey:                      os.Getenv("SPANBARN_API_KEY"),
+		APIKeySHA256:                os.Getenv("SPANBARN_API_KEY_SHA256"),
+		AdminUsername:               os.Getenv("SPANBARN_ADMIN_USERNAME"),
+		AdminPassword:               os.Getenv("SPANBARN_ADMIN_PASSWORD"),
+		AdminPasswordBcrypt:         os.Getenv("SPANBARN_ADMIN_PASSWORD_BCRYPT"),
+		SessionSecret:               os.Getenv("SPANBARN_SESSION_SECRET"),
+		SessionTTLSeconds:           getenvInt("SPANBARN_SESSION_TTL_SECONDS", 43200),
+		MaxBodyBytes:                getenvInt64("SPANBARN_MAX_BODY_BYTES", 1<<20),
+		MaxSpoolBytes:               getenvInt64("SPANBARN_MAX_SPOOL_BYTES", 0),
+		RetentionFullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
+		RetentionAggregatedDays:     getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
+		RetentionErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
+		RetentionInterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
+		BoringRetentionMinutes:      getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
+		MetricsRetentionDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
+		LogRetentionHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
+		ErrorLogRetentionDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
+		RetentionDeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
+		IngestSampleRate:            getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
+		SlowThresholdMS:             getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
+		AggregationInterval:         getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),
+		SelfEndpoint:                os.Getenv("SPANBARN_SELF_ENDPOINT"),
+		SelfAPIKey:                  os.Getenv("SPANBARN_SELF_API_KEY"),
+		SelfMetricsIntervalSec:      getenvInt("SPANBARN_SELF_METRICS_INTERVAL_SECONDS", 30),
+		SelfMetricsDisabled:         getenvInt("SPANBARN_SELF_METRICS_DISABLED", 0) != 0,
+		BugBarnEndpoint:             os.Getenv("SPANBARN_BUGBARN_ENDPOINT"),
+		BugBarnAPIKey:               os.Getenv("SPANBARN_BUGBARN_API_KEY"),
+		FunnelBarnEndpoint:          os.Getenv("SPANBARN_FUNNELBARN_ENDPOINT"),
+		FunnelBarnAPIKey:            os.Getenv("SPANBARN_FUNNELBARN_API_KEY"),
+		FunnelBarnProject:           getenv("SPANBARN_FUNNELBARN_PROJECT", "spanbarn"),
+		Environment:                 getenv("SPANBARN_ENVIRONMENT", "development"),
+		LoginRatePerMinute:          getenvInt("SPANBARN_LOGIN_RATE_PER_MINUTE", 10),
+		IngestRatePerMinute:         getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),
+		APIRatePerMinute:            getenvInt("SPANBARN_API_RATE_PER_MINUTE", 300),
+		MetricsToken:                os.Getenv("SPANBARN_METRICS_TOKEN"),
+		QueryTimeoutSeconds:         getenvInt("SPANBARN_QUERY_TIMEOUT_SECONDS", 30),
+		RedisURL:                    os.Getenv("SPANBARN_REDIS_URL"),
+		RedisQueueURL:               os.Getenv("SPANBARN_REDIS_QUEUE_URL"),
+		CacheTTLSeconds:             getenvInt("SPANBARN_CACHE_TTL_SECONDS", 30),
+		Mode:                        getenv("SPANBARN_MODE", "standalone"),
+		WriterURL:                   os.Getenv("SPANBARN_WRITER_URL"),
+		OIDCIssuer:                  os.Getenv("SPANBARN_OIDC_ISSUER"),
+		OIDCClientID:                os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
+		OIDCClientSecret:            os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
+		OIDCRedirectURL:             os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
+		OIDCRequiredGroup:           getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
+		OIDCCLIClientID:             os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
+		GRPCAddr:                    getenv("SPANBARN_GRPC_ADDR", ":4317"),
 	}
 
 	if raw := os.Getenv("SPANBARN_ALLOWED_ORIGINS"); raw != "" {

--- a/internal/repository/migrations/027_index_prompt_records_service.go
+++ b/internal/repository/migrations/027_index_prompt_records_service.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up027, down027)
+}
+
+// up027 adds a covering index for the prompts page's service-filtered query:
+//
+//	WHERE project_id = ? AND service = ? AND ingested_at BETWEEN ? AND ?
+//	ORDER BY ingested_at DESC
+//
+// The existing idx_prompt_records_service is (project_id, service, name,
+// start_time_us) — it has no ingested_at, so a service-filtered prompts query
+// could not use the index for the time-window range or the ORDER BY and fell
+// back to a scan + sort. prompt_records is a small table, so building this
+// index is cheap (unlike the spans-table index removed in migration 022).
+func up027(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_prompt_records_project_service_ingested ON prompt_records(project_id, service, ingested_at)`)
+	return err
+}
+
+func down027(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP INDEX IF EXISTS idx_prompt_records_project_service_ingested`)
+	return err
+}

--- a/internal/repository/repo_aggregates.go
+++ b/internal/repository/repo_aggregates.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -135,28 +136,16 @@ func (r *Repository) QueryAggregates(f AggregateFilter) ([]Aggregate, error) {
 	return out, rows.Err()
 }
 
-func (r *Repository) DeleteAggregatesOlderThan(cutoff time.Time) (int64, error) {
-	var total int64
-	for {
-		var n int64
-		err := r.execLow(func() error {
-			res, e := r.db.Exec(
-				"DELETE FROM aggregates WHERE rowid IN (SELECT rowid FROM aggregates WHERE bucket < ? LIMIT 1000)",
-				cutoff,
-			)
-			if e != nil {
-				return e
-			}
-			n, _ = res.RowsAffected()
-			return nil
-		})
-		if err != nil {
-			return total, err
+func (r *Repository) DeleteAggregatesOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			"DELETE FROM aggregates WHERE rowid IN (SELECT rowid FROM aggregates WHERE bucket < ? LIMIT ?)",
+			cutoff, retentionDeleteBatch,
+		)
+		if e != nil {
+			return 0, e
 		}
-		total += n
-		if n == 0 {
-			break
-		}
-	}
-	return total, nil
+		n, _ := res.RowsAffected()
+		return n, nil
+	})
 }

--- a/internal/repository/repo_alerts.go
+++ b/internal/repository/repo_alerts.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -220,17 +221,17 @@ func (r *Repository) QueryErrorSamples(f SpanFilter) ([]Span, error) {
 	return r.scanErrorSamples(q, args...)
 }
 
-func (r *Repository) DeleteErrorSamplesOlderThan(cutoff time.Time) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec("DELETE FROM error_samples WHERE sampled_at < ?", cutoff)
+func (r *Repository) DeleteErrorSamplesOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			"DELETE FROM error_samples WHERE rowid IN (SELECT rowid FROM error_samples WHERE sampled_at < ? LIMIT ?)",
+			cutoff, retentionDeleteBatch)
 		if e != nil {
-			return e
+			return 0, e
 		}
-		n, _ = res.RowsAffected()
-		return nil
+		n, _ := res.RowsAffected()
+		return n, nil
 	})
-	return n, err
 }
 
 func (r *Repository) scanErrorSamples(query string, args ...any) ([]Span, error) {

--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -227,31 +227,31 @@ func (r *Repository) LogHistogram(ctx context.Context, f LogFilter, bucketSecs i
 // DeleteLogsOlderThan removes log records ingested before cutoff, skipping logs
 // whose trace_id is pinned or appears in recently-sampled error_samples.
 func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
+	return r.batchedDelete(ctx, func() (int64, error) {
 		res, e := r.db.ExecContext(ctx, `
-			DELETE FROM logs
-			WHERE ingested_at < ?
-			AND (trace_id IS NULL
-			     OR (trace_id NOT IN (
-			             SELECT trace_id FROM pinned_traces
-			             WHERE project_id = logs.project_id
+			DELETE FROM logs WHERE rowid IN (
+			    SELECT rowid FROM logs
+			    WHERE ingested_at < ?
+			    AND (trace_id IS NULL
+			         OR (trace_id NOT IN (
+			                 SELECT trace_id FROM pinned_traces
+			                 WHERE project_id = logs.project_id
+			             )
+			             AND trace_id NOT IN (
+			                 SELECT DISTINCT trace_id FROM error_samples
+			                 WHERE sampled_at > ?
+			             )
 			         )
-			         AND trace_id NOT IN (
-			             SELECT DISTINCT trace_id FROM error_samples
-			             WHERE sampled_at > ?
-			         )
-			     )
-			)`,
-			cutoff, errorLogCutoff,
+			    )
+			    LIMIT ?)`,
+			cutoff, errorLogCutoff, retentionDeleteBatch,
 		)
 		if e != nil {
-			return e
+			return 0, e
 		}
-		n, _ = res.RowsAffected()
-		return nil
+		n, _ := res.RowsAffected()
+		return n, nil
 	})
-	return n, err
 }
 
 // --- Pinned Traces ---

--- a/internal/repository/repo_metric_rollups.go
+++ b/internal/repository/repo_metric_rollups.go
@@ -182,28 +182,16 @@ func (r *Repository) QueryProjectRollups(ctx context.Context, projectID int64, f
 
 // DeleteMetricRollupsOlderThan removes rollup buckets older than cutoff, in
 // bounded chunks so the write lock is never held long enough to block ingest.
-func (r *Repository) DeleteMetricRollupsOlderThan(cutoff time.Time) (int64, error) {
-	var total int64
-	for {
-		var n int64
-		err := r.execLow(func() error {
-			res, e := r.db.Exec(
-				"DELETE FROM metric_rollups WHERE rowid IN (SELECT rowid FROM metric_rollups WHERE bucket < ? LIMIT 1000)",
-				cutoff,
-			)
-			if e != nil {
-				return e
-			}
-			n, _ = res.RowsAffected()
-			return nil
-		})
-		if err != nil {
-			return total, err
+func (r *Repository) DeleteMetricRollupsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			"DELETE FROM metric_rollups WHERE rowid IN (SELECT rowid FROM metric_rollups WHERE bucket < ? LIMIT ?)",
+			cutoff, retentionDeleteBatch,
+		)
+		if e != nil {
+			return 0, e
 		}
-		total += n
-		if n == 0 {
-			break
-		}
-	}
-	return total, nil
+		n, _ := res.RowsAffected()
+		return n, nil
+	})
 }

--- a/internal/repository/repo_metric_rollups_test.go
+++ b/internal/repository/repo_metric_rollups_test.go
@@ -102,7 +102,7 @@ func TestDeleteMetricRollupsOlderThan(t *testing.T) {
 		t.Fatalf("upsert: %v", err)
 	}
 
-	deleted, err := repo.DeleteMetricRollupsOlderThan(base.Add(-24 * time.Hour))
+	deleted, err := repo.DeleteMetricRollupsOlderThan(context.Background(), base.Add(-24*time.Hour))
 	if err != nil {
 		t.Fatalf("delete: %v", err)
 	}

--- a/internal/repository/repo_metrics.go
+++ b/internal/repository/repo_metrics.go
@@ -202,28 +202,16 @@ func (r *Repository) QueryMetricSeries(ctx context.Context, f MetricFilter) ([]M
 // in bounded chunks so a large backlog never holds the write lock long enough to
 // block ingest (an unbatched DELETE here previously stalled writes for minutes).
 func (r *Repository) DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	var total int64
-	for {
-		var n int64
-		err := r.execLow(func() error {
-			res, e := r.db.ExecContext(ctx,
-				`DELETE FROM metrics WHERE rowid IN (SELECT rowid FROM metrics WHERE ingested_at < ? LIMIT 1000)`,
-				cutoff)
-			if e != nil {
-				return e
-			}
-			n, _ = res.RowsAffected()
-			return nil
-		})
-		if err != nil {
-			return total, err
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			`DELETE FROM metrics WHERE rowid IN (SELECT rowid FROM metrics WHERE ingested_at < ? LIMIT ?)`,
+			cutoff, retentionDeleteBatch)
+		if e != nil {
+			return 0, e
 		}
-		total += n
-		if n == 0 {
-			break
-		}
-	}
-	return total, nil
+		n, _ := res.RowsAffected()
+		return n, nil
+	})
 }
 
 // MarshalMetricExtra serialises the Extra field of a MetricRow for JSON responses.

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -206,21 +206,24 @@ func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
 }
 
 // DeleteBoringSpansOlderThan removes non-error, fast spans ingested before cutoff.
-// Uses idx_spans_ingested (ingested_at) for the range scan.
-func (r *Repository) DeleteBoringSpansOlderThan(cutoff time.Time, slowThresholdUs int64) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec(
-			`DELETE FROM spans WHERE ingested_at < ? AND status NOT IN ('error','ERROR','Error') AND duration_us < ?`,
-			cutoff, slowThresholdUs,
+// Uses idx_spans_ingested (ingested_at) for the range scan. The delete is batched
+// (retentionDeleteBatch rows per statement) so a large purge never holds the
+// write lock long enough to block the WAL checkpoint or read-only queries.
+func (r *Repository) DeleteBoringSpansOlderThan(ctx context.Context, cutoff time.Time, slowThresholdUs int64) (int64, error) {
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			`DELETE FROM spans WHERE rowid IN (
+				SELECT rowid FROM spans
+				WHERE ingested_at < ? AND status NOT IN ('error','ERROR','Error') AND duration_us < ?
+				LIMIT ?)`,
+			cutoff, slowThresholdUs, retentionDeleteBatch,
 		)
 		if e != nil {
-			return e
+			return 0, e
 		}
-		n, _ = res.RowsAffected()
-		return nil
+		n, _ := res.RowsAffected()
+		return n, nil
 	})
-	return n, err
 }
 
 func (r *Repository) CountSpansOlderThan(cutoff time.Time) (int64, error) {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -19,11 +19,20 @@ const DefaultQueryTimeout = 30 * time.Second
 //   - repo_aggregates.go — pre-computed aggregate CRUD
 //   - repo_alerts.go     — alert CRUD, error samples
 type Repository struct {
-	db           *sql.DB
-	queryTimeout time.Duration
-	readOnly     bool
-	scheduler    *writescheduler.Scheduler
+	db               *sql.DB
+	queryTimeout     time.Duration
+	readOnly         bool
+	scheduler        *writescheduler.Scheduler
+	deleteBatchYield time.Duration
 }
+
+// retentionDeleteBatch caps the rows touched by a single batched retention
+// DELETE. Bounding each statement keeps the SQLite write-lock hold short so the
+// periodic WAL checkpoint and concurrent read-only queries are never starved
+// during a large purge (an unbatched DELETE here previously held the lock for
+// 40–140s, blocking the WAL checkpoint and timing out reads such as the prompts
+// page).
+const retentionDeleteBatch = 1000
 
 // NewRepository creates a Repository backed by the given database connection.
 func NewRepository(db *sql.DB) *Repository {
@@ -77,4 +86,45 @@ func (r *Repository) execLow(fn func() error) error {
 		return fn()
 	}
 	return r.scheduler.Submit(context.Background(), writescheduler.Low, fn)
+}
+
+// SetDeleteBatchYield sets how long batchedDelete pauses between batches. The
+// pause releases the write lock so the periodic WAL checkpoint and read-only
+// queries get a turn during a large retention purge. 0 (the default) disables
+// the pause; batches still release the lock between submissions, the pause just
+// guarantees the checkpoint a contention-free window.
+func (r *Repository) SetDeleteBatchYield(d time.Duration) { r.deleteBatchYield = d }
+
+// batchedDelete repeatedly runs exec — a single retentionDeleteBatch-bounded
+// DELETE returning the rows it affected — through the low-priority write queue
+// until a batch deletes fewer than retentionDeleteBatch rows (i.e. the tail is
+// reached). Between batches it releases the write lock and, when a yield is
+// configured, pauses so the WAL checkpoint and readers are not starved. It
+// returns the total rows deleted.
+func (r *Repository) batchedDelete(ctx context.Context, exec func() (int64, error)) (int64, error) {
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		var n int64
+		if err := r.execLow(func() error {
+			var e error
+			n, e = exec()
+			return e
+		}); err != nil {
+			return total, err
+		}
+		total += n
+		if n < retentionDeleteBatch {
+			return total, nil
+		}
+		if r.deleteBatchYield > 0 {
+			select {
+			case <-ctx.Done():
+				return total, ctx.Err()
+			case <-time.After(r.deleteBatchYield):
+			}
+		}
+	}
 }

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -1,7 +1,10 @@
 package repository
 
 import (
+	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -447,7 +450,7 @@ func TestDeleteAggregatesOlderThan(t *testing.T) {
 	bucket := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
 	_ = repo.UpsertAggregate(Aggregate{ProjectID: p.ID, Service: "web", Operation: "op", Bucket: bucket, Count: 1})
 
-	n, err := repo.DeleteAggregatesOlderThan(bucket.Add(time.Hour))
+	n, err := repo.DeleteAggregatesOlderThan(context.Background(), bucket.Add(time.Hour))
 	if err != nil {
 		t.Fatalf("DeleteAggregatesOlderThan: %v", err)
 	}
@@ -615,7 +618,7 @@ func TestInsertAndQueryErrorSamples(t *testing.T) {
 	}
 
 	// Delete with future cutoff.
-	n, err := repo.DeleteErrorSamplesOlderThan(time.Now().Add(time.Hour))
+	n, err := repo.DeleteErrorSamplesOlderThan(context.Background(), time.Now().Add(time.Hour))
 	if err != nil {
 		t.Fatalf("DeleteErrorSamplesOlderThan: %v", err)
 	}
@@ -709,5 +712,103 @@ func TestProjectUsageStatsAll(t *testing.T) {
 	p2stats := stats[1]
 	if p2stats.SpanCount != 3 || p2stats.ErrorCount != 1 || p2stats.RecentSpanCount != 3 {
 		t.Errorf("p2 unexpected: %+v", p2stats)
+	}
+}
+
+// insertBoringSpans inserts count non-error, fast spans backdated to ingestedAt
+// so retention's boring-span cleanup will consider them deletable.
+func insertBoringSpans(t *testing.T, repo *Repository, projectID int64, count int, ingestedAt time.Time) {
+	t.Helper()
+	spans := make([]Span, count)
+	for i := range spans {
+		spans[i] = Span{
+			ProjectID:   projectID,
+			TraceID:     fmt.Sprintf("boring-trace-%d", i),
+			SpanID:      fmt.Sprintf("boring-span-%d", i),
+			Name:        "op",
+			Service:     "svc",
+			Resource:    "/r",
+			Kind:        "server",
+			Status:      "ok",
+			StartTimeUs: ingestedAt.UnixMicro(),
+			DurationUs:  1000, // well under the slow threshold
+			Attributes:  "{}",
+			Events:      "[]",
+		}
+	}
+	if err := repo.InsertSpans(spans); err != nil {
+		t.Fatalf("InsertSpans: %v", err)
+	}
+	if _, err := repo.DB().Exec("UPDATE spans SET ingested_at = ?", ingestedAt); err != nil {
+		t.Fatalf("backdate ingested_at: %v", err)
+	}
+}
+
+func countSpans(t *testing.T, repo *Repository) int {
+	t.Helper()
+	var n int
+	if err := repo.DB().QueryRow("SELECT COUNT(*) FROM spans").Scan(&n); err != nil {
+		t.Fatalf("count spans: %v", err)
+	}
+	return n
+}
+
+// TestDeleteBoringSpansBatchedAndYields verifies the boring-span cleanup deletes
+// in retentionDeleteBatch-sized batches and pauses deleteBatchYield between them,
+// so it never holds the write lock for the whole purge.
+func TestDeleteBoringSpansBatchedAndYields(t *testing.T) {
+	repo := setupTestDB(t)
+	if _, err := repo.CreateProject("proj", "Proj"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	// 2.5 batches => 3 statements (1000, 1000, 500) => 2 inter-batch yields.
+	total := 2*retentionDeleteBatch + retentionDeleteBatch/2
+	old := time.Now().Add(-2 * time.Hour).UTC()
+	insertBoringSpans(t, repo, 1, total, old)
+
+	const yield = 15 * time.Millisecond
+	repo.SetDeleteBatchYield(yield)
+
+	start := time.Now()
+	n, err := repo.DeleteBoringSpansOlderThan(context.Background(), time.Now(), 1_000_000)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("DeleteBoringSpansOlderThan: %v", err)
+	}
+	if int(n) != total {
+		t.Fatalf("deleted %d rows, want %d", n, total)
+	}
+	if remaining := countSpans(t, repo); remaining != 0 {
+		t.Fatalf("expected all boring spans deleted, %d remain", remaining)
+	}
+	// With 3 batches there are 2 yields; allow for scheduler slack.
+	if elapsed < 2*yield {
+		t.Fatalf("delete finished in %v, expected at least 2 yields (%v): not batched", elapsed, 2*yield)
+	}
+}
+
+// TestBatchedDeleteRespectsContextCancellation verifies a batched retention
+// delete stops promptly when its context is cancelled, leaving rows intact.
+func TestBatchedDeleteRespectsContextCancellation(t *testing.T) {
+	repo := setupTestDB(t)
+	if _, err := repo.CreateProject("proj", "Proj"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	total := 2 * retentionDeleteBatch
+	insertBoringSpans(t, repo, 1, total, time.Now().Add(-2*time.Hour).UTC())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the first batch
+
+	n, err := repo.DeleteBoringSpansOlderThan(ctx, time.Now(), 1_000_000)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 rows deleted on immediate cancel, got %d", n)
+	}
+	if remaining := countSpans(t, repo); remaining != total {
+		t.Fatalf("expected %d spans intact after cancel, got %d", total, remaining)
 	}
 }

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -40,13 +40,13 @@ type Repository interface {
 	GetSpansForAggregation(cutoff time.Time, limit int) ([]repository.Span, error)
 	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
-	DeleteBoringSpansOlderThan(cutoff time.Time, slowThresholdUs int64) (int64, error)
+	DeleteBoringSpansOlderThan(ctx context.Context, cutoff time.Time, slowThresholdUs int64) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
-	DeleteErrorSamplesOlderThan(cutoff time.Time) (int64, error)
-	DeleteAggregatesOlderThan(cutoff time.Time) (int64, error)
+	DeleteErrorSamplesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+	DeleteAggregatesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteExpiredE2EUsers(now time.Time) (int64, error)
 	DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
-	DeleteMetricRollupsOlderThan(cutoff time.Time) (int64, error)
+	DeleteMetricRollupsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error)
 	GetSetting(key string) (string, error)
 }
@@ -327,17 +327,17 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	if cfg.BoringRetentionMinutes > 0 && cfg.SlowThresholdUS > 0 {
 		boringCutoff := now.Add(-time.Duration(cfg.BoringRetentionMinutes) * time.Minute)
 		var boringErr error
-		boringDeleted, boringErr = w.repo.DeleteBoringSpansOlderThan(boringCutoff, cfg.SlowThresholdUS)
+		boringDeleted, boringErr = w.repo.DeleteBoringSpansOlderThan(ctx, boringCutoff, cfg.SlowThresholdUS)
 		if boringErr != nil {
 			return boringErr
 		}
 	}
 
-	errorSamplesDeleted, err := w.repo.DeleteErrorSamplesOlderThan(errorCutoff)
+	errorSamplesDeleted, err := w.repo.DeleteErrorSamplesOlderThan(ctx, errorCutoff)
 	if err != nil {
 		return err
 	}
-	aggregatesDeleted, err := w.repo.DeleteAggregatesOlderThan(aggCutoff)
+	aggregatesDeleted, err := w.repo.DeleteAggregatesOlderThan(ctx, aggCutoff)
 	if err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	metricRollupsDeleted, err := w.repo.DeleteMetricRollupsOlderThan(metricRollupCutoff)
+	metricRollupsDeleted, err := w.repo.DeleteMetricRollupsOlderThan(ctx, metricRollupCutoff)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

The prompts page in the UI intermittently hangs ~30s then errors. Diagnosed live with the `sb` CLI against prod.

It is **not** a slow query — the prompts query over the well-indexed `prompt_records` table is sub-second when the DB is idle. The hang is intermittent **write-lock / IO starvation**.

`sb database --project spanbarn` (self-telemetry) showed the retention worker holding the single SQLite write lock for minutes at a time:

| operation | p50 | p95 |
|---|---|---|
| `delete from error_samples` | 42s | 140s |
| `delete from metrics …` | 40s | 134s |
| `delete from spans … duration_us < ?` (boring) | 42s | 121s |
| `pragma wal_checkpoint(truncate)` (every 30s) | 29s | 34s |
| `delete from logs …` | 16s | 33s |

`RunOnce` ran six secondary deletes back-to-back with **no yield**; several were single unbounded `DELETE`s. With `wal_autocheckpoint(0)` the only checkpoint is the 30s `PRAGMA wal_checkpoint(TRUNCATE)`, which needs the same single writer connection — so during a sweep the checkpoint starves, the WAL balloons, and read-only queries (the prompts page) blow past the 30s client timeout.

## Fix

- Add `Repository.batchedDelete(ctx, exec)` + `SetDeleteBatchYield`: `LIMIT 1000` rowid-bounded delete loop that releases the lock and pauses between batches.
- Convert all six retention deletes to that pattern (the three unbatched ones now batch; all now yield). `ctx` threaded through for cancellable yielding.
- New env `SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS` (default 200ms), wired into both retention repos.
- Migration **027** `idx_prompt_records_project_service_ingested` for the service-filtered prompts query (latent full-scan; not the root cause).
- Tests for batching, yield timing, and context cancellation.

No single retention write now holds the lock more than ~1s, so the checkpoint keeps running, the WAL stays small, and reads stay fast during a sweep.

## Verification

- `go test -race ./...` ✅ · `make spec-check` ✅ · `go vet` + `gofmt` clean.
- Post-deploy: loop `sb prompts --project spanbarn` across a 5-min retention cycle (expect zero `context deadline exceeded`) and confirm DELETE p95 in self-telemetry drops from 120–140s to low seconds.

## Follow-up (out of scope)

`prompt_records` still has no retention and grows unbounded.