### PR TITLE
perf(writer): alert reads off the write connection + drop 2 redundant span indexes

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -208,8 +208,12 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	ratioLookup := ingest.NewCachedRatioLookup(queryRepo, time.Minute)
 
 	alertNotifier := alert.NewDefaultNotifier(alert.NotifierConfig{}, logger)
-	alertEval := alert.NewEvaluator(repo, alertNotifier, logger, ratioLookup)
-	alertRunner := alert.NewRunner(alertEval, repo, time.Minute, logger)
+	// Alert reads (ListAlerts/QueryAggregates/QueryMetricRollups, every interval)
+	// run on the read-only connection so they never contend with the single
+	// writer connection; the rare trigger write stays on the writable repo.
+	alertEval := alert.NewEvaluator(queryRepo, alertNotifier, logger, ratioLookup)
+	alertEval.SetTriggerWriter(repo)
+	alertRunner := alert.NewRunner(alertEval, queryRepo, time.Minute, logger)
 	alertCtx, alertCancel := context.WithCancel(ctx)
 	defer alertCancel()
 	safeGo("alert-runner", &wg, func() { alertRunner.Run(alertCtx) })
@@ -847,8 +851,11 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	safeGo("retention", &wg, func() { retentionWorker.Run(retentionCtx) })
 
 	alertNotifier := alert.NewDefaultNotifier(alert.NotifierConfig{}, logger)
-	alertEval := alert.NewEvaluator(repo, alertNotifier, logger, writerRatioLookup)
-	alertRunner := alert.NewRunner(alertEval, repo, time.Minute, logger)
+	// Alert reads run on the read-only connection; the rare trigger write stays
+	// on the writable repo. Keeps alert evaluation off the single writer path.
+	alertEval := alert.NewEvaluator(queryRepo, alertNotifier, logger, writerRatioLookup)
+	alertEval.SetTriggerWriter(repo)
+	alertRunner := alert.NewRunner(alertEval, queryRepo, time.Minute, logger)
 	alertCtx, alertCancel := context.WithCancel(ctx)
 	defer alertCancel()
 	safeGo("alert-runner", &wg, func() { alertRunner.Run(alertCtx) })

--- a/internal/alert/evaluator.go
+++ b/internal/alert/evaluator.go
@@ -16,11 +16,20 @@ import (
 
 var alertTracer = otel.Tracer("spanbarn/alert")
 
-// AlertRepository defines the data access methods needed by the evaluator.
+// AlertRepository defines the read data access methods needed by the evaluator.
+// These run every interval and can be pointed at a read-only DB connection so
+// alert evaluation never contends with the single writer connection.
 type AlertRepository interface {
 	ListAlerts(projectID int64) ([]repository.Alert, error)
 	QueryAggregates(filter repository.AggregateFilter) ([]repository.Aggregate, error)
 	QueryMetricRollups(ctx context.Context, f repository.MetricRollupFilter) ([]repository.MetricRollup, error)
+	UpdateAlertLastTriggered(alertID int64, at time.Time) error
+}
+
+// AlertTriggerWriter performs the one write the evaluator makes — recording a
+// trigger. It only fires when an alert actually crosses its threshold (rare), so
+// it can stay on the writable connection while reads move to the read-only one.
+type AlertTriggerWriter interface {
 	UpdateAlertLastTriggered(alertID int64, at time.Time) error
 }
 
@@ -50,7 +59,8 @@ type SampleRatioLookup interface {
 
 // Evaluator checks alert conditions against aggregate data and sends notifications.
 type Evaluator struct {
-	repo        AlertRepository
+	repo        AlertRepository    // reads (may be a read-only connection)
+	triggers    AlertTriggerWriter // the rare trigger write (writable connection)
 	notify      Notifier
 	logger      *slog.Logger
 	now         func() time.Time // injectable clock for testing
@@ -59,17 +69,28 @@ type Evaluator struct {
 
 // NewEvaluator creates an Evaluator with the given dependencies. ratioLookup
 // is used to correct error rates for projects using error-biased sampling.
-// Pass nil for no correction.
+// Pass nil for no correction. repo serves both reads and (by default) the
+// trigger write; call SetTriggerWriter to route the write to a separate
+// (writable) connection when repo is read-only.
 func NewEvaluator(repo AlertRepository, notifier Notifier, logger *slog.Logger, ratioLookup SampleRatioLookup) *Evaluator {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &Evaluator{
 		repo:        repo,
+		triggers:    repo,
 		notify:      notifier,
 		logger:      logger,
 		now:         time.Now,
 		ratioLookup: ratioLookup,
+	}
+}
+
+// SetTriggerWriter routes the trigger-recording write to a separate connection
+// (typically the writable one) so read queries can run on a read-only pool.
+func (e *Evaluator) SetTriggerWriter(w AlertTriggerWriter) {
+	if w != nil {
+		e.triggers = w
 	}
 }
 
@@ -273,8 +294,8 @@ func (e *Evaluator) maybeTrigger(ctx context.Context, span trace.Span, a reposit
 		}
 	}
 
-	// Update last_triggered_at.
-	if err := e.repo.UpdateAlertLastTriggered(a.ID, now); err != nil {
+	// Update last_triggered_at on the writable connection.
+	if err := e.triggers.UpdateAlertLastTriggered(a.ID, now); err != nil {
 		return fmt.Errorf("update last_triggered_at: %w", err)
 	}
 

--- a/internal/repository/migrations/028_drop_redundant_span_indexes.go
+++ b/internal/repository/migrations/028_drop_redundant_span_indexes.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up028, down028)
+}
+
+// up028 drops two span indexes that are strict prefixes of existing composite
+// indexes, so every span INSERT was maintaining redundant B-trees:
+//
+//   - idx_spans_project_id (project_id)  ⊂ idx_spans_project_ingested (project_id, ingested_at)
+//   - idx_spans_ingested   (ingested_at) ⊂ idx_spans_project_stats    (ingested_at, project_id, status)
+//
+// Verified on production via EXPLAIN QUERY PLAN that the affected project_id and
+// ingested_at (retention/query) predicates fall back to the composites as
+// covering-index searches — no full scans. Removing them cuts per-insert write
+// amplification on the hot spans table. DROP INDEX is a metadata/free-page
+// operation, so it does not scan the table and is safe during a rolling deploy.
+func up028(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`DROP INDEX IF EXISTS idx_spans_project_id`,
+		`DROP INDEX IF EXISTS idx_spans_ingested`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down028(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`CREATE INDEX IF NOT EXISTS idx_spans_project_id ON spans(project_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_ingested ON spans(ingested_at)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Two low-risk changes that cut contention on the single serialized writer connection so it drains the backlog faster. (Cache/memory resize deferred — infra-constrained.)

## D — alert reads off the write connection
`alertEval`/`alertRunner` ran on the read-write `repo`, so their `ListAlerts` / `QueryAggregates` / `QueryMetricRollups` (every 60 s — this is the SPA-38 `context deadline exceeded` query) competed with span inserts on the single writer connection. Now the evaluator's **reads and the runner's project listing use `queryRepo` (read-only connection)**; only the rare `UpdateAlertLastTriggered` stays on the writable repo (via a new `SetTriggerWriter`). Backward-compatible constructor — no test churn.

## A — drop 2 redundant span indexes
The spans table has **13 indexes**; every INSERT maintains all of them. Migration **028** drops two that are strict prefixes of existing composites:
- `idx_spans_project_id (project_id)` ⊂ `idx_spans_project_ingested (project_id, ingested_at)`
- `idx_spans_ingested (ingested_at)` ⊂ `idx_spans_project_stats (ingested_at, project_id, status)`

**Verified on prod via `EXPLAIN QUERY PLAN`**: the `project_id` and `ingested_at` predicates fall back to the composites as **covering-index** searches (no full scans). `DROP INDEX` is a metadata/free-page op — no table scan, safe during rolling deploy. `down028` recreates them.

## Tests
Full suite green locally (15 pkg ok); migration exercised by the repository test suite (now at version 28); alert tests green.

## Follow-ups (deferred by design)
Deeper index consolidation via per-query EXPLAIN, insert profiling, and the WAL-cap quiesce / ingest backpressure (logs-never-dropped) remain queued.