### PR TITLE
fix(litestream): bound WAL with threshold-gated TRUNCATE under PASSIVE

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -175,7 +175,14 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	// mode so we never reset its WAL generation (a TRUNCATE would force a full
 	// re-snapshot); Litestream itself owns WAL truncation of the same generation.
 	cpMode := checkpointMode()
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, logger) })
+	// Under Litestream (PASSIVE) the WAL grows under sustained read load; escalate
+	// to a bounding TRUNCATE only once it exceeds the configured size (~256 WAL
+	// frames per MiB at the default 4 KiB page size). 0 = never (standalone TRUNCATE).
+	cpTruncateFrames := 0
+	if cpMode == repository.CheckpointPassive {
+		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
+	}
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
@@ -791,7 +798,14 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		}
 	})
 	cpMode := checkpointMode()
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, logger) })
+	// Under Litestream (PASSIVE) the WAL grows under sustained read load; escalate
+	// to a bounding TRUNCATE only once it exceeds the configured size (~256 WAL
+	// frames per MiB at the default 4 KiB page size). 0 = never (standalone TRUNCATE).
+	cpTruncateFrames := 0
+	if cpMode == repository.CheckpointPassive {
+		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
+	}
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	LogRetentionHours           int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
 	ErrorLogRetentionDays       int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
 	RetentionDeleteBatchYieldMS int // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
+	WALTruncateThresholdMB      int // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
 	IngestSampleRate            float64
 	SlowThresholdMS             int
 	AggregationInterval         string
@@ -89,6 +90,7 @@ func Load() Config {
 		LogRetentionHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
 		ErrorLogRetentionDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
 		RetentionDeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
+		WALTruncateThresholdMB:      getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
 		IngestSampleRate:            getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
 		SlowThresholdMS:             getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:         getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -154,7 +154,12 @@ const (
 // BugBarn and FunnelBarn do. Once Litestream is doing the periodic checkpoint
 // as part of its replication loop, this goroutine can go away entirely and
 // "snapshots are not the writer's problem" becomes literally true.
-func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, log *slog.Logger) {
+// truncateAboveFrames, when > 0 and mode is PASSIVE, escalates to a one-off
+// TRUNCATE on any tick where the WAL still holds more than that many frames
+// after the PASSIVE pass. This bounds the WAL under sustained read load (PASSIVE
+// cannot reset it past the oldest reader snapshot) at the cost of an occasional
+// Litestream re-snapshot — only when the WAL actually grows large, not every tick.
+func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, truncateAboveFrames int, log *slog.Logger) {
 	retryInterval := 5 * time.Second
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -163,7 +168,12 @@ func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, 
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			d.checkpoint(ctx, mode, retryInterval, log)
+			frames := d.checkpoint(ctx, mode, retryInterval, log)
+			if mode == CheckpointPassive && truncateAboveFrames > 0 && frames > truncateAboveFrames {
+				log.Info("wal exceeded truncate threshold; escalating to one TRUNCATE checkpoint",
+					"wal_frames", frames, "threshold_frames", truncateAboveFrames)
+				d.checkpoint(ctx, CheckpointTruncate, retryInterval, log)
+			}
 		}
 	}
 }
@@ -178,20 +188,24 @@ func (d *DB) FinalCheckpoint(mode CheckpointMode, log *slog.Logger) {
 	d.checkpoint(ctx, mode, 0, log)
 }
 
-func (d *DB) checkpoint(ctx context.Context, mode CheckpointMode, retryInterval time.Duration, log *slog.Logger) {
+// checkpoint runs one wal_checkpoint(mode) and returns the WAL size in frames
+// after the attempt (the pragma's `log` column), or -1 if it errored. In
+// TRUNCATE mode it retries on busy=1 (reader blocking backfill); PASSIVE returns
+// after a single pass.
+func (d *DB) checkpoint(ctx context.Context, mode CheckpointMode, retryInterval time.Duration, log *slog.Logger) int {
 	for {
 		var busy, walFrames, checkpointed int
 		if err := d.QueryRowContext(ctx, "PRAGMA wal_checkpoint("+string(mode)+")").Scan(&busy, &walFrames, &checkpointed); err != nil {
 			if ctx.Err() == nil {
 				log.Warn("wal checkpoint error", "mode", string(mode), "error", err)
 			}
-			return
+			return -1
 		}
 		if busy == 0 {
 			// Reclaim up to 5000 freed pages (~20 MiB) per tick. No-op when
 			// auto_vacuum != INCREMENTAL (i.e. before migration 018 has run).
 			_, _ = d.ExecContext(ctx, "PRAGMA incremental_vacuum(5000)")
-			return
+			return walFrames
 		}
 		// busy=1: a reader snapshot is blocking full WAL backfill. PASSIVE has
 		// already flushed every frame it could this pass and does not escalate, so
@@ -199,15 +213,15 @@ func (d *DB) checkpoint(ctx context.Context, mode CheckpointMode, retryInterval 
 		// interval. TRUNCATE retries so the WAL is actually reset once the reader
 		// releases.
 		if mode != CheckpointTruncate {
-			return
+			return walFrames
 		}
 		log.Debug("wal checkpoint blocked by reader, retrying", "wal_frames", walFrames, "checkpointed", checkpointed)
 		if retryInterval == 0 {
-			return
+			return walFrames
 		}
 		select {
 		case <-ctx.Done():
-			return
+			return walFrames
 		case <-time.After(retryInterval):
 		}
 	}

--- a/internal/repository/db_checkpoint_test.go
+++ b/internal/repository/db_checkpoint_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -64,5 +65,35 @@ func TestCheckpointModes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCheckpointFrameCount verifies checkpoint() reports the WAL frame count that
+// RunPeriodicCheckpoint's PASSIVE->TRUNCATE escalation depends on: PASSIVE leaves
+// frames in the WAL (>0), TRUNCATE resets it to 0.
+func TestCheckpointFrameCount(t *testing.T) {
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	path := filepath.Join(t.TempDir(), "cp.db")
+	db, err := NewDB(path)
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := Migrate(db.DB); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	repo := NewRepository(db.DB)
+	for i := 0; i < 50; i++ {
+		if _, err := repo.CreateProject(fmt.Sprintf("p%d", i), "x"); err != nil {
+			t.Fatalf("CreateProject %d: %v", i, err)
+		}
+	}
+	ctx := context.Background()
+
+	if n := db.checkpoint(ctx, CheckpointPassive, 0, discard); n <= 0 {
+		t.Fatalf("PASSIVE checkpoint should report >0 WAL frames, got %d", n)
+	}
+	if n := db.checkpoint(ctx, CheckpointTruncate, 0, discard); n != 0 {
+		t.Fatalf("TRUNCATE checkpoint should report 0 WAL frames after reset, got %d", n)
 	}
 }


### PR DESCRIPTION
## Problem

The PASSIVE-under-Litestream checkpoint (#115, v0.3.246) eliminated the forced full re-snapshots, but revealed the tradeoff the original code flagged: **PASSIVE can't reset the WAL past the oldest reader snapshot**, so under sustained dashboard/alert read load the prod WAL grew to **~437 MB** and plateaued. That degraded write throughput enough that the writer only kept pace with incoming spans and the accumulated span backlog (~2.8k batches) stopped draining.

## Fix

`RunPeriodicCheckpoint` now escalates PASSIVE → a single **TRUNCATE** on any tick where the WAL still exceeds `SPANBARN_WAL_TRUNCATE_THRESHOLD_MB` (default **256 MB**; `0` disables). This bounds the WAL for healthy throughput, while a WAL-resetting TRUNCATE — and the Litestream re-snapshot it triggers — happens **only occasionally when the WAL is actually large**, not every 30 s like the original design.

- `checkpoint()` returns the WAL frame count (the pragma's `log` column) so the loop can decide.
- New config knob `WALTruncateThresholdMB` (env `SPANBARN_WAL_TRUNCATE_THRESHOLD_MB`, default 256) — tunable per-env without a code change.
- Standalone (no Litestream) is unchanged: always TRUNCATE.

## Tests

- `TestCheckpointFrameCount`: PASSIVE reports >0 WAL frames, TRUNCATE resets to 0.
- `TestCheckpointModes` still green; full suite green locally (15 pkg ok).

## Rollout / tuning

Watch prod after deploy: WAL should stay ≲256 MB, backlog should resume draining, and `wal exceeded truncate threshold` should log only occasionally. If re-snapshots feel too frequent, raise `SPANBARN_WAL_TRUNCATE_THRESHOLD_MB`; if the WAL feels too large, lower it.