### PR TITLE
fix(litestream): PASSIVE checkpoint under Litestream to stop forced re-snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Go checks
         if: steps.detect.outputs.go_mods != '0'
         shell: bash
+        env:
+          # Isolate the Go module cache per job. These self-hosted runners host
+          # many repos on one machine sharing the default GOMODCACHE; a
+          # concurrent `go clean -modcache` or module churn from another repo can
+          # truncate a module extraction mid-parse and surface here as a spurious
+          # "expected 'package', found 'EOF'". A job-scoped cache is immune to
+          # that cross-repo race.
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
         run: |
           set -euo pipefail
           prune=( \( -path './.git' -o -path './.cache' -o -path './.ci-venv' -o -path '*/node_modules' -o -path '*/.venv' \) -prune -o )

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -168,16 +168,16 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	safeGo("worker", &wg, func() { w.Run(workerCtx) })
-	// Always run the app-side checkpoint even when Litestream is active.
-	// Litestream's own PASSIVE checkpoint has no busy_timeout on its connection
-	// and returns SQLITE_BUSY immediately when a write transaction is in flight
-	// (~20 span writes/s means it almost never succeeds). The app's TRUNCATE
-	// checkpoint has busy_timeout(30000) and will wait for a clear window.
-	// WAL-level reader locks ensure Litestream's unstreamed frames are never
-	// truncated before S3 confirms them, so dual checkpointing is safe.
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	// Run the app-side checkpoint on a fixed interval. Its busy_timeout(30000)
+	// lets it wait for a clear write window, which Litestream's own checkpoint
+	// (no busy_timeout, ~20 writes/s) rarely gets — so the writer stays the
+	// reliable WAL flush. When Litestream is attached we checkpoint in PASSIVE
+	// mode so we never reset its WAL generation (a TRUNCATE would force a full
+	// re-snapshot); Litestream itself owns WAL truncation of the same generation.
+	cpMode := checkpointMode()
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, logger) })
 	if litestreamActive() {
-		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
+		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
 
 	retentionCfg := retention.Config{
@@ -332,7 +332,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	ingestHandler.Stop()
 	workerCancel()
 	wg.Wait()
-	db.FinalCheckpoint(logger)
+	db.FinalCheckpoint(checkpointMode(), logger)
 
 	logger.Info("shutdown complete")
 	return nil
@@ -790,9 +790,10 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 			}
 		}
 	})
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
+	cpMode := checkpointMode()
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, logger) })
 	if litestreamActive() {
-		logger.Info("litestream active: WAL checkpoint also running in-process with busy_timeout")
+		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
 
 	// Retention queries (DELETE/SELECT on the full spans table) can take
@@ -852,7 +853,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionCancel()
 	workerCancel()
 	wg.Wait()
-	db.FinalCheckpoint(logger)
+	db.FinalCheckpoint(checkpointMode(), logger)
 
 	logger.Info("writer shutdown complete")
 	return nil
@@ -922,10 +923,22 @@ func safeGo(name string, wg *sync.WaitGroup, fn func()) {
 }
 
 // litestreamActive returns true when this process is running as the -exec child
-// of Litestream. In that case Litestream owns WAL checkpointing as part of its
-// replication cycle; spanbarn must not run a competing checkpoint goroutine.
+// of Litestream. In that case Litestream owns WAL generations and truncation as
+// part of its replication cycle, so the writer must checkpoint in PASSIVE mode
+// (see checkpointMode) — a TRUNCATE would reset the WAL header and force
+// Litestream into a costly full re-snapshot.
 func litestreamActive() bool {
 	return os.Getenv("LITESTREAM_ACCESS_KEY_ID") != ""
+}
+
+// checkpointMode picks the WAL checkpoint strategy for this process: PASSIVE when
+// a Litestream replica is attached (so we never reset its WAL generation), else
+// TRUNCATE for aggressive standalone WAL bounding.
+func checkpointMode() repository.CheckpointMode {
+	if litestreamActive() {
+		return repository.CheckpointPassive
+	}
+	return repository.CheckpointTruncate
 }
 
 // startSelfMetrics wires and launches the periodic self-metrics reporter, which

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -45,10 +45,12 @@ func buildDSN(dbPath string, readOnly bool) string {
 	if !readOnly {
 		q.Add("_pragma", "journal_mode(WAL)")
 		q.Add("_pragma", "synchronous(NORMAL)")
-		// Disable automatic passive checkpoints; the writer runs explicit TRUNCATE
-		// checkpoints on a fixed interval instead. Passive checkpoints silently
-		// stop at any reader snapshot boundary, so they cannot prevent unbounded
-		// WAL growth under sustained read load.
+		// Disable SQLite's automatic passive checkpoints; the writer issues
+		// explicit checkpoints on a fixed interval instead — TRUNCATE when running
+		// standalone, or PASSIVE when a Litestream replica is attached (see
+		// RunPeriodicCheckpoint / CheckpointMode). SQLite's own automatic passive
+		// checkpoints silently stop at any reader snapshot boundary, so they cannot
+		// prevent unbounded WAL growth under sustained read load.
 		q.Add("_pragma", "wal_autocheckpoint(0)")
 		// Keep the index working set resident. The spans table carries ~12
 		// indexes, so every insert traverses many B-trees; with the SQLite
@@ -109,10 +111,30 @@ func (d *DB) Close() error {
 	return d.DB.Close()
 }
 
-// RunPeriodicCheckpoint blocks until ctx is cancelled, issuing a WAL TRUNCATE
-// checkpoint on each tick. When a checkpoint returns busy=1 (a reader snapshot
-// blocks full WAL backfill), it retries every retryInterval until the readers
-// release or the next full-interval tick arrives.
+// CheckpointMode selects the WAL checkpoint strategy the writer issues.
+//
+//   - CheckpointTruncate resets the WAL to zero bytes on each tick. It bounds WAL
+//     size aggressively, but RESTARTS the WAL header — which a co-resident
+//     Litestream replica reads as "wal truncated by another process" and answers
+//     by starting a new generation and re-uploading a full snapshot (multi-minute,
+//     lock-contending). Use only when no Litestream replica is attached.
+//   - CheckpointPassive folds committed frames into the main DB without resetting
+//     the WAL header, so an attached Litestream keeps streaming the same generation
+//     (no forced re-snapshot). Litestream performs its own WAL restarts as part of
+//     replication; the writer's PASSIVE pass is the reliable flush that keeps the
+//     WAL bounded even when Litestream's own checkpoint loses the write-lock race.
+type CheckpointMode string
+
+const (
+	CheckpointTruncate CheckpointMode = "TRUNCATE"
+	CheckpointPassive  CheckpointMode = "PASSIVE"
+)
+
+// RunPeriodicCheckpoint blocks until ctx is cancelled, issuing a WAL checkpoint
+// in the given mode on each tick. In TRUNCATE mode, when a checkpoint returns
+// busy=1 (a reader snapshot blocks full WAL backfill) it retries every
+// retryInterval until the readers release or the next full-interval tick arrives;
+// PASSIVE mode never escalates, so it simply waits for the next tick.
 //
 // Note: TRUNCATE mode does NOT automatically retry via busy_timeout when readers
 // block WAL backfill — it returns SQLITE_BUSY immediately in that phase. busy_timeout
@@ -132,7 +154,7 @@ func (d *DB) Close() error {
 // BugBarn and FunnelBarn do. Once Litestream is doing the periodic checkpoint
 // as part of its replication loop, this goroutine can go away entirely and
 // "snapshots are not the writer's problem" becomes literally true.
-func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, log *slog.Logger) {
+func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, log *slog.Logger) {
 	retryInterval := 5 * time.Second
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -141,27 +163,27 @@ func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, 
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			d.checkpoint(ctx, retryInterval, log)
+			d.checkpoint(ctx, mode, retryInterval, log)
 		}
 	}
 }
 
-// FinalCheckpoint runs one WAL TRUNCATE checkpoint on a fresh context. Call
-// after all writers have stopped (e.g. after wg.Wait()) and before db.Close(),
-// so the WAL is merged into the main file on every clean shutdown.
+// FinalCheckpoint runs one WAL checkpoint (in the given mode) on a fresh context.
+// Call after all writers have stopped (e.g. after wg.Wait()) and before
+// db.Close(), so the WAL is merged into the main file on every clean shutdown.
 // With wal_autocheckpoint(0), db.Close() does not checkpoint automatically.
-func (d *DB) FinalCheckpoint(log *slog.Logger) {
+func (d *DB) FinalCheckpoint(mode CheckpointMode, log *slog.Logger) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	d.checkpoint(ctx, 0, log)
+	d.checkpoint(ctx, mode, 0, log)
 }
 
-func (d *DB) checkpoint(ctx context.Context, retryInterval time.Duration, log *slog.Logger) {
+func (d *DB) checkpoint(ctx context.Context, mode CheckpointMode, retryInterval time.Duration, log *slog.Logger) {
 	for {
 		var busy, walFrames, checkpointed int
-		if err := d.QueryRowContext(ctx, "PRAGMA wal_checkpoint(TRUNCATE)").Scan(&busy, &walFrames, &checkpointed); err != nil {
+		if err := d.QueryRowContext(ctx, "PRAGMA wal_checkpoint("+string(mode)+")").Scan(&busy, &walFrames, &checkpointed); err != nil {
 			if ctx.Err() == nil {
-				log.Warn("wal checkpoint error", "error", err)
+				log.Warn("wal checkpoint error", "mode", string(mode), "error", err)
 			}
 			return
 		}
@@ -171,8 +193,14 @@ func (d *DB) checkpoint(ctx context.Context, retryInterval time.Duration, log *s
 			_, _ = d.ExecContext(ctx, "PRAGMA incremental_vacuum(5000)")
 			return
 		}
-		// busy=1: a reader snapshot is blocking full WAL backfill. Retry after a
-		// short interval so the WAL can be drained once the reader finishes.
+		// busy=1: a reader snapshot is blocking full WAL backfill. PASSIVE has
+		// already flushed every frame it could this pass and does not escalate, so
+		// there is nothing to gain by retrying within the tick — wait for the next
+		// interval. TRUNCATE retries so the WAL is actually reset once the reader
+		// releases.
+		if mode != CheckpointTruncate {
+			return
+		}
 		log.Debug("wal checkpoint blocked by reader, retrying", "wal_frames", walFrames, "checkpointed", checkpointed)
 		if retryInterval == 0 {
 			return

--- a/internal/repository/db_checkpoint_test.go
+++ b/internal/repository/db_checkpoint_test.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckpointModes exercises both WAL checkpoint strategies against a
+// file-backed DB (WAL mode is a no-op on :memory:). Both must complete without
+// error and leave committed data readable. TRUNCATE must additionally reset the
+// WAL file to zero bytes; PASSIVE folds frames into the main DB but is allowed to
+// leave the WAL file in place (it does not reset the header — that is precisely
+// what keeps a co-resident Litestream on the same generation).
+func TestCheckpointModes(t *testing.T) {
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	for _, mode := range []CheckpointMode{CheckpointPassive, CheckpointTruncate} {
+		t.Run(string(mode), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "cp.db")
+			db, err := NewDB(path)
+			if err != nil {
+				t.Fatalf("NewDB: %v", err)
+			}
+			t.Cleanup(func() { db.Close() })
+			if err := Migrate(db.DB); err != nil {
+				t.Fatalf("Migrate: %v", err)
+			}
+			repo := NewRepository(db.DB)
+
+			// Generate WAL frames. wal_autocheckpoint(0) means nothing is folded
+			// into the main DB until we checkpoint explicitly.
+			for i := 0; i < 20; i++ {
+				if _, err := repo.CreateProject(fmt.Sprintf("p%d", i), "x"); err != nil {
+					t.Fatalf("CreateProject %d: %v", i, err)
+				}
+			}
+			walPath := path + "-wal"
+			if fi, err := os.Stat(walPath); err != nil || fi.Size() == 0 {
+				t.Fatalf("expected a non-empty WAL before checkpoint (err=%v)", err)
+			}
+
+			db.FinalCheckpoint(mode, discard)
+
+			// Committed data must survive the checkpoint.
+			got, err := repo.GetProjectBySlug("p19")
+			if err != nil {
+				t.Fatalf("GetProjectBySlug after %s checkpoint: %v", mode, err)
+			}
+			if got.Slug != "p19" {
+				t.Fatalf("unexpected project after checkpoint: %+v", got)
+			}
+
+			if mode == CheckpointTruncate {
+				fi, err := os.Stat(walPath)
+				if err != nil {
+					t.Fatalf("stat WAL after TRUNCATE: %v", err)
+				}
+				if fi.Size() != 0 {
+					t.Fatalf("TRUNCATE should reset the WAL to 0 bytes, got %d", fi.Size())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Production writer contention traced to a **dual WAL-ownership** conflict. The writer runs a 30s `PRAGMA wal_checkpoint(TRUNCATE)` *even while running as the Litestream `-exec` child*. `TRUNCATE` resets the WAL header, which Litestream reads as `wal truncated by another process` → it starts a **new generation and re-uploads a full snapshot** (~671 MB, 2–5 min) roughly every 30 min.

Observed in prod (`spanbarn-production`):
- `sync: new generation reason="wal truncated by another process"` immediately followed by a multi-minute `write snapshot`.
- Continuous `checkpoint: mode=PASSIVE/RESTART err=database is locked` (Litestream losing the lock race).
- Span `write-queue` backlog stuck (~3000 batches), redis-queue pinned at its 768 MB cap → ingest dropping metrics/logs (`OOM command not allowed`), alert/warmer reads hitting `context deadline exceeded`. An external write couldn't get the lock for 100s straight.

Root cause is the app's `TRUNCATE`, funneled through the single serialized writer connection (`MaxOpenConns=1`).

## Fix

Introduce `CheckpointMode {TRUNCATE, PASSIVE}`:
- **Litestream attached → PASSIVE.** Folds committed frames into the main DB without resetting the WAL header, so Litestream keeps streaming the *same* generation (no forced re-snapshot). The writer's `busy_timeout(30000)` PASSIVE pass stays the reliable flush that bounds the WAL; Litestream owns truncation of its own generation.
- **Standalone → TRUNCATE** (unchanged, aggressive WAL bounding).

Covers both writer entry points and both `FinalCheckpoint` shutdown paths.

## Tests

- New `TestCheckpointModes` (file-backed DB): both modes complete, data survives; TRUNCATE resets WAL to 0 bytes.
- Full suite green locally (15 pkg ok, 0 fail).

## Rollout

Verify on prod after deploy: `new generation / wal truncated` lines stop, snapshots no longer recur every ~30 min, WAL stays bounded, write-queue drains, and a `litestream restore` round-trips.