### PR TITLE
ci(release): fix .deb build — bump Go to 1.26 and pin nfpm

### DIFF
--- a/.github/workflows/binary-release.yml
+++ b/.github/workflows/binary-release.yml
@@ -109,11 +109,13 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           cache: true
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        # Pin nfpm (not @latest) so a new release bumping its Go requirement
+        # can't break the .deb build out from under us. v2.47.0 needs Go >= 1.26.4.
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.47.0
 
       - name: Build binary
         env:


### PR DESCRIPTION
## Problem

The `Build .deb Packages` job in `binary-release.yml` pins Go 1.25 but installs `nfpm@latest`. nfpm v2.47.0 now requires Go >= 1.26.4, so `go install ...@latest` fails under `GOTOOLCHAIN=local`:

```
nfpm/v2@v2.47.0 requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

This broke the `v0.3.244` Binary Release (the .deb jobs failed; tag, images, npm/pypi/macOS/Homebrew all succeeded — production deploy was unaffected).

## Fix

- Bump the job's Go to 1.26 (matches `build-and-test`).
- Pin nfpm to `v2.47.0` instead of `@latest` so a future requirement bump can't break the release out from under us.