### PR TITLE
fix(db): size SQLite page cache + mmap to stop ingest write-throughput collapse

### DIFF
--- a/deploy/k8s/base/deployment-ingest.yaml
+++ b/deploy/k8s/base/deployment-ingest.yaml
@@ -43,9 +43,10 @@ spec:
             - name: SPANBARN_DB_PATH
               value: "/var/lib/spanbarn/spanbarn.db"
             # Tell Go's GC the soft cap so it reacts to memory pressure before
-            # the cgroup OOM-kills us. ~90% of the 256Mi limit.
+            # the cgroup OOM-kills us. ~90% of the 512Mi limit, leaving room for
+            # the read-only SQLite page cache (32 MiB) + reclaimable mmap window.
             - name: GOMEMLIMIT
-              value: "230MiB"
+              value: "448MiB"
           envFrom:
             - secretRef:
                 name: spanbarn-secrets
@@ -56,10 +57,10 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 128Mi
             limits:
               cpu: 200m
-              memory: 256Mi
+              memory: 512Mi
           livenessProbe:
             httpGet:
               path: /api/v1/health

--- a/deploy/k8s/base/deployment.yaml
+++ b/deploy/k8s/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
             - name: SPANBARN_MODE
               value: "writer"
             - name: GOMEMLIMIT
-              value: "230MiB"
+              value: "1024MiB"
             - name: SPANBARN_REDIS_QUEUE_URL
               valueFrom:
                 secretKeyRef:
@@ -42,10 +42,14 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 64Mi
+              memory: 512Mi
             limits:
               cpu: 500m
-              memory: 256Mi
+              # Sized for the 256 MiB SQLite page cache + Go heap (GOMEMLIMIT
+              # 1 GiB) + reclaimable mmap window against a ~900 MB DB. The prior
+              # 256Mi cap forced the default 2 MiB cache, which thrashed index
+              # pages to disk and collapsed write throughput.
+              memory: 2Gi
           # startupProbe disables liveness/readiness until the container is
           # actually up. With a 6 GB+ SQLite DB, a fresh migration (e.g. a
           # CREATE INDEX) can take several minutes during which the binary

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -50,9 +50,25 @@ func buildDSN(dbPath string, readOnly bool) string {
 		// stop at any reader snapshot boundary, so they cannot prevent unbounded
 		// WAL growth under sustained read load.
 		q.Add("_pragma", "wal_autocheckpoint(0)")
+		// Keep the index working set resident. The spans table carries ~12
+		// indexes, so every insert traverses many B-trees; with the SQLite
+		// default 2 MiB cache against a ~900 MB DB those pages were evicted and
+		// pread back from disk on every batch, collapsing write throughput below
+		// the ingest rate and backing up the redis write-queue. A 256 MiB page
+		// cache holds the hot interior pages; the mmap window serves the rest
+		// from the OS page cache (reclaimable) instead of per-page pread.
+		// Sized to fit under the writer pod's GOMEMLIMIT / memory limit.
+		q.Add("_pragma", "cache_size(-262144)")   // 256 MiB (negative = KiB)
+		q.Add("_pragma", "mmap_size(2147483648)") // 2 GiB
 	}
 	if readOnly {
 		q.Set("mode", "ro")
+		// Reader/query handles run in memory-constrained pods, so keep the page
+		// cache modest (still 16x the SQLite default). The mmap window is OS page
+		// cache and reclaimable under pressure, so it speeds up dashboard/alert
+		// reads without growing the Go heap.
+		q.Add("_pragma", "cache_size(-32768)")    // 32 MiB
+		q.Add("_pragma", "mmap_size(1073741824)") // 1 GiB
 	}
 	prefix := "file:"
 	if !strings.HasPrefix(dbPath, "file:") && dbPath != ":memory:" {


### PR DESCRIPTION
## Problem

Production stopped ingesting spans ("no services reporting"). Ingest returns 200s, but the writer's redis `write-queue` was frozen/growing (~1.2k) while aggregates/retention still committed. A restart did not help — the contention recurred on a fresh process.

## Root cause (confirmed via goroutine dump)

All writes serialize through one scheduler goroutine on a single SQLite connection (`MaxOpenConns=1`). Each span insert maintains the `spans` table's ~12 indexes. `buildDSN` set no `cache_size`/`mmap_size`, so SQLite ran with its **default 2 MiB page cache** against a **~900 MB** DB — index pages were evicted and `pread` back from disk on every batch. A live goroutine dump showed the scheduler pinned in `_unixRead`/`_sqlite3WalReadFrame` inside `InsertSpansContext` across every sample. As the DB grew, per-batch write time crossed the point where throughput < ingest rate → queue backlog → spans stop landing. The constant `database is locked` and alert-eval read timeouts are the same cause (the one connection is never idle).

This is gradual degradation (DB size crossing the 2 MiB cache), not a regression from a specific commit.

## Fix

- **`buildDSN`**: writer gets a 256 MiB page cache + 2 GiB mmap window; the read-only handle gets a modest 32 MiB cache + 1 GiB mmap (reclaimable OS page cache — speeds up dashboard/alert reads without growing the Go heap). Both pragmas are upper bounds, so small DBs only allocate what they touch.
- **writer Deployment**: memory limit 256Mi → 2Gi, request → 512Mi, `GOMEMLIMIT` 230MiB → 1024MiB (node has ~7 GB free).
- **ingest/reader Deployment**: limit 256Mi → 512Mi, `GOMEMLIMIT` → 448MiB.

## Validation

Built via pipeline and deployed to the production writer; confirm the `write-queue` drains to ~0 and spans reappear.