### PR TITLE
feat(writer): skip WAL checkpoints while draining a backlog so it can catch up

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -182,7 +182,8 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	if cpMode == repository.CheckpointPassive {
 		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
 	}
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
+	// Combined (spool) mode has no Redis write-queue backlog to gate on, so no busy skip.
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, nil, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
@@ -805,7 +806,16 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	if cpMode == repository.CheckpointPassive {
 		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
 	}
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
+	// While the span write-queue is backed up, skip checkpoints so the single
+	// writer connection isn't blocked (up to busy_timeout) draining the backlog.
+	cpBusy := func() bool {
+		if cfg.CheckpointSkipQueueDepth <= 0 {
+			return false
+		}
+		n, err := writeQueue.Len(workerCtx)
+		return err == nil && n > int64(cfg.CheckpointSkipQueueDepth)
+	}
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, cpBusy, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	ErrorLogRetentionDays       int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
 	RetentionDeleteBatchYieldMS int // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
 	WALTruncateThresholdMB      int // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
+	CheckpointSkipQueueDepth    int // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints (which can block the single connection up to busy_timeout) so it can pour throughput into draining the backlog; it still forces an occasional checkpoint to bound the WAL (default 100; 0 disables gating)
 	IngestSampleRate            float64
 	SlowThresholdMS             int
 	AggregationInterval         string
@@ -91,6 +92,7 @@ func Load() Config {
 		ErrorLogRetentionDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
 		RetentionDeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
 		WALTruncateThresholdMB:      getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
+		CheckpointSkipQueueDepth:    getenvInt("SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH", 100),
 		IngestSampleRate:            getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
 		SlowThresholdMS:             getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:         getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -154,20 +154,54 @@ const (
 // BugBarn and FunnelBarn do. Once Litestream is doing the periodic checkpoint
 // as part of its replication loop, this goroutine can go away entirely and
 // "snapshots are not the writer's problem" becomes literally true.
+// maxSkippedCheckpoints bounds how many consecutive ticks the busy gate may skip
+// before a checkpoint is forced anyway, so a long catch-up cannot grow the WAL
+// without limit. At a 30s interval this is ~10 minutes.
+const maxSkippedCheckpoints = 20
+
+// checkpointGate decides whether to skip this checkpoint tick. While the writer
+// is busy draining a backlog, a checkpoint is skipped so it doesn't block the
+// single connection — but only up to maxSkippedCheckpoints consecutive ticks, so
+// the WAL still gets bounded during a long catch-up. Returns whether to skip and
+// the updated consecutive-skip count.
+func checkpointGate(busy bool, skipped int) (skip bool, nextSkipped int) {
+	if busy && skipped < maxSkippedCheckpoints {
+		return true, skipped + 1
+	}
+	return false, 0
+}
+
 // truncateAboveFrames, when > 0 and mode is PASSIVE, escalates to a one-off
 // TRUNCATE on any tick where the WAL still holds more than that many frames
 // after the PASSIVE pass. This bounds the WAL under sustained read load (PASSIVE
 // cannot reset it past the oldest reader snapshot) at the cost of an occasional
 // Litestream re-snapshot — only when the WAL actually grows large, not every tick.
-func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, truncateAboveFrames int, log *slog.Logger) {
+//
+// busy, when non-nil and returning true, means the writer is behind on its
+// backlog. A checkpoint runs on the single writer connection and can block span
+// inserts for up to busy_timeout, so while busy we skip the tick and pour
+// throughput into draining — except every maxSkippedCheckpoints ticks, where one
+// checkpoint is forced to keep the WAL bounded during a long catch-up.
+func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, truncateAboveFrames int, busy func() bool, log *slog.Logger) {
 	retryInterval := 5 * time.Second
 	t := time.NewTicker(interval)
 	defer t.Stop()
+	skipped := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			isBusy := busy != nil && busy()
+			if skip, next := checkpointGate(isBusy, skipped); skip {
+				skipped = next
+				log.Debug("writer catching up on backlog; skipping checkpoint", "consecutive_skips", skipped)
+				continue
+			}
+			if skipped >= maxSkippedCheckpoints {
+				log.Info("forcing checkpoint after prolonged catch-up to bound the WAL", "skipped", skipped)
+			}
+			skipped = 0
 			frames := d.checkpoint(ctx, mode, retryInterval, log)
 			if mode == CheckpointPassive && truncateAboveFrames > 0 && frames > truncateAboveFrames {
 				log.Info("wal exceeded truncate threshold; escalating to one TRUNCATE checkpoint",

--- a/internal/repository/db_checkpoint_test.go
+++ b/internal/repository/db_checkpoint_test.go
@@ -97,3 +97,32 @@ func TestCheckpointFrameCount(t *testing.T) {
 		t.Fatalf("TRUNCATE checkpoint should report 0 WAL frames after reset, got %d", n)
 	}
 }
+
+// TestCheckpointGate covers the busy-skip decision: skip while busy up to the
+// cap, then force a checkpoint; never skip when idle.
+func TestCheckpointGate(t *testing.T) {
+	// Not busy: always checkpoint, skip count resets.
+	if skip, next := checkpointGate(false, 0); skip || next != 0 {
+		t.Fatalf("idle should checkpoint: skip=%v next=%d", skip, next)
+	}
+	if skip, next := checkpointGate(false, 5); skip || next != 0 {
+		t.Fatalf("idle should checkpoint and reset skips: skip=%v next=%d", skip, next)
+	}
+
+	// Busy: skip and increment, until the cap is reached.
+	skipped := 0
+	for i := 0; i < maxSkippedCheckpoints; i++ {
+		skip, next := checkpointGate(true, skipped)
+		if !skip {
+			t.Fatalf("busy below cap (skipped=%d) should skip", skipped)
+		}
+		skipped = next
+	}
+	if skipped != maxSkippedCheckpoints {
+		t.Fatalf("expected %d consecutive skips, got %d", maxSkippedCheckpoints, skipped)
+	}
+	// At the cap while still busy: force a checkpoint (don't skip), reset count.
+	if skip, next := checkpointGate(true, skipped); skip || next != 0 {
+		t.Fatalf("busy at cap should force checkpoint and reset: skip=%v next=%d", skip, next)
+	}
+}


### PR DESCRIPTION
## Problem

The recurring writer "wedge" (this morning: 14 h stalled, ingest dropping, queues at the redis cap). Root cause: while the span write-queue is backed up, the writer still runs a PASSIVE checkpoint every 30 s on its **single serialized connection**. That checkpoint uses `busy_timeout(30000)`, so when it can't grab the checkpoint lock (Litestream or a reader holds it) it **blocks span inserts for up to 30 s per tick** — starving the drain, so the queue grows until redis hits `noeviction` and ingest drops (including logs).

## Fix (idea B — skip checkpoints under load)

Gate the checkpoint on backlog depth: while the write-queue holds more than `SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH` batches (**default 100**), skip the checkpoint tick and give the connection to draining. To keep the WAL from growing without bound during a long catch-up, a checkpoint is **forced after ≤ `maxSkippedCheckpoints` (~10 min)** of consecutive skips.

- Only the split-writer (Redis-queue) path is gated; the combined spool path passes `busy=nil` (unchanged).
- The WAL-size TRUNCATE backstop from the previous PR still applies on non-skipped ticks.
- Skip decision factored into `checkpointGate(busy, skipped)` for deterministic unit testing.

## Tests

- `TestCheckpointGate`: skips while busy up to the cap, then forces; never skips when idle.
- `TestCheckpointModes` / `TestCheckpointFrameCount` still green; full suite green locally (15 pkg ok).

## Scope / follow-ups

This is the **catch-up** half. Next, as their own changes: ingest **backpressure via a shared Redis state key** (503/Retry-After, **logs exempt** — the "never drop logs" guarantee), then the **WAL-cap quiesce** (let Litestream truncate without a re-snapshot) and a **10-min deadlock restart** last-resort.