### PR TITLE
fix(security): audit remediation (S1–S13)

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -74,6 +74,11 @@ func run() error {
 		return err
 	}
 
+	// Trust proxy forwarding headers for client-IP determination only when
+	// configured (default: on outside dev), so rate limiting keys on the real
+	// client behind Caddy/Nginx instead of the shared proxy IP.
+	api.SetTrustProxy(cfg.TrustProxy)
+
 	switch cfg.Mode {
 	case "ingest":
 		return runIngestMode(cfg, logger)
@@ -296,8 +301,9 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	api.WarmCaches(ctx, queryRepo, querySvc.Cache(), logger)
 
 	mux := http.NewServeMux()
-	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+	loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
+	loginRL := api.RateLimitMiddleware(loginLimiter, "login")
+	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
 		api.WarmLoginCaches(context.Background(), querySvc, logger)
 	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
@@ -522,11 +528,9 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 
 	mux := http.NewServeMux()
 	if sessionMgr != nil && userAuth != nil {
-		loginRL := api.RateLimitMiddleware(
-			api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute),
-			"login",
-		)
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+		loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
+		loginRL := api.RateLimitMiddleware(loginLimiter, "login")
+		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
 			api.WarmLoginCaches(context.Background(), querySvc, logger)
 		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
@@ -706,8 +710,9 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	if oidcClient := buildOIDCClient(cfg, logger); oidcClient != nil {
 		apiServer.SetOIDCClient(oidcClient)
 	}
-	loginRL := api.RateLimitMiddleware(api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute), "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+	loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
+	loginRL := api.RateLimitMiddleware(loginLimiter, "login")
+	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
 		api.WarmLoginCaches(context.Background(), querySvc, logger)
 	})))
 	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
@@ -1210,11 +1215,9 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 
 	mux := http.NewServeMux()
 	if sessionMgr != nil && userAuth != nil {
-		loginRL := api.RateLimitMiddleware(
-			api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute),
-			"login",
-		)
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, func() {
+		loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
+		loginRL := api.RateLimitMiddleware(loginLimiter, "login")
+		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
 			api.WarmLoginCaches(context.Background(), querySvc, logger)
 		})))
 		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -70,6 +70,10 @@ func run() error {
 		}
 	}
 
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
 	switch cfg.Mode {
 	case "ingest":
 		return runIngestMode(cfg, logger)

--- a/internal/api/auth_middleware.go
+++ b/internal/api/auth_middleware.go
@@ -115,6 +115,15 @@ func SessionOrReadKey(sm *auth.SessionManager, authorizer *auth.Authorizer, oidc
 							writeError(w, http.StatusForbidden, "not authorized for SpanBarn", "")
 							return
 						}
+						// OIDC access-token users are read-only, exactly like
+						// read-scoped API keys (serveAPIKey below). Without this
+						// gate a token authorized only for the read group could
+						// reach the mutating project routes mounted on this same
+						// middleware (DELETE/approve/e2e/verbose).
+						if r.Method != http.MethodGet && r.Method != http.MethodHead {
+							writeError(w, http.StatusForbidden, "token is read-only", "")
+							return
+						}
 						ctx := SetUsername(r.Context(), claims.PreferredName())
 						next.ServeHTTP(w, r.WithContext(ctx))
 						return

--- a/internal/api/e2e.go
+++ b/internal/api/e2e.go
@@ -68,7 +68,7 @@ func (s *Server) handleE2ESession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	secure := r.TLS != nil
+	secure := isSecureRequest(r)
 	sessionExpires := time.Now().Add(s.sessionMgr.TTL())
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",

--- a/internal/api/hardening_extra_test.go
+++ b/internal/api/hardening_extra_test.go
@@ -1,0 +1,37 @@
+package api
+
+import "testing"
+
+func TestSafeNextPath(t *testing.T) {
+	safe := map[string]string{
+		"/dashboard":       "/dashboard",
+		"/a/b?x=1":         "/a/b?x=1",
+		"/":                "/",
+		"":                 "/",
+		"//evil.com":       "/", // protocol-relative
+		"https://evil.com": "/", // absolute URL
+		"/\\evil.com":      "/", // backslash trick
+		"javascript:alert": "/", // scheme, no leading slash
+		"evil":             "/", // relative, no leading slash
+	}
+	for in, want := range safe {
+		if got := safeNextPath(in); got != want {
+			t.Errorf("safeNextPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSecretEqual(t *testing.T) {
+	if !secretEqual("hunter2", "hunter2") {
+		t.Error("equal secrets should compare equal")
+	}
+	if secretEqual("hunter2", "hunter3") {
+		t.Error("different secrets must not compare equal")
+	}
+	if secretEqual("short", "longer-value") {
+		t.Error("different-length secrets must not compare equal")
+	}
+	if secretEqual("", "x") {
+		t.Error("empty vs non-empty must not compare equal")
+	}
+}

--- a/internal/api/iam_proxy.go
+++ b/internal/api/iam_proxy.go
@@ -22,10 +22,14 @@ func (s *Server) handleIAMProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Strip the /api/iam-proxy prefix to get the path on IamBarn.
+	// Strip the /api/iam-proxy prefix to get the path on IamBarn. Only the
+	// widget's own API namespace may be reached — this is a scoped proxy for the
+	// iambarn-profile widget, not an open relay for arbitrary IamBarn paths with
+	// the user's bearer token.
 	path := strings.TrimPrefix(r.URL.Path, "/api/iam-proxy")
-	if path == "" {
-		path = "/"
+	if !strings.HasPrefix(path, "/api/") {
+		writeError(w, http.StatusForbidden, "path not allowed", "")
+		return
 	}
 	issuer := strings.TrimRight(s.oidc.Config().Issuer, "/")
 	targetURL := issuer + path
@@ -50,11 +54,26 @@ func (s *Server) handleIAMProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	defer resp.Body.Close()
 
-	for k, vals := range resp.Header {
-		for _, v := range vals {
-			w.Header().Add(k, v)
+	// Copy only a safe allowlist of response headers. Notably never forward
+	// Set-Cookie (which would let IamBarn set cookies on the SpanBarn origin) or
+	// hop-by-hop headers.
+	for _, h := range proxyResponseHeaders {
+		if v := resp.Header.Get(h); v != "" {
+			w.Header().Set(h, v)
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+// proxyResponseHeaders is the set of upstream response headers the IAM proxy
+// echoes back to the browser. Everything else (Set-Cookie, hop-by-hop headers,
+// server fingerprints) is dropped.
+var proxyResponseHeaders = []string{
+	"Content-Type",
+	"Content-Length",
+	"Cache-Control",
+	"ETag",
+	"Last-Modified",
+	"Vary",
 }

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -58,6 +58,7 @@ func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager, onLo
 			Path:     "/",
 			Expires:  time.Now().Add(sm.TTL()),
 			HttpOnly: true,
+			Secure:   isSecureRequest(r),
 			SameSite: http.SameSiteLaxMode,
 		})
 
@@ -81,6 +82,7 @@ func HandleLogout() http.HandlerFunc {
 			Path:     "/",
 			MaxAge:   -1,
 			HttpOnly: true,
+			Secure:   isSecureRequest(r),
 			SameSite: http.SameSiteLaxMode,
 		})
 		// Clear the auth-method hint set by the OIDC callback so a

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -21,7 +21,11 @@ type loginResponse struct {
 // onLoginSuccess is called (in the request goroutine) after a session is
 // created; pass nil to skip. The function should return quickly or launch its
 // own goroutine — the HTTP response is written immediately after the call.
-func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager, onLoginSuccess func()) http.HandlerFunc {
+//
+// accountLimiter (may be nil) throttles attempts per-username under the "login"
+// category, so a distributed brute-force spread across many source IPs is still
+// bounded per account — the per-IP RateLimitMiddleware only limits a single IP.
+func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager, accountLimiter *RateLimiter, onLoginSuccess func()) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		_, span := apiTracer.Start(r.Context(), "api.login")
 		defer span.End()
@@ -35,6 +39,14 @@ func HandleLogin(userAuth *auth.UserAuthenticator, sm *auth.SessionManager, onLo
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
 			return
+		}
+
+		if accountLimiter != nil && req.Username != "" {
+			if !accountLimiter.Allow("login", "acct:"+req.Username) {
+				w.Header().Set("Retry-After", "60")
+				writeError(w, http.StatusTooManyRequests, "too many login attempts", "")
+				return
+			}
 		}
 
 		if err := userAuth.Authenticate(req.Username, req.Password); err != nil {

--- a/internal/api/login_test.go
+++ b/internal/api/login_test.go
@@ -82,6 +82,38 @@ func TestLoginSuccess(t *testing.T) {
 	}
 }
 
+// TestLoginCookieSecureOnForwardedProto verifies the session cookie is marked
+// Secure when the request arrived over HTTPS at the proxy (X-Forwarded-Proto),
+// which is the only signal available since TLS terminates upstream.
+func TestLoginCookieSecureOnForwardedProto(t *testing.T) {
+	userAuth, sm := setupLoginTest(t)
+	handler := HandleLogin(userAuth, sm, nil)
+
+	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "correct-pass"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var found bool
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "session" {
+			found = true
+			if !c.Secure {
+				t.Error("session cookie should be Secure when X-Forwarded-Proto is https")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected session cookie to be set")
+	}
+}
+
 func TestLoginWrongPassword(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
 	handler := HandleLogin(userAuth, sm, nil)

--- a/internal/api/login_test.go
+++ b/internal/api/login_test.go
@@ -43,7 +43,7 @@ func setupLoginTest(t *testing.T) (*auth.UserAuthenticator, *auth.SessionManager
 
 func TestLoginSuccess(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm, nil)
+	handler := HandleLogin(userAuth, sm, nil, nil)
 
 	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "correct-pass"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
@@ -87,7 +87,7 @@ func TestLoginSuccess(t *testing.T) {
 // which is the only signal available since TLS terminates upstream.
 func TestLoginCookieSecureOnForwardedProto(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm, nil)
+	handler := HandleLogin(userAuth, sm, nil, nil)
 
 	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "correct-pass"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
@@ -116,7 +116,7 @@ func TestLoginCookieSecureOnForwardedProto(t *testing.T) {
 
 func TestLoginWrongPassword(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm, nil)
+	handler := HandleLogin(userAuth, sm, nil, nil)
 
 	body, _ := json.Marshal(loginRequest{Username: "admin", Password: "wrong-pass"})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
@@ -130,9 +130,37 @@ func TestLoginWrongPassword(t *testing.T) {
 	}
 }
 
+// TestLoginAccountThrottle verifies the per-username limiter bounds attempts
+// against one account regardless of source IP: with a 2/min account limit, the
+// third attempt is refused with 429 even before password checking.
+func TestLoginAccountThrottle(t *testing.T) {
+	userAuth, sm := setupLoginTest(t)
+	limiter := NewRateLimiter(2 /*login*/, 1000, 1000)
+	handler := HandleLogin(userAuth, sm, limiter, nil)
+
+	do := func() int {
+		body, _ := json.Marshal(loginRequest{Username: "admin", Password: "wrong-pass"})
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if c := do(); c != http.StatusUnauthorized {
+		t.Fatalf("attempt 1: want 401, got %d", c)
+	}
+	if c := do(); c != http.StatusUnauthorized {
+		t.Fatalf("attempt 2: want 401, got %d", c)
+	}
+	if c := do(); c != http.StatusTooManyRequests {
+		t.Fatalf("attempt 3: want 429 (account throttled), got %d", c)
+	}
+}
+
 func TestLoginMethodNotAllowed(t *testing.T) {
 	userAuth, sm := setupLoginTest(t)
-	handler := HandleLogin(userAuth, sm, nil)
+	handler := HandleLogin(userAuth, sm, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/login", nil)
 	rec := httptest.NewRecorder()

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -60,7 +60,7 @@ func (m *Metrics) Handler(metricsToken string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if metricsToken != "" {
 			auth := r.Header.Get("Authorization")
-			if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != metricsToken {
+			if !strings.HasPrefix(auth, "Bearer ") || !secretEqual(strings.TrimPrefix(auth, "Bearer "), metricsToken) {
 				writeError(w, http.StatusUnauthorized, "unauthorized", "invalid or missing bearer token")
 				return
 			}

--- a/internal/api/metrics_query.go
+++ b/internal/api/metrics_query.go
@@ -169,6 +169,12 @@ func (h *metricsQueryHandlers) handleMetricSeries(w http.ResponseWriter, r *http
 	}
 
 	labels := parseLabelParams(r)
+	for k := range labels {
+		if !repository.ValidLabelKey(k) {
+			writeError(w, http.StatusBadRequest, "invalid label key", "")
+			return
+		}
+	}
 	groupBy := parseGroupBy(r)
 
 	// Long ranges read the downsampled rollups instead of scanning raw points.

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -175,6 +176,12 @@ func maxBodyBytesMiddleware(maxBytes int64, next http.Handler) http.Handler {
 	})
 }
 
+// secretEqual compares two secrets in constant time to avoid leaking their
+// contents through response-timing differences.
+func secretEqual(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
 // apiKeyAuth validates the X-SpanBarn-Api-Key header.
 func apiKeyAuth(apiKey string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -183,7 +190,7 @@ func apiKeyAuth(apiKey string, next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing API key", "set X-SpanBarn-Api-Key header")
 			return
 		}
-		if key != apiKey {
+		if !secretEqual(key, apiKey) {
 			writeError(w, http.StatusUnauthorized, "invalid API key", "")
 			return
 		}
@@ -207,7 +214,7 @@ func apiKeyOrBearerAuth(apiKey string, next http.Handler) http.Handler {
 			writeError(w, http.StatusUnauthorized, "missing API key", "set X-SpanBarn-Api-Key or Authorization: Bearer header")
 			return
 		}
-		if key != apiKey {
+		if !secretEqual(key, apiKey) {
 			writeError(w, http.StatusUnauthorized, "invalid API key", "")
 			return
 		}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -98,25 +98,25 @@ func recoveryMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
 }
 
 // corsMiddleware applies CORS headers.
-// For ingest and traces endpoints, it allows wildcard origins (browser SDK support).
-// For other routes, it respects the configured AllowedOrigins.
+//
+// Three tiers, matched on the exact path so a public prefix can never bleed into
+// a sibling (e.g. the ingest endpoint /api/v1/spans vs the session-authed SSE
+// stream /api/v1/spans/live):
+//   - Public, API-key ingest: any origin, but never with credentials.
+//   - Session-authed browser ingest: credentials, but only for allow-listed
+//     origins — reflecting an arbitrary origin with credentials would let any
+//     site drive a logged-in operator's browser into writing data.
+//   - Everything else (dashboard APIs, live-tail SSE): the strict AllowedOrigins
+//     policy, without credentials.
 func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		path := r.URL.Path
-
-		// Ingest endpoints allow any origin for browser SDKs.
-		// Echo the request origin instead of '*' so credentialed requests
-		// (credentials: 'include') are also accepted by the browser.
-		if strings.HasPrefix(path, "/api/v1/spans") ||
-			strings.HasPrefix(path, "/v1/traces") ||
-			path == "/api/v1/telemetry" ||
-			path == "/api/v1/client-errors" {
-			origin := r.Header.Get("Origin")
-			if origin == "" {
-				origin = "*"
-			}
-			w.Header().Set("Access-Control-Allow-Origin", origin)
-			w.Header().Set("Access-Control-Allow-Credentials", "true")
+		switch r.URL.Path {
+		// Public, API-key-authenticated ingest. Browser SDKs post cross-origin
+		// and authenticate with the X-SpanBarn-Api-Key header, not cookies, so
+		// any origin is allowed WITHOUT credentials. Never combine a reflected
+		// origin with Allow-Credentials here.
+		case "/api/v1/spans", "/v1/traces":
+			w.Header().Set("Access-Control-Allow-Origin", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-SpanBarn-Api-Key, Authorization, traceparent, tracestate")
 			w.Header().Set("Access-Control-Max-Age", "86400")
@@ -127,15 +127,36 @@ func corsMiddleware(allowedOrigins []string, next http.Handler) http.Handler {
 			}
 			next.ServeHTTP(w, r)
 			return
+
+		// Session-authenticated, browser-driven ingest (frontend telemetry and
+		// client errors). These carry the session cookie, so credentials are
+		// required — but only for allow-listed origins. Reflecting an arbitrary
+		// origin with credentials was the cross-origin write-injection vector.
+		case "/api/v1/telemetry", "/api/v1/client-errors":
+			if origin := r.Header.Get("Origin"); origin != "" && originAllowed(origin, allowedOrigins) {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+				w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-SpanBarn-Api-Key, Authorization, traceparent, tracestate")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+				w.Header().Set("Vary", "Origin")
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
 		}
 
-		// Other routes: respect AllowedOrigins config.
+		// All other routes: respect AllowedOrigins config, without credentials.
 		origin := r.Header.Get("Origin")
 		if origin != "" && originAllowed(origin, allowedOrigins) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 			w.Header().Set("Access-Control-Max-Age", "86400")
+			w.Header().Set("Vary", "Origin")
 			if r.Method == http.MethodOptions {
 				w.WriteHeader(http.StatusNoContent)
 				return

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -33,7 +33,8 @@ func newCORSTestServer(t *testing.T) *httptest.Server {
 func TestCORSIngestEndpoint(t *testing.T) {
 	ts := newCORSTestServer(t)
 
-	// Preflight to /api/v1/spans
+	// Preflight to /api/v1/spans — public API-key ingest is wildcard, and must
+	// NOT be credentialed (that would expose it to cross-site cookie use).
 	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/api/v1/spans", nil)
 	req.Header.Set("Origin", "https://example.com")
 	req.Header.Set("Access-Control-Request-Method", "POST")
@@ -47,8 +48,11 @@ func TestCORSIngestEndpoint(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("expected 204 for OPTIONS, got %d", resp.StatusCode)
 	}
-	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "https://example.com" {
-		t.Fatalf("expected CORS allow-origin 'https://example.com', got %q", acao)
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "*" {
+		t.Fatalf("expected CORS allow-origin '*', got %q", acao)
+	}
+	if cred := resp.Header.Get("Access-Control-Allow-Credentials"); cred != "" {
+		t.Fatalf("public ingest must not be credentialed, got Allow-Credentials %q", cred)
 	}
 	acah := resp.Header.Get("Access-Control-Allow-Headers")
 	if !strings.Contains(acah, "X-SpanBarn-Api-Key") {
@@ -74,13 +78,69 @@ func TestCORSOTLPEndpoint(t *testing.T) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("expected 204 for OPTIONS preflight, got %d", resp.StatusCode)
 	}
-	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "https://geobarn.test.wiebe.xyz" {
-		t.Fatalf("expected CORS allow-origin 'https://geobarn.test.wiebe.xyz', got %q", acao)
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "*" {
+		t.Fatalf("expected CORS allow-origin '*', got %q", acao)
+	}
+	if cred := resp.Header.Get("Access-Control-Allow-Credentials"); cred != "" {
+		t.Fatalf("public OTLP ingest must not be credentialed, got Allow-Credentials %q", cred)
 	}
 	acah := resp.Header.Get("Access-Control-Allow-Headers")
 	for _, h := range []string{"Authorization", "traceparent", "Content-Type"} {
 		if !strings.Contains(acah, h) {
 			t.Fatalf("expected CORS allow-headers to include %q, got %q", h, acah)
+		}
+	}
+}
+
+// TestCORSLiveTailNotWildcard is the S6 regression: the session-authed SSE
+// stream /api/v1/spans/live shares a prefix with the public ingest endpoint but
+// must NOT get wildcard/credentialed CORS. With no AllowedOrigins configured, an
+// arbitrary origin must receive no Access-Control-Allow-Origin at all.
+func TestCORSLiveTailNotWildcard(t *testing.T) {
+	ts := newCORSTestServer(t)
+
+	req, _ := http.NewRequest(http.MethodOptions, ts.URL+"/api/v1/spans/live", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if acao := resp.Header.Get("Access-Control-Allow-Origin"); acao != "" {
+		t.Fatalf("live-tail must not reflect an arbitrary origin, got ACAO %q", acao)
+	}
+	if cred := resp.Header.Get("Access-Control-Allow-Credentials"); cred != "" {
+		t.Fatalf("live-tail must not be credentialed, got Allow-Credentials %q", cred)
+	}
+}
+
+// TestCORSTelemetryRequiresAllowlist is the S8 regression: session-authed
+// browser ingest must only be credentialed for allow-listed origins. With no
+// AllowedOrigins configured, an arbitrary origin gets neither a reflected origin
+// nor Allow-Credentials, so it cannot drive credentialed cross-origin writes.
+func TestCORSTelemetryRequiresAllowlist(t *testing.T) {
+	ts := newCORSTestServer(t)
+
+	for _, path := range []string{"/api/v1/telemetry", "/api/v1/client-errors"} {
+		req, _ := http.NewRequest(http.MethodOptions, ts.URL+path, nil)
+		req.Header.Set("Origin", "https://evil.example")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: request failed: %v", path, err)
+		}
+		acao := resp.Header.Get("Access-Control-Allow-Origin")
+		cred := resp.Header.Get("Access-Control-Allow-Credentials")
+		resp.Body.Close()
+		if acao == "https://evil.example" || acao == "*" {
+			t.Errorf("%s: must not allow arbitrary origin, got ACAO %q", path, acao)
+		}
+		if cred != "" {
+			t.Errorf("%s: must not credential an unlisted origin, got Allow-Credentials %q", path, cred)
 		}
 	}
 }

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -4,8 +4,21 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"net/http"
+	"strings"
 	"time"
 )
+
+// safeNextPath returns next only if it is a root-relative local path, otherwise
+// "/". This blocks open-redirect abuse of the post-login ?next= parameter: an
+// absolute URL, a protocol-relative "//evil.com", or a "/\evil" backslash trick
+// would otherwise send the freshly-authenticated user to an attacker's site.
+func safeNextPath(next string) string {
+	if next == "" || !strings.HasPrefix(next, "/") ||
+		strings.HasPrefix(next, "//") || strings.HasPrefix(next, "/\\") {
+		return "/"
+	}
+	return next
+}
 
 const (
 	oidcStateCookie = "spanbarn_oidc_state"
@@ -35,7 +48,8 @@ func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, nonce, secure))
 	// Stash the post-login redirect target so the callback can send the user
 	// back to the page they came from (e.g. /profile after a token refresh).
-	if next := r.URL.Query().Get("next"); next != "" {
+	// Only local paths are stored, never an attacker-supplied absolute URL.
+	if next := safeNextPath(r.URL.Query().Get("next")); next != "/" {
 		http.SetCookie(w, oidcShortLivedCookie(oidcNextCookie, next, secure))
 	}
 	http.Redirect(w, r, authURL, http.StatusFound)
@@ -134,9 +148,10 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, oidcShortLivedCookie(oidcStateCookie, "", secure))
 	http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, "", secure))
 	// Redirect back to the original page if one was stashed, otherwise /.
+	// Re-validate at the point of use so only a local path is ever followed.
 	next := "/"
-	if c, err := r.Cookie(oidcNextCookie); err == nil && c.Value != "" {
-		next = c.Value
+	if c, err := r.Cookie(oidcNextCookie); err == nil {
+		next = safeNextPath(c.Value)
 	}
 	http.SetCookie(w, oidcShortLivedCookie(oidcNextCookie, "", secure))
 	// Prevent the browser from caching this redirect — a cached response

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -30,7 +30,7 @@ func (s *Server) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "oidc unavailable", "")
 		return
 	}
-	secure := r.TLS != nil
+	secure := isSecureRequest(r)
 	http.SetCookie(w, oidcShortLivedCookie(oidcStateCookie, state, secure))
 	http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, nonce, secure))
 	// Stash the post-login redirect target so the callback can send the user
@@ -95,7 +95,7 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "session unavailable", "")
 		return
 	}
-	secure := r.TLS != nil
+	secure := isSecureRequest(r)
 	expires := time.Now().Add(s.sessionMgr.TTL())
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session",

--- a/internal/api/oidc_resource_middleware_test.go
+++ b/internal/api/oidc_resource_middleware_test.go
@@ -97,6 +97,18 @@ func TestSessionOrReadKey_IamBarnJWT(t *testing.T) {
 		}
 	})
 
+	t.Run("write method rejected as read-only → 403", func(t *testing.T) {
+		for _, m := range []string{http.MethodDelete, http.MethodPost, http.MethodPut} {
+			req := httptest.NewRequest(m, "/api/v1/projects/1", nil)
+			req.Header.Set("Authorization", "Bearer "+sign(base()))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code != http.StatusForbidden {
+				t.Errorf("%s: expected 403 (read-only), got %d", m, rec.Code)
+			}
+		}
+	})
+
 	t.Run("disallowed role → 403", func(t *testing.T) {
 		c := base()
 		c["roles"] = []string{"member"}

--- a/internal/api/ratelimit.go
+++ b/internal/api/ratelimit.go
@@ -2,10 +2,47 @@ package api
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// trustProxyHeaders controls whether X-Forwarded-For/X-Real-IP are trusted when
+// determining the client IP for rate limiting. It is process-global because the
+// trust decision is a property of the deployment, not of any one limiter.
+var trustProxyHeaders atomic.Bool
+
+// SetTrustProxy configures proxy-header trust for client-IP determination.
+// Enable it only when the app sits behind a reverse proxy that overwrites the
+// forwarding headers (Caddy/Nginx); otherwise clients could spoof them to evade
+// rate limits. Call once at startup, before serving.
+func SetTrustProxy(v bool) { trustProxyHeaders.Store(v) }
+
+// clientIP returns the rate-limit key IP for a request. Behind a trusted proxy
+// it uses the right-most X-Forwarded-For entry (the hop the proxy itself
+// appended — left entries can be client-forged) or X-Real-IP, falling back to
+// the transport peer. Directly exposed, it always uses the transport peer so
+// forwarding headers cannot be spoofed to dodge limits.
+func clientIP(r *http.Request) string {
+	if trustProxyHeaders.Load() {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			parts := strings.Split(xff, ",")
+			if ip := strings.TrimSpace(parts[len(parts)-1]); ip != "" {
+				return ip
+			}
+		}
+		if xr := strings.TrimSpace(r.Header.Get("X-Real-IP")); xr != "" {
+			return xr
+		}
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
 
 // bucket implements a token bucket for rate limiting.
 type bucket struct {
@@ -102,16 +139,7 @@ func (rl *RateLimiter) cleanup() {
 func RateLimitMiddleware(rl *RateLimiter, category string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			clientIP := r.RemoteAddr
-			// Strip port if present.
-			if idx := lastIndexByte(clientIP, ':'); idx != -1 {
-				// Check if this looks like host:port (not just IPv6).
-				if clientIP[0] != '[' || idx > 0 {
-					clientIP = clientIP[:idx]
-				}
-			}
-
-			if !rl.Allow(category, clientIP) {
+			if !rl.Allow(category, clientIP(r)) {
 				w.Header().Set("Retry-After", "60")
 				writeError(w, http.StatusTooManyRequests, "rate limit exceeded", "")
 				return
@@ -119,13 +147,4 @@ func RateLimitMiddleware(rl *RateLimiter, category string) func(http.Handler) ht
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-func lastIndexByte(s string, c byte) int {
-	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/api/ratelimit_test.go
+++ b/internal/api/ratelimit_test.go
@@ -7,6 +7,49 @@ import (
 	"time"
 )
 
+func TestClientIP(t *testing.T) {
+	newReq := func(remote, xff, xrip string) *http.Request {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.RemoteAddr = remote
+		if xff != "" {
+			r.Header.Set("X-Forwarded-For", xff)
+		}
+		if xrip != "" {
+			r.Header.Set("X-Real-IP", xrip)
+		}
+		return r
+	}
+
+	t.Run("untrusted uses RemoteAddr and ignores headers", func(t *testing.T) {
+		SetTrustProxy(false)
+		got := clientIP(newReq("10.0.0.1:5555", "1.2.3.4", "9.9.9.9"))
+		if got != "10.0.0.1" {
+			t.Errorf("want 10.0.0.1 (peer, headers ignored), got %q", got)
+		}
+	})
+
+	t.Run("trusted uses right-most XFF entry", func(t *testing.T) {
+		SetTrustProxy(true)
+		defer SetTrustProxy(false)
+		// Left entry is client-forgeable; the right-most is proxy-appended.
+		got := clientIP(newReq("10.0.0.1:5555", "6.6.6.6, 203.0.113.7", ""))
+		if got != "203.0.113.7" {
+			t.Errorf("want 203.0.113.7 (proxy-appended), got %q", got)
+		}
+	})
+
+	t.Run("trusted falls back to X-Real-IP then peer", func(t *testing.T) {
+		SetTrustProxy(true)
+		defer SetTrustProxy(false)
+		if got := clientIP(newReq("10.0.0.1:5555", "", "198.51.100.2")); got != "198.51.100.2" {
+			t.Errorf("want X-Real-IP 198.51.100.2, got %q", got)
+		}
+		if got := clientIP(newReq("10.0.0.1:5555", "", "")); got != "10.0.0.1" {
+			t.Errorf("want peer 10.0.0.1, got %q", got)
+		}
+	})
+}
+
 func newTestRateLimiter(loginRate, ingestRate, apiRate int) *RateLimiter {
 	configs := map[string]float64{
 		"login":  float64(loginRate) / 60.0,

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -189,9 +189,11 @@ func (s *Server) registerRoutes() {
 		s.mux.Handle("/api/v1/export", apiRL(sessionAuth(eh)))
 	}
 
-	// Setup endpoint — public, no auth required.
+	// Setup endpoint — intentionally public (onboarding), but rate-limited and
+	// GET-only + read-idempotent (see handleSetup) so anonymous callers cannot
+	// use it to spam projects or amplify writes.
 	if s.repo != nil {
-		s.mux.HandleFunc("/api/v1/setup/{slug}", s.handleSetup)
+		s.mux.Handle("/api/v1/setup/{slug}", apiRL(http.HandlerFunc(s.handleSetup)))
 	}
 
 	// E2E session endpoint — API key auth required; only works when e2e_enabled.

--- a/internal/api/security.go
+++ b/internal/api/security.go
@@ -1,6 +1,23 @@
 package api
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
+)
+
+// isSecureRequest reports whether the original client connection used HTTPS.
+// TLS terminates at the reverse proxy (Caddy/Nginx) in every real deployment, so
+// r.TLS is nil for the request the app sees; the proxy conveys the real scheme
+// via X-Forwarded-Proto. Honouring that header only decides whether the Secure
+// cookie flag and HSTS are emitted, so a spoofed value can at most affect the
+// spoofer's own session — and browsers ignore an HSTS header received over
+// plaintext — which makes it safe to trust here without a proxy allowlist.
+func isSecureRequest(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}
 
 // SecurityHeaders adds standard security headers to all responses.
 func SecurityHeaders(next http.Handler) http.Handler {
@@ -10,7 +27,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("X-XSS-Protection", "0")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'")
-		if r.TLS != nil {
+		if isSecureRequest(r) {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
 		next.ServeHTTP(w, r)

--- a/internal/api/security_test.go
+++ b/internal/api/security_test.go
@@ -68,3 +68,21 @@ func TestHSTSOnTLS(t *testing.T) {
 		t.Errorf("HSTS header: expected %q, got %q", expected, got)
 	}
 }
+
+// TestHSTSOnForwardedProto covers the real deployment shape: TLS terminates at
+// the proxy (r.TLS == nil) and the scheme arrives via X-Forwarded-Proto, which
+// must still drive HSTS emission.
+func TestHSTSOnForwardedProto(t *testing.T) {
+	handler := SecurityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if got := rr.Header().Get("Strict-Transport-Security"); got == "" {
+		t.Error("HSTS should be set when X-Forwarded-Proto is https")
+	}
+}

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -3,7 +3,9 @@ package api
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -29,23 +31,35 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 	_, span := apiTracer.Start(r.Context(), "api.setup")
 	defer span.End()
 
+	// This endpoint is intentionally public (onboarding UX) but must not be a
+	// write amplifier: only GET is allowed and, once a project exists, the page
+	// is served read-only with no further writes.
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+
 	slug := r.PathValue("slug")
 	if slug == "" {
 		http.Error(w, "slug is required", http.StatusBadRequest)
 		return
 	}
 
-	project, err := s.repo.EnsureProjectPending(slug, slug)
-	if err != nil {
-		s.logger.Error("setup: ensure project", "slug", slug, "error", err)
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-
+	// The setup key is deterministic from (session secret, slug), so it never
+	// needs to be read back; render it directly.
 	plaintext, keySHA := setupKey(s.sessionSecret, slug)
 
-	if err := s.repo.EnsureSetupAPIKey(project.ID, keySHA); err != nil {
-		s.logger.Error("setup: ensure api key", "project_id", project.ID, "error", err)
+	project, err := s.repo.GetProjectBySlug(slug)
+	if errors.Is(err, sql.ErrNoRows) {
+		// First visit for this slug: create the pending project and register its
+		// setup key. Repeat visits skip both writes.
+		project, err = s.repo.EnsureProjectPending(slug, slug)
+		if err == nil {
+			err = s.repo.EnsureSetupAPIKey(project.ID, keySHA)
+		}
+	}
+	if err != nil {
+		s.logger.Error("setup: ensure project/key", "slug", slug, "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/setup.go
+++ b/internal/api/setup.go
@@ -10,12 +10,12 @@ import (
 	"time"
 )
 
-const setupInsecureFallback = "spanbarn-setup-insecure"
-
+// setupKey deterministically derives a project's setup ingest key from the
+// server session secret and the project slug. The secret is mandatory outside
+// dev (enforced by config.Validate), so there is deliberately no constant
+// fallback — a weak/guessable key would let anyone forge a project's ingest
+// credentials, and the setup endpoint is public.
 func setupKey(secret, slug string) (plaintext, keySHA256 string) {
-	if secret == "" {
-		secret = setupInsecureFallback
-	}
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte("setup:" + slug))
 	raw := mac.Sum(nil)

--- a/internal/api/setup_test.go
+++ b/internal/api/setup_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestHandleSetupRejectsNonGet verifies the public setup endpoint only serves
+// GET. Mutating methods must be refused before any project/key writes happen, so
+// the endpoint cannot be driven as a write amplifier.
+func TestHandleSetupRejectsNonGet(t *testing.T) {
+	s := &Server{logger: slog.Default()}
+	for _, m := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		req := httptest.NewRequest(m, "/api/v1/setup/myproj", nil)
+		rec := httptest.NewRecorder()
+		s.handleSetup(rec, req)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("%s: want 405, got %d", m, rec.Code)
+		}
+	}
+}
+
+// TestSetupKeyDeterministicAndSecretDependent confirms the setup key is derived
+// from (secret, slug): stable for a given secret, and different when the secret
+// changes — so a strong mandatory secret keeps it unforgeable.
+func TestSetupKeyDeterministicAndSecretDependent(t *testing.T) {
+	a1, _ := setupKey("secret-A", "proj")
+	a2, _ := setupKey("secret-A", "proj")
+	b1, _ := setupKey("secret-B", "proj")
+	if a1 != a2 {
+		t.Errorf("setupKey not deterministic: %q vs %q", a1, a2)
+	}
+	if a1 == b1 {
+		t.Error("setupKey must change when the secret changes")
+	}
+	if len(a1) != 40 {
+		t.Errorf("setup key plaintext length = %d, want 40", len(a1))
+	}
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -129,8 +129,10 @@ func MakeExpiredToken(secret, username string) string {
 func randomHex(n int) string {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
-		// Fallback: use current time (very unlikely).
-		return time.Now().UTC().Format(time.RFC3339Nano)
+		// crypto/rand should never fail; if it does, the system entropy source is
+		// broken and continuing would emit a predictable session secret or nonce.
+		// Fail hard rather than degrade to a guessable value.
+		panic("auth: crypto/rand failed: " + err.Error())
 	}
 	return hex.EncodeToString(b)
 }

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -11,6 +11,18 @@ import (
 // ErrInvalidCredentials is returned when username/password don't match.
 var ErrInvalidCredentials = errors.New("invalid credentials")
 
+// ErrPasswordTooLong is returned when a password exceeds bcrypt's usable length.
+var ErrPasswordTooLong = errors.New("password too long (max 72 bytes)")
+
+const (
+	// bcryptCost is the work factor for new password hashes. Existing hashes keep
+	// their own cost (bcrypt stores it), so raising this needs no migration.
+	bcryptCost = 12
+	// maxPasswordBytes is bcrypt's hard limit; bytes past it are ignored, so we
+	// reject rather than silently truncate (which would weaken a long password).
+	maxPasswordBytes = 72
+)
+
 // UserLookup abstracts the repository method needed for user authentication.
 type UserLookup interface {
 	GetUserByUsername(username string) (UserRecord, error)
@@ -65,9 +77,14 @@ func (a *UserAuthenticator) Authenticate(username, password string) error {
 	return nil
 }
 
-// HashPassword hashes a plaintext password using bcrypt. Useful for CLI user creation.
+// HashPassword hashes a plaintext password using bcrypt. Useful for CLI user
+// creation. Passwords longer than bcrypt's 72-byte limit are rejected rather
+// than silently truncated.
 func HashPassword(password string) (string, error) {
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if len(password) > maxPasswordBytes {
+		return "", ErrPasswordTooLong
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcryptCost)
 	if err != nil {
 		return "", err
 	}

--- a/internal/auth/user_test.go
+++ b/internal/auth/user_test.go
@@ -21,6 +21,26 @@ func (m *mockUserLookup) GetUserByUsername(username string) (UserRecord, error) 
 	return UserRecord{}, errors.New("not found")
 }
 
+func TestHashPasswordTooLong(t *testing.T) {
+	// 73 bytes: one past bcrypt's usable length. Must be rejected, not truncated.
+	long := make([]byte, maxPasswordBytes+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if _, err := HashPassword(string(long)); !errors.Is(err, ErrPasswordTooLong) {
+		t.Errorf("want ErrPasswordTooLong for %d-byte password, got %v", len(long), err)
+	}
+
+	// Exactly 72 bytes is still accepted.
+	ok := make([]byte, maxPasswordBytes)
+	for i := range ok {
+		ok[i] = 'a'
+	}
+	if _, err := HashPassword(string(ok)); err != nil {
+		t.Errorf("72-byte password should hash, got %v", err)
+	}
+}
+
 func TestHashAndVerifyPassword(t *testing.T) {
 	password := "super-secret-123"
 	hash, err := HashPassword(password)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ type Config struct {
 	OIDCResourceAudiences       []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
 	OIDCCLIClientID             string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
 	GRPCAddr                    string   // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
+	TrustProxy                  bool     // SPANBARN_TRUST_PROXY — trust X-Forwarded-For/X-Real-IP for client IP (rate limiting); defaults to true outside dev
 }
 
 // Load reads configuration from SPANBARN_* environment variables with defaults.
@@ -142,6 +143,12 @@ func Load() Config {
 		}
 	}
 
+	// Trust proxy headers for client-IP determination by default in every named
+	// deployment (which always sits behind Caddy/Nginx), but not in dev where the
+	// app is reached directly and headers would be client-spoofable. Explicit
+	// SPANBARN_TRUST_PROXY overrides either way.
+	cfg.TrustProxy = getenvBool("SPANBARN_TRUST_PROXY", !cfg.IsDevEnvironment())
+
 	return cfg
 }
 
@@ -189,6 +196,18 @@ func getenvInt64(key string, fallback int64) int64 {
 	if raw := os.Getenv(key); raw != "" {
 		if parsed, err := strconv.ParseInt(raw, 10, 64); err == nil && parsed > 0 {
 			return parsed
+		}
+	}
+	return fallback
+}
+
+func getenvBool(key string, fallback bool) bool {
+	if raw := os.Getenv(key); raw != "" {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "1", "true", "yes", "on":
+			return true
+		case "0", "false", "no", "off":
+			return false
 		}
 	}
 	return fallback

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -142,6 +143,30 @@ func Load() Config {
 	}
 
 	return cfg
+}
+
+// IsDevEnvironment reports whether the configured environment is a local/dev
+// one where relaxed security defaults (e.g. an empty session secret) are
+// tolerated. Every named deployment environment (testing, staging, production)
+// is treated as non-dev.
+func (c Config) IsDevEnvironment() bool {
+	switch strings.ToLower(strings.TrimSpace(c.Environment)) {
+	case "", "development", "dev", "local":
+		return true
+	default:
+		return false
+	}
+}
+
+// Validate checks configuration invariants required to run an API server safely.
+// It is called for the long-running server modes, not the CLI subcommands.
+func (c Config) Validate() error {
+	if c.SessionSecret == "" && !c.IsDevEnvironment() {
+		return fmt.Errorf("SPANBARN_SESSION_SECRET must be set in the %q environment: "+
+			"it signs session tokens and derives per-project setup keys, so a missing "+
+			"secret makes both forgeable", c.Environment)
+	}
+	return nil
 }
 
 func getenv(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+func TestValidateSessionSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		secret  string
+		wantErr bool
+	}{
+		{"prod without secret", "production", "", true},
+		{"staging without secret", "staging", "", true},
+		{"testing without secret", "testing", "", true},
+		{"prod with secret", "production", "s3cret", false},
+		{"development without secret", "development", "", false},
+		{"empty env without secret", "", "", false},
+		{"local without secret", "local", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := Config{Environment: tc.env, SessionSecret: tc.secret}
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("Validate(env=%q, secret=%q): want error, got nil", tc.env, tc.secret)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("Validate(env=%q, secret=%q): want nil, got %v", tc.env, tc.secret, err)
+			}
+		})
+	}
+}
+
+func TestIsDevEnvironment(t *testing.T) {
+	dev := []string{"", "development", "DEV", "Local", "  dev  "}
+	for _, e := range dev {
+		if !(Config{Environment: e}).IsDevEnvironment() {
+			t.Errorf("IsDevEnvironment(%q) = false, want true", e)
+		}
+	}
+	nonDev := []string{"production", "staging", "testing"}
+	for _, e := range nonDev {
+		if (Config{Environment: e}).IsDevEnvironment() {
+			t.Errorf("IsDevEnvironment(%q) = true, want false", e)
+		}
+	}
+}

--- a/internal/repository/metric_filters.go
+++ b/internal/repository/metric_filters.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// ErrInvalidLabelKey is returned when a metric label (attribute) key contains
+// characters outside the safe allowlist. The key is interpolated into the SQL
+// JSON path (only the value is bound), so an unvalidated key — e.g. one
+// containing a single quote — is a SQL-injection vector. Callers must reject it.
+var ErrInvalidLabelKey = errors.New("invalid metric label key")
+
+// validLabelKey matches legitimate OTLP attribute keys: dotted identifiers such
+// as "service.name" or "http.status_code". Anything outside this set (notably
+// quotes, spaces, parentheses) is rejected so the JSON path stays safe to
+// interpolate.
+var validLabelKey = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// ValidLabelKey reports whether k is a safe metric label key. Exported so the
+// API layer can reject bad keys with a 400 before they reach the query.
+func ValidLabelKey(k string) bool {
+	return validLabelKey.MatchString(k)
+}
+
+// appendAttrFilters adds one `JSON_EXTRACT(attributes, '$."<key>"') = ?`
+// predicate per attribute to where/args, binding each value as a parameter. Each
+// key is validated with ValidLabelKey first; an invalid key returns
+// ErrInvalidLabelKey rather than being interpolated, closing the JSON-path
+// injection vector shared by the metric-series and rollup queries.
+func appendAttrFilters(where []string, args []any, attrs map[string]string) ([]string, []any, error) {
+	for k, v := range attrs {
+		if !validLabelKey.MatchString(k) {
+			return nil, nil, fmt.Errorf("%w: %q", ErrInvalidLabelKey, k)
+		}
+		where = append(where, fmt.Sprintf(`JSON_EXTRACT(attributes, '$."%s"') = ?`, k))
+		args = append(args, v)
+	}
+	return where, args, nil
+}

--- a/internal/repository/repo_metric_rollups.go
+++ b/internal/repository/repo_metric_rollups.go
@@ -99,9 +99,9 @@ func (r *Repository) QueryMetricRollups(ctx context.Context, f MetricRollupFilte
 
 	where := []string{"project_id = ?", "name = ?", "bucket >= ?", "bucket <= ?"}
 	args := []any{f.ProjectID, f.Name, f.From, f.To}
-	for k, v := range f.Attributes {
-		where = append(where, fmt.Sprintf(`JSON_EXTRACT(attributes, '$."%s"') = ?`, k))
-		args = append(args, v)
+	where, args, err := appendAttrFilters(where, args, f.Attributes)
+	if err != nil {
+		return nil, err
 	}
 
 	limit := f.Limit

--- a/internal/repository/repo_metrics.go
+++ b/internal/repository/repo_metrics.go
@@ -156,10 +156,9 @@ func (r *Repository) QueryMetricSeries(ctx context.Context, f MetricFilter) ([]M
 	where := []string{"project_id = ?", "name = ?", "ingested_at >= ?", "ingested_at <= ?"}
 	args := []any{f.ProjectID, f.Name, f.From, f.To}
 
-	for k, v := range f.Attributes {
-		// Double-quoting the key handles dots in names like "service.name".
-		where = append(where, fmt.Sprintf(`JSON_EXTRACT(attributes, '$."%s"') = ?`, k))
-		args = append(args, v)
+	where, args, err := appendAttrFilters(where, args, f.Attributes)
+	if err != nil {
+		return nil, err
 	}
 
 	limit := f.Limit

--- a/internal/repository/repo_metrics_test.go
+++ b/internal/repository/repo_metrics_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -180,6 +181,63 @@ func TestQueryMetricSeriesLabelFilter(t *testing.T) {
 	}
 	if rows[0].Value != 10 {
 		t.Errorf("want value 10, got %v", rows[0].Value)
+	}
+}
+
+// TestQueryMetricSeriesRejectsInjectionKey is a regression test for the metric
+// label-key SQL injection: a key that tries to break out of the JSON-path string
+// literal (e.g. `x') OR 1=1 --`) must be rejected with ErrInvalidLabelKey rather
+// than interpolated, so it can never widen the query past its project scope.
+func TestQueryMetricSeriesRejectsInjectionKey(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	svcA, _ := json.Marshal(map[string]string{"service.name": "svc-a"})
+	svcB, _ := json.Marshal(map[string]string{"service.name": "svc-b"})
+	recs := []model.MetricRecord{
+		{ProjectID: 1, Name: "req", Type: model.MetricTypeSum, TimeUnixNano: uint64(now.UnixNano()), Value: 10, Attributes: svcA},
+		{ProjectID: 2, Name: "req", Type: model.MetricTypeSum, TimeUnixNano: uint64(now.UnixNano()), Value: 20, Attributes: svcB},
+	}
+	if err := repo.InsertMetrics(context.Background(), recs); err != nil {
+		t.Fatalf("InsertMetrics: %v", err)
+	}
+
+	injections := []string{
+		`x') OR 1=1 --`,
+		`service.name"='svc-a`,
+		`a' UNION SELECT 1 --`,
+	}
+	for _, badKey := range injections {
+		_, err := repo.QueryMetricSeries(context.Background(), MetricFilter{
+			ProjectID:  1,
+			Name:       "req",
+			From:       now.Add(-time.Minute),
+			To:         now.Add(time.Minute),
+			Attributes: map[string]string{badKey: "1"},
+		})
+		if !errors.Is(err, ErrInvalidLabelKey) {
+			t.Errorf("QueryMetricSeries(%q): want ErrInvalidLabelKey, got %v", badKey, err)
+		}
+
+		_, err = repo.QueryMetricRollups(context.Background(), MetricRollupFilter{
+			ProjectID:  1,
+			Name:       "req",
+			From:       now.Add(-time.Minute),
+			To:         now.Add(time.Minute),
+			Attributes: map[string]string{badKey: "1"},
+		})
+		if !errors.Is(err, ErrInvalidLabelKey) {
+			t.Errorf("QueryMetricRollups(%q): want ErrInvalidLabelKey, got %v", badKey, err)
+		}
+	}
+
+	// A legitimate dotted key must still work.
+	if _, err := repo.QueryMetricSeries(context.Background(), MetricFilter{
+		ProjectID: 1, Name: "req",
+		From: now.Add(-time.Minute), To: now.Add(time.Minute),
+		Attributes: map[string]string{"service.name": "svc-a"},
+	}); err != nil {
+		t.Fatalf("QueryMetricSeries(valid key): %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Security audit remediation (13 findings, all verified at `file:line`). Cryptographic primitives and most of the SQL layer were already sound; this closes one exploitable SQL injection, a privilege-escalation gap, a cookie/TLS hardening gap, and hardens the rest.

### Critical / High
- **S1 — SQL injection via metric label key** (`repo_metrics.go`, `repo_metric_rollups.go`): the label *key* was `fmt.Sprintf`'d unescaped into a single-quoted JSON path (value was bound), letting a read-scoped key break out and read the whole DB. Now allowlist-validated (`ValidLabelKey`) at the repo layer + 400 at the API boundary. Regression test covers quote/UNION payloads.
- **S2 — Secure cookie + HSTS never applied** behind the TLS-terminating proxy (gated on `r.TLS`, always nil). New `isSecureRequest()` honours `X-Forwarded-Proto` for login/logout/OIDC/e2e cookies and HSTS.
- **S3 — empty `SPANBARN_SESSION_SECRET`** only warned and setup keys fell back to a hard-coded constant. `Config.Validate()` makes it fatal outside dev; the constant fallback is removed.

### Medium
- **S4 — OIDC read-auth privilege escalation**: the JWT branch skipped the GET/HEAD gate the API-key branch enforced, so read-only tokens could `DELETE`/approve projects. Same gate now applied.
- **S5 — public setup endpoint** now GET-only, read-idempotent (writes only on first visit), and rate-limited. Stays public by design.
- **S6/S8 — CORS**: prefix match leaked credentialed wildcard CORS to the `/spans/live` SSE stream and reflected arbitrary origins with credentials on session ingest. Split into three exact-match tiers (public API-key ingest → `*` no credentials; session ingest → credentials only for allow-listed origins; everything else → strict).
- **S7 — rate limiting** keyed on the proxy IP. Added proxy-aware `clientIP` (`SPANBARN_TRUST_PROXY`, default on outside dev) + per-account login throttle.

### Low
- **S9** IAM proxy: restrict to `/api/` widget paths + response-header allowlist (no `Set-Cookie` passthrough).
- **S10** constant-time compares for the static ingest key and `/metrics` token.
- **S11** `randomHex` fails closed (panic) instead of degrading to a timestamp.
- **S12** reject >72-byte passwords (no silent bcrypt truncation); bcrypt cost 10 → 12.
- **S13** OIDC `?next=` open-redirect: only root-relative local paths are followed.

## New / changed config
- `SPANBARN_SESSION_SECRET` is now **required** outside dev.
- `SPANBARN_TRUST_PROXY` (default on outside dev) enables `X-Forwarded-For`/`X-Real-IP` trust for rate-limit client IP.

## Testing
`go test -race ./...` green; `go vet` + `gofmt` clean. New regression tests: metric-label injection (series + rollups), forwarded-proto Secure/HSTS, config validation, OIDC read-only gate, setup method gate, CORS tiers (incl. `/spans/live` negative), proxy-aware client IP, per-account login throttle, password length cap, `safeNextPath`, constant-time compare.
