### PR TITLE
refactor(quality): NormalizeSQL scanners + span WHERE dedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,20 @@ jobs:
               (cd "$dir" && python -m build)
             fi
           done < <(find . "${prune[@]}" \( -name pyproject.toml -o -name requirements.txt \) -print)
+
+  quality:
+    runs-on: [self-hosted, build]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+          cache: false
+      - name: Quality gate
+        shell: bash
+        env:
+          # Job-scoped module cache — same cross-repo race avoidance as the
+          # `code` job (see its note). The gate fetches gocyclo/dupl via `go run`.
+          GOMODCACHE: ${{ runner.temp }}/gomodcache
+        run: bash scripts/quality-gate.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ make dev      # docker compose up --build
 baseline recorded in that script. Baselines only move in the improving direction
 — when you legitimately improve a metric, ratchet its baseline DOWN in the script.
 Enforced metrics:
-- **Coverage** — `internal/service` and `internal/repository` stay above their floors.
+- **Coverage** — `internal/service` and `internal/repository` stay above their package floors, AND every individual source file in them stays above a per-file floor (no fully-uncovered file hiding behind well-covered siblings; migration DDL and test files excluded).
 - **Cyclomatic complexity** — the count of functions over gocyclo 15 may not grow.
 - **File length** — the count of files over 500 lines may not grow, and no file may exceed a hard cap.
 - **Duplication** — the count of `dupl` clone groups may not grow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,21 @@ make dev      # docker compose up --build
 - Go: `go test ./...` (race detector in CI)
 - Frontend: Vitest
 - E2E: Playwright
-- Coverage gate: service + repository packages >= 60%
+
+## Quality gate (`make quality-gate`, CI job `quality`)
+
+`scripts/quality-gate.sh` is a ratchet: CI fails if any metric regresses past the
+baseline recorded in that script. Baselines only move in the improving direction
+— when you legitimately improve a metric, ratchet its baseline DOWN in the script.
+Enforced metrics:
+- **Coverage** — `internal/service` and `internal/repository` stay above their floors.
+- **Cyclomatic complexity** — the count of functions over gocyclo 15 may not grow.
+- **File length** — the count of files over 500 lines may not grow, and no file may exceed a hard cap.
+- **Duplication** — the count of `dupl` clone groups may not grow.
 
 ## CI/CD (GitHub Actions)
 
-- `ci.yml` — lint, test, build on every push/PR
+- `ci.yml` — spec, lint/test/build (`code`), and the `quality` gate on every push/PR
 - `build-and-test.yml` — Docker build + deploy to k3s testing
 - `deploy-production.yml` — manual production deploy with confirmation
 - `binary-release.yml` — semver tags, .deb packages, macOS tarballs, npm/PyPI SDK publish

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export XDG_CACHE_HOME := $(CURDIR)/.cache
 export GOCACHE := $(CURDIR)/.cache/go-build
 export GOMODCACHE := $(CURDIR)/.cache/go-mod
 
-.PHONY: help setup test lint build dev docker-build spec-check
+.PHONY: help setup test lint build dev docker-build spec-check quality-gate
 
 help:
 	@printf '%s\n' \
@@ -16,6 +16,7 @@ help:
 		'  setup        bootstrap local tooling when manifests exist' \
 		'  test         run spec checks plus available language tests' \
 		'  lint         run available linters and static checks' \
+		'  quality-gate enforce coverage/complexity/file-length/duplication baselines' \
 		'  build        run available build checks' \
 		'  dev          start the local compose stack if available' \
 		'  docker-build build placeholder images when Dockerfiles exist' \
@@ -130,6 +131,11 @@ lint:
 		fi; \
 	done; \
 	if [ "$$found" -eq 0 ]; then echo "[lint] no code manifests found yet"; fi
+
+quality-gate:
+	@set -eu; \
+	for dir in $(GOCACHE) $(GOMODCACHE); do mkdir -p "$$dir"; done; \
+	bash scripts/quality-gate.sh
 
 build:
 	@set -eu; \

--- a/cmd/sb/commands.go
+++ b/cmd/sb/commands.go
@@ -55,6 +55,36 @@ func scopedClient(projectFlag string) (*Client, error) {
 	return c, nil
 }
 
+// runQueryCmd handles the common CLI shape: the standard project + time-range
+// flags, an optional --service filter, then a GET to endpoint and emit.
+// Commands with additional flags keep their own implementation.
+func runQueryCmd(name, endpoint string, args []string, withService bool) error {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	project := commonFlags(fs)
+	from, to := addTimeFlags(fs)
+	var service *string
+	if withService {
+		service = fs.String("service", "", "filter by service")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	client, err := scopedClient(*project)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	applyTimeRange(params, *from, *to)
+	if service != nil && *service != "" {
+		params.Set("service", *service)
+	}
+	data, err := client.query(endpoint, params)
+	if err != nil {
+		return err
+	}
+	return emit(data)
+}
+
 // --- auth / setup ---
 
 func cmdLogin(args []string) error {
@@ -452,23 +482,7 @@ func cmdMetrics(args []string) error {
 }
 
 func cmdMetricNames(args []string) error {
-	fs := flag.NewFlagSet("metrics names", flag.ContinueOnError)
-	project := commonFlags(fs)
-	from, to := addTimeFlags(fs)
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	client, err := scopedClient(*project)
-	if err != nil {
-		return err
-	}
-	params := url.Values{}
-	applyTimeRange(params, *from, *to)
-	data, err := client.query("/api/v1/metrics/names", params)
-	if err != nil {
-		return err
-	}
-	return emit(data)
+	return runQueryCmd("metrics names", "/api/v1/metrics/names", args, false)
 }
 
 func cmdMetricSeries(args []string) error {
@@ -592,69 +606,13 @@ func cmdPromptDetail(args []string) error {
 }
 
 func cmdDeps(args []string) error {
-	fs := flag.NewFlagSet("deps", flag.ContinueOnError)
-	project := commonFlags(fs)
-	from, to := addTimeFlags(fs)
-	service := fs.String("service", "", "filter by source service")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	client, err := scopedClient(*project)
-	if err != nil {
-		return err
-	}
-	params := url.Values{}
-	applyTimeRange(params, *from, *to)
-	if *service != "" {
-		params.Set("service", *service)
-	}
-	data, err := client.query("/api/v1/dependencies", params)
-	if err != nil {
-		return err
-	}
-	return emit(data)
+	return runQueryCmd("deps", "/api/v1/dependencies", args, true)
 }
 
 func cmdDatabase(args []string) error {
-	fs := flag.NewFlagSet("database", flag.ContinueOnError)
-	project := commonFlags(fs)
-	from, to := addTimeFlags(fs)
-	service := fs.String("service", "", "filter by service")
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	client, err := scopedClient(*project)
-	if err != nil {
-		return err
-	}
-	params := url.Values{}
-	applyTimeRange(params, *from, *to)
-	if *service != "" {
-		params.Set("service", *service)
-	}
-	data, err := client.query("/api/v1/database", params)
-	if err != nil {
-		return err
-	}
-	return emit(data)
+	return runQueryCmd("database", "/api/v1/database", args, true)
 }
 
 func cmdServiceMap(args []string) error {
-	fs := flag.NewFlagSet("service-map", flag.ContinueOnError)
-	project := commonFlags(fs)
-	from, to := addTimeFlags(fs)
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	client, err := scopedClient(*project)
-	if err != nil {
-		return err
-	}
-	params := url.Values{}
-	applyTimeRange(params, *from, *to)
-	data, err := client.query("/api/v1/service-map", params)
-	if err != nil {
-		return err
-	}
-	return emit(data)
+	return runQueryCmd("service-map", "/api/v1/service-map", args, false)
 }

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -197,18 +197,8 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
 
-	retentionCfg := retention.Config{
-		FullRetentionHours:        cfg.RetentionFullHours,
-		InterestingRetentionHours: cfg.RetentionInterestingHours,
-		BoringRetentionMinutes:    cfg.BoringRetentionMinutes,
-		ErrorRetentionDays:        cfg.RetentionErrorDays,
-		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
-		MetricsRetentionDays:      cfg.MetricsRetentionDays,
-		LogRetentionHours:         cfg.LogRetentionHours,
-		ErrorLogRetentionDays:     cfg.ErrorLogRetentionDays,
-		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
-	}
-	repo.SetDeleteBatchYield(time.Duration(cfg.RetentionDeleteBatchYieldMS) * time.Millisecond)
+	retentionCfg := retentionConfigFrom(cfg)
+	repo.SetDeleteBatchYield(time.Duration(cfg.Retention.DeleteBatchYieldMS) * time.Millisecond)
 	retentionWorker := retention.NewRetentionWorker(repo, aggregator, retentionCfg, logger)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)
 	defer retentionCancel()
@@ -260,22 +250,8 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		defer queryCache.Close()
 	}
 
-	serverCfg := api.ServerConfig{
-		APIKey:             cfg.APIKey,
-		MaxBodyBytes:       cfg.MaxBodyBytes,
-		AllowedOrigins:     cfg.AllowedOrigins,
-		Version:            Version,
-		Environment:        cfg.Environment,
-		MetricsToken:       cfg.MetricsToken,
-		LoginRate:          cfg.LoginRatePerMinute,
-		IngestRate:         cfg.IngestRatePerMinute,
-		APIRate:            cfg.APIRatePerMinute,
-		SessionSecret:      cfg.SessionSecret,
-		PublicURL:          cfg.PublicURL,
-		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
-		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
-		FunnelBarnProject:  cfg.FunnelBarnProject,
-	}
+	serverCfg := serverConfigFrom(cfg)
+	serverCfg.MetricsToken = cfg.MetricsToken
 	// Mutations (trace exclusions, alerts CRUD) still use the write repo.
 	apiServer := api.NewServerWithQuery(serverCfg, ingestHandler, querySvc, sessionMgr, logger,
 		api.WithRepository(repo),
@@ -454,21 +430,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 	}
 	authorizer := auth.NewAuthorizer(staticKeyHash, keyLookup, logger)
 
-	serverCfg := api.ServerConfig{
-		APIKey:             cfg.APIKey,
-		MaxBodyBytes:       cfg.MaxBodyBytes,
-		AllowedOrigins:     cfg.AllowedOrigins,
-		Version:            Version,
-		Environment:        cfg.Environment,
-		LoginRate:          cfg.LoginRatePerMinute,
-		IngestRate:         cfg.IngestRatePerMinute,
-		APIRate:            cfg.APIRatePerMinute,
-		SessionSecret:      cfg.SessionSecret,
-		PublicURL:          cfg.PublicURL,
-		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
-		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
-		FunnelBarnProject:  cfg.FunnelBarnProject,
-	}
+	serverCfg := serverConfigFrom(cfg)
 	// Trace buffer: holds spans for up to 10 min then applies ratio-based
 	// sampling per (project, operation). Error traces always pass intact.
 	var ratioLookup ingest.SampleRatioLookup
@@ -684,22 +646,8 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 		defer queryCache.Close()
 	}
 
-	serverCfg := api.ServerConfig{
-		APIKey:             cfg.APIKey,
-		MaxBodyBytes:       cfg.MaxBodyBytes,
-		AllowedOrigins:     cfg.AllowedOrigins,
-		Version:            Version,
-		Environment:        cfg.Environment,
-		MetricsToken:       cfg.MetricsToken,
-		LoginRate:          cfg.LoginRatePerMinute,
-		IngestRate:         cfg.IngestRatePerMinute,
-		APIRate:            cfg.APIRatePerMinute,
-		SessionSecret:      cfg.SessionSecret,
-		PublicURL:          cfg.PublicURL,
-		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
-		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
-		FunnelBarnProject:  cfg.FunnelBarnProject,
-	}
+	serverCfg := serverConfigFrom(cfg)
+	serverCfg.MetricsToken = cfg.MetricsToken
 	// No ingest handler — OTLP goes to the reader pod per ingress rules.
 	apiServer := api.NewServerWithQuery(serverCfg, nil, querySvc, sessionMgr, logger,
 		api.WithRepository(repo),
@@ -861,19 +809,9 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionRepo := repository.NewRepository(db.DB)
 	retentionRepo.SetQueryTimeout(5 * time.Minute)
 	retentionRepo.SetWriteScheduler(scheduler)
-	retentionRepo.SetDeleteBatchYield(time.Duration(cfg.RetentionDeleteBatchYieldMS) * time.Millisecond)
+	retentionRepo.SetDeleteBatchYield(time.Duration(cfg.Retention.DeleteBatchYieldMS) * time.Millisecond)
 
-	retentionCfg := retention.Config{
-		FullRetentionHours:        cfg.RetentionFullHours,
-		InterestingRetentionHours: cfg.RetentionInterestingHours,
-		BoringRetentionMinutes:    cfg.BoringRetentionMinutes,
-		ErrorRetentionDays:        cfg.RetentionErrorDays,
-		AggregateRetentionDays:    cfg.RetentionAggregatedDays,
-		MetricsRetentionDays:      cfg.MetricsRetentionDays,
-		LogRetentionHours:         cfg.LogRetentionHours,
-		ErrorLogRetentionDays:     cfg.ErrorLogRetentionDays,
-		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
-	}
+	retentionCfg := retentionConfigFrom(cfg)
 	retentionWorker := retention.NewRetentionWorker(retentionRepo, accumulator, retentionCfg, logger)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)
 	defer retentionCancel()
@@ -925,18 +863,18 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 // not crash the process.
 func buildOIDCClient(cfg config.Config, logger *slog.Logger) *auth.OIDCClient {
 	oc := auth.OIDCConfig{
-		Issuer:            cfg.OIDCIssuer,
-		ClientID:          cfg.OIDCClientID,
-		ClientSecret:      cfg.OIDCClientSecret,
-		RedirectURL:       cfg.OIDCRedirectURL,
-		RequiredGroup:     cfg.OIDCRequiredGroup,
-		ResourceAudiences: cfg.OIDCResourceAudiences,
-		CLIClientID:       cfg.OIDCCLIClientID,
+		Issuer:            cfg.OIDC.Issuer,
+		ClientID:          cfg.OIDC.ClientID,
+		ClientSecret:      cfg.OIDC.ClientSecret,
+		RedirectURL:       cfg.OIDC.RedirectURL,
+		RequiredGroup:     cfg.OIDC.RequiredGroup,
+		ResourceAudiences: cfg.OIDC.ResourceAudiences,
+		CLIClientID:       cfg.OIDC.CLIClientID,
 	}
 	// The sb CLI's device-code tokens carry the CLI client id as their
 	// audience, so accept it as a resource audience automatically.
-	if cfg.OIDCCLIClientID != "" {
-		oc.ResourceAudiences = append(oc.ResourceAudiences, cfg.OIDCCLIClientID)
+	if cfg.OIDC.CLIClientID != "" {
+		oc.ResourceAudiences = append(oc.ResourceAudiences, cfg.OIDC.CLIClientID)
 	}
 	if !oc.Enabled() {
 		return nil
@@ -1005,11 +943,11 @@ func checkpointMode() repository.CheckpointMode {
 // POSTs SpanBarn's own OTLP metrics to its ingest endpoint so the Metrics page
 // always has live data (dogfooding). A nil rec or disabled config is a no-op.
 func startSelfMetrics(ctx context.Context, cfg config.Config, wg *sync.WaitGroup, rec *selfmetrics.Recorder, logger *slog.Logger) {
-	if rec == nil || cfg.SelfMetricsDisabled {
+	if rec == nil || cfg.Self.MetricsDisabled {
 		return
 	}
-	endpoint := cfg.SelfEndpoint
-	apiKey := cfg.SelfAPIKey
+	endpoint := cfg.Self.Endpoint
+	apiKey := cfg.Self.APIKey
 	if endpoint == "" {
 		// In standalone mode (no explicit endpoint) post to ourselves so the
 		// feature works out of the box without extra env vars.
@@ -1030,7 +968,7 @@ func startSelfMetrics(ctx context.Context, cfg config.Config, wg *sync.WaitGroup
 	reporter := selfmetrics.NewReporter(
 		rec,
 		endpoint, apiKey,
-		time.Duration(cfg.SelfMetricsIntervalSec)*time.Second,
+		time.Duration(cfg.Self.MetricsIntervalSec)*time.Second,
 		map[string]string{
 			"service.name":     "spanbarn",
 			"spanbarn.mode":    cfg.Mode,
@@ -1039,7 +977,7 @@ func startSelfMetrics(ctx context.Context, cfg config.Config, wg *sync.WaitGroup
 		startNano,
 		logger,
 	)
-	logger.Info("self-metrics enabled", "endpoint", endpoint, "interval_s", cfg.SelfMetricsIntervalSec)
+	logger.Info("self-metrics enabled", "endpoint", endpoint, "interval_s", cfg.Self.MetricsIntervalSec)
 	safeGo("self-metrics", wg, func() { reporter.Run(ctx) })
 }
 
@@ -1209,21 +1147,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 		defer queryCache.Close()
 	}
 
-	serverCfg := api.ServerConfig{
-		APIKey:             cfg.APIKey,
-		MaxBodyBytes:       cfg.MaxBodyBytes,
-		AllowedOrigins:     cfg.AllowedOrigins,
-		Version:            Version,
-		Environment:        cfg.Environment,
-		LoginRate:          cfg.LoginRatePerMinute,
-		IngestRate:         cfg.IngestRatePerMinute,
-		APIRate:            cfg.APIRatePerMinute,
-		SessionSecret:      cfg.SessionSecret,
-		PublicURL:          cfg.PublicURL,
-		FunnelBarnEndpoint: cfg.FunnelBarnEndpoint,
-		FunnelBarnAPIKey:   cfg.FunnelBarnAPIKey,
-		FunnelBarnProject:  cfg.FunnelBarnProject,
-	}
+	serverCfg := serverConfigFrom(cfg)
 	opts := []api.ServerOption{api.WithAuthorizer(authorizer)}
 	if roRepo != nil {
 		opts = append(opts, api.WithRepository(roRepo), api.WithPaths(cfg.DBPath, cfg.SpoolDir), api.WithCache(queryCache))

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -91,6 +91,18 @@ func run() error {
 	}
 }
 
+// registerAuthRoutes wires the login route (rate-limited with a per-account
+// throttle and a post-login cache warm) and the logout route onto mux. Shared
+// by every serving mode.
+func registerAuthRoutes(mux *http.ServeMux, cfg config.Config, userAuth *auth.UserAuthenticator, sessionMgr *auth.SessionManager, querySvc *service.QueryService, logger *slog.Logger) {
+	loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
+	loginRL := api.RateLimitMiddleware(loginLimiter, "login")
+	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
+		api.WarmLoginCaches(context.Background(), querySvc, logger)
+	})))
+	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
+}
+
 // runStandalone is the all-in-one single-node mode (docker-compose, small
 // self-hosted installs). No Redis queue required. Reads go to a dedicated
 // read-only DB connection so the writer goroutines are never starved by
@@ -277,12 +289,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	api.WarmCaches(ctx, queryRepo, querySvc.Cache(), logger)
 
 	mux := http.NewServeMux()
-	loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
-	loginRL := api.RateLimitMiddleware(loginLimiter, "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
-		api.WarmLoginCaches(context.Background(), querySvc, logger)
-	})))
-	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
+	registerAuthRoutes(mux, cfg, userAuth, sessionMgr, querySvc, logger)
 	mux.Handle("/", apiServer.Handler())
 
 	httpServer := &http.Server{
@@ -398,7 +405,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}
-			keyLookup = &readOnlyKeyLookupAdapter{repo: roRepo}
+			keyLookup = &readOnlyKeyLookupAdapter{keyLookupAdapter{repo: roRepo}}
 
 			sessionMgr = auth.NewSessionManager(cfg.SessionSecret, int64(cfg.SessionTTLSeconds))
 			userAuth = auth.NewUserAuthenticator(&userLookupAdapter{repo: roRepo}, logger)
@@ -490,12 +497,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 
 	mux := http.NewServeMux()
 	if sessionMgr != nil && userAuth != nil {
-		loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
-		loginRL := api.RateLimitMiddleware(loginLimiter, "login")
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
-			api.WarmLoginCaches(context.Background(), querySvc, logger)
-		})))
-		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
+		registerAuthRoutes(mux, cfg, userAuth, sessionMgr, querySvc, logger)
 	}
 	mux.Handle("/", apiServer.Handler())
 
@@ -658,12 +660,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	if oidcClient := buildOIDCClient(cfg, logger); oidcClient != nil {
 		apiServer.SetOIDCClient(oidcClient)
 	}
-	loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
-	loginRL := api.RateLimitMiddleware(loginLimiter, "login")
-	mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
-		api.WarmLoginCaches(context.Background(), querySvc, logger)
-	})))
-	mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
+	registerAuthRoutes(mux, cfg, userAuth, sessionMgr, querySvc, logger)
 	mux.Handle("/", apiServer.Handler())
 	logger.Info("writer API ready")
 
@@ -1028,22 +1025,11 @@ func (a *keyLookupAdapter) TouchAPIKey(id int64) error {
 }
 
 // readOnlyKeyLookupAdapter is used by the ingest pod which opens the database
-// in read-only mode. TouchAPIKey is a no-op because last_used_at can be
-// inferred from the presence of spans in the writer's database.
+// in read-only mode. It reuses keyLookupAdapter's GetAPIKeyByHash and overrides
+// TouchAPIKey to a no-op, because last_used_at can be inferred from the presence
+// of spans in the writer's database.
 type readOnlyKeyLookupAdapter struct {
-	repo *repository.Repository
-}
-
-func (a *readOnlyKeyLookupAdapter) GetAPIKeyByHash(keyHash string) (auth.APIKeyRecord, error) {
-	k, err := a.repo.GetAPIKeyByHash(keyHash)
-	if err != nil {
-		return auth.APIKeyRecord{}, err
-	}
-	return auth.APIKeyRecord{
-		ID:        k.ID,
-		ProjectID: k.ProjectID,
-		Scope:     k.Scope,
-	}, nil
+	keyLookupAdapter
 }
 
 func (a *readOnlyKeyLookupAdapter) TouchAPIKey(_ int64) error { return nil }
@@ -1110,7 +1096,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}
-			keyLookup = &readOnlyKeyLookupAdapter{repo: roRepo}
+			keyLookup = &readOnlyKeyLookupAdapter{keyLookupAdapter{repo: roRepo}}
 			logger.Info("read-only DB attached for failover reads", "path", cfg.DBPath)
 		}
 	}
@@ -1163,12 +1149,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 
 	mux := http.NewServeMux()
 	if sessionMgr != nil && userAuth != nil {
-		loginLimiter := api.NewRateLimiter(cfg.LoginRatePerMinute, cfg.IngestRatePerMinute, cfg.APIRatePerMinute)
-		loginRL := api.RateLimitMiddleware(loginLimiter, "login")
-		mux.Handle("/api/v1/login", loginRL(api.HandleLogin(userAuth, sessionMgr, loginLimiter, func() {
-			api.WarmLoginCaches(context.Background(), querySvc, logger)
-		})))
-		mux.Handle("/api/v1/logout", http.HandlerFunc(api.HandleLogout()))
+		registerAuthRoutes(mux, cfg, userAuth, sessionMgr, querySvc, logger)
 	}
 	mux.Handle("/", apiServer.Handler())
 

--- a/cmd/spanbarn/runtime.go
+++ b/cmd/spanbarn/runtime.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/wiebe-xyz/spanbarn/internal/api"
+	"github.com/wiebe-xyz/spanbarn/internal/config"
+	"github.com/wiebe-xyz/spanbarn/internal/retention"
+)
+
+// serverConfigFrom builds the api.ServerConfig fields shared by every mode.
+// MetricsToken is deliberately left unset: the standalone and writer modes opt
+// into token-gated /metrics by setting it on the returned value, while reader
+// and ingest historically leave it open — so callers set it explicitly rather
+// than have this helper change that behaviour.
+func serverConfigFrom(cfg config.Config) api.ServerConfig {
+	return api.ServerConfig{
+		APIKey:             cfg.APIKey,
+		MaxBodyBytes:       cfg.MaxBodyBytes,
+		AllowedOrigins:     cfg.AllowedOrigins,
+		Version:            Version,
+		Environment:        cfg.Environment,
+		LoginRate:          cfg.LoginRatePerMinute,
+		IngestRate:         cfg.IngestRatePerMinute,
+		APIRate:            cfg.APIRatePerMinute,
+		SessionSecret:      cfg.SessionSecret,
+		PublicURL:          cfg.PublicURL,
+		FunnelBarnEndpoint: cfg.FunnelBarn.Endpoint,
+		FunnelBarnAPIKey:   cfg.FunnelBarn.APIKey,
+		FunnelBarnProject:  cfg.FunnelBarn.Project,
+	}
+}
+
+// retentionConfigFrom maps the app config's retention windows onto the retention
+// worker's config. Shared by the standalone and writer bootstraps so the mapping
+// lives in one place.
+func retentionConfigFrom(cfg config.Config) retention.Config {
+	return retention.Config{
+		FullRetentionHours:        cfg.Retention.FullHours,
+		InterestingRetentionHours: cfg.Retention.InterestingHours,
+		BoringRetentionMinutes:    cfg.Retention.BoringMinutes,
+		ErrorRetentionDays:        cfg.Retention.ErrorDays,
+		AggregateRetentionDays:    cfg.Retention.AggregatedDays,
+		MetricsRetentionDays:      cfg.Retention.MetricsDays,
+		LogRetentionHours:         cfg.Retention.LogHours,
+		ErrorLogRetentionDays:     cfg.Retention.ErrorLogDays,
+		SlowThresholdUS:           int64(cfg.SlowThresholdMS) * 1000,
+	}
+}

--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -3,10 +3,8 @@ package api
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -20,8 +18,6 @@ import (
 	collectorpb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 var apiTracer = otel.Tracer("spanbarn/api")
@@ -41,29 +37,14 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		if strings.Contains(err.Error(), "http: request body too large") {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "failed to read body", err.Error())
+	body, ok := readOTLPBody(w, r)
+	if !ok {
 		return
 	}
 
 	var req collectorpb.ExportTraceServiceRequest
-	ct := r.Header.Get("Content-Type")
-	switch {
-	case strings.Contains(ct, "application/json"):
-		if err := protojson.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
-			return
-		}
-	default:
-		if err := proto.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid protobuf", err.Error())
-			return
-		}
+	if !decodeOTLP(w, r, body, &req) {
+		return
 	}
 
 	projectID := GetProjectID(r.Context())
@@ -105,20 +86,7 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 		enqueueSpan.End()
 	}
 
-	// Return ExportTraceServiceResponse.
-	resp := &collectorpb.ExportTraceServiceResponse{}
-	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "application/json") {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		data, _ := protojson.Marshal(resp)
-		_, _ = w.Write(data)
-	} else {
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
-		data, _ := proto.Marshal(resp)
-		_, _ = w.Write(data)
-	}
+	writeOTLPResponse(w, r, &collectorpb.ExportTraceServiceResponse{})
 }
 
 // otlpToSpanRecords converts an OTLP ExportTraceServiceRequest into SpanRecords

--- a/internal/api/otlp_common.go
+++ b/internal/api/otlp_common.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// readOTLPBody reads the full request body, mapping a MaxBytesReader overflow to
+// 413 and any other read error to 400. Returns ok=false after writing the error
+// response, so callers just `if !ok { return }`.
+func readOTLPBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		if strings.Contains(err.Error(), "http: request body too large") {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "")
+			return nil, false
+		}
+		writeError(w, http.StatusBadRequest, "failed to read body", err.Error())
+		return nil, false
+	}
+	return body, true
+}
+
+// decodeOTLP unmarshals an OTLP export request from body into msg, choosing
+// protojson vs binary protobuf by the Content-Type header. Returns ok=false
+// after writing the error response.
+func decodeOTLP(w http.ResponseWriter, r *http.Request, body []byte, msg proto.Message) bool {
+	if strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		if err := protojson.Unmarshal(body, msg); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
+			return false
+		}
+		return true
+	}
+	if err := proto.Unmarshal(body, msg); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid protobuf", err.Error())
+		return false
+	}
+	return true
+}
+
+// writeOTLPResponse marshals an OTLP export response with 200, choosing
+// protojson vs binary protobuf by the Accept header (defaulting to protobuf).
+func writeOTLPResponse(w http.ResponseWriter, r *http.Request, resp proto.Message) {
+	if strings.Contains(r.Header.Get("Accept"), "application/json") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		data, _ := protojson.Marshal(resp)
+		_, _ = w.Write(data)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-protobuf")
+	w.WriteHeader(http.StatusOK)
+	data, _ := proto.Marshal(resp)
+	_, _ = w.Write(data)
+}

--- a/internal/api/otlp_logs.go
+++ b/internal/api/otlp_logs.go
@@ -2,16 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
-	"strings"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 
 	collectorlogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 func (s *Server) handleOTLPLogs(w http.ResponseWriter, r *http.Request) {
@@ -20,48 +16,20 @@ func (s *Server) handleOTLPLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		if strings.Contains(err.Error(), "http: request body too large") {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "failed to read body", err.Error())
+	body, ok := readOTLPBody(w, r)
+	if !ok {
 		return
 	}
 
 	var req collectorlogspb.ExportLogsServiceRequest
-	ct := r.Header.Get("Content-Type")
-	switch {
-	case strings.Contains(ct, "application/json"):
-		if err := protojson.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
-			return
-		}
-	default:
-		if err := proto.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid protobuf", err.Error())
-			return
-		}
+	if !decodeOTLP(w, r, body, &req) {
+		return
 	}
 
 	projectID := GetProjectID(r.Context())
-	recs := otlpToLogRecords(&req, projectID)
-	s.logsIngest.Enqueue(recs)
+	s.logsIngest.Enqueue(otlpToLogRecords(&req, projectID))
 
-	resp := &collectorlogspb.ExportLogsServiceResponse{}
-	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "application/json") {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		data, _ := protojson.Marshal(resp)
-		_, _ = w.Write(data)
-	} else {
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
-		data, _ := proto.Marshal(resp)
-		_, _ = w.Write(data)
-	}
+	writeOTLPResponse(w, r, &collectorlogspb.ExportLogsServiceResponse{})
 }
 
 // otlpToLogRecords converts an ExportLogsServiceRequest into LogRecords.

--- a/internal/api/otlp_metrics.go
+++ b/internal/api/otlp_metrics.go
@@ -2,16 +2,12 @@ package api
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
-	"strings"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 
 	collectormetricspb "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	metricspb "go.opentelemetry.io/proto/otlp/metrics/v1"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 )
 
 func (s *Server) handleOTLPMetrics(w http.ResponseWriter, r *http.Request) {
@@ -20,48 +16,20 @@ func (s *Server) handleOTLPMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		if strings.Contains(err.Error(), "http: request body too large") {
-			writeError(w, http.StatusRequestEntityTooLarge, "request body too large", "")
-			return
-		}
-		writeError(w, http.StatusBadRequest, "failed to read body", err.Error())
+	body, ok := readOTLPBody(w, r)
+	if !ok {
 		return
 	}
 
 	var req collectormetricspb.ExportMetricsServiceRequest
-	ct := r.Header.Get("Content-Type")
-	switch {
-	case strings.Contains(ct, "application/json"):
-		if err := protojson.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON", err.Error())
-			return
-		}
-	default:
-		if err := proto.Unmarshal(body, &req); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid protobuf", err.Error())
-			return
-		}
+	if !decodeOTLP(w, r, body, &req) {
+		return
 	}
 
 	projectID := GetProjectID(r.Context())
-	recs := otlpToMetricRecords(&req, projectID)
-	s.metricsIngest.Enqueue(recs)
+	s.metricsIngest.Enqueue(otlpToMetricRecords(&req, projectID))
 
-	resp := &collectormetricspb.ExportMetricsServiceResponse{}
-	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "application/json") {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		data, _ := protojson.Marshal(resp)
-		_, _ = w.Write(data)
-	} else {
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		w.WriteHeader(http.StatusOK)
-		data, _ := proto.Marshal(resp)
-		_, _ = w.Write(data)
-	}
+	writeOTLPResponse(w, r, &collectormetricspb.ExportMetricsServiceResponse{})
 }
 
 // otlpToMetricRecords converts an ExportMetricsServiceRequest into MetricRecords.

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -104,15 +104,7 @@ func (h *projectHandlers) handleList(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	projects, err := h.repo.ListProjects()
-	if err != nil {
-		writeServerError(w, r, "failed to list projects", err)
-		return
-	}
-	if projects == nil {
-		projects = []repository.Project{}
-	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(projects)
+	writeListJSON(w, r, "projects", projects, err)
 }
 
 func (h *projectHandlers) handleDelete(w http.ResponseWriter, r *http.Request, id int64) {

--- a/internal/api/query.go
+++ b/internal/api/query.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -19,14 +20,8 @@ func (h *queryHandlers) handleServices(w http.ResponseWriter, r *http.Request) {
 	ctx, span := apiTracer.Start(r.Context(), "api.query.services")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -116,14 +111,8 @@ func (h *queryHandlers) handleTraces(w http.ResponseWriter, r *http.Request) {
 	ctx, span := apiTracer.Start(r.Context(), "api.query.traces")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -160,14 +149,8 @@ func (h *queryHandlers) handleTraceGroups(w http.ResponseWriter, r *http.Request
 	ctx, span := apiTracer.Start(r.Context(), "api.query.trace_groups")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -223,14 +206,8 @@ func (h *queryHandlers) handleDependencies(w http.ResponseWriter, r *http.Reques
 	ctx, span := apiTracer.Start(r.Context(), "api.query.dependencies")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -249,14 +226,8 @@ func (h *queryHandlers) handleDependencyTraces(w http.ResponseWriter, r *http.Re
 	ctx, span := apiTracer.Start(r.Context(), "api.query.dependency_traces")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -285,14 +256,8 @@ func (h *queryHandlers) handleDatabaseQueries(w http.ResponseWriter, r *http.Req
 	ctx, span := apiTracer.Start(r.Context(), "api.query.database")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -311,14 +276,8 @@ func (h *queryHandlers) handleDatabaseQueryDetail(w http.ResponseWriter, r *http
 	ctx, span := apiTracer.Start(r.Context(), "api.query.database_detail")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -342,14 +301,8 @@ func (h *queryHandlers) handleServiceMap(w http.ResponseWriter, r *http.Request)
 	ctx, span := apiTracer.Start(r.Context(), "api.query.service_map")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -368,14 +321,8 @@ func (h *queryHandlers) handleWebVitals(w http.ResponseWriter, r *http.Request) 
 	ctx, span := apiTracer.Start(r.Context(), "api.query.web_vitals")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -394,14 +341,8 @@ func (h *queryHandlers) handleWebVitalsTimeseries(w http.ResponseWriter, r *http
 	ctx, span := apiTracer.Start(r.Context(), "api.query.web_vitals_timeseries")
 	defer span.End()
 
-	if r.Method != http.MethodGet {
-		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
-		return
-	}
-
-	from, to, err := parseTimeRange(r)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+	from, to, ok := parseGetTimeRange(w, r)
+	if !ok {
 		return
 	}
 
@@ -512,4 +453,35 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeListJSON writes a JSON list response for a list endpoint: a query error
+// becomes a 500, a nil slice is normalised to [] (so the client always sees an
+// array), and the list is written with 200. what names the resource in the
+// error message.
+func writeListJSON[T any](w http.ResponseWriter, r *http.Request, what string, list []T, err error) {
+	if err != nil {
+		writeServerError(w, r, "failed to list "+what, err)
+		return
+	}
+	if list == nil {
+		list = []T{}
+	}
+	writeJSON(w, http.StatusOK, list)
+}
+
+// parseGetTimeRange runs the preamble shared by the GET query handlers: it
+// enforces the GET method and parses the ?from/?to range, writing the
+// appropriate error response and returning ok=false on failure.
+func parseGetTimeRange(w http.ResponseWriter, r *http.Request) (from, to time.Time, ok bool) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed", "")
+		return
+	}
+	f, t, err := parseTimeRange(r)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid time range", err.Error())
+		return
+	}
+	return f, t, true
 }

--- a/internal/api/saved_queries.go
+++ b/internal/api/saved_queries.go
@@ -31,14 +31,7 @@ func (h *savedQueryHandlers) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *savedQueryHandlers) handleList(w http.ResponseWriter, r *http.Request) {
 	projectID := parseInt64Param(r, "project_id", 1)
 	queries, err := h.repo.ListSavedQueries(projectID)
-	if err != nil {
-		writeServerError(w, r, "failed to list saved queries", err)
-		return
-	}
-	if queries == nil {
-		queries = []repository.SavedQuery{}
-	}
-	writeJSON(w, http.StatusOK, queries)
+	writeListJSON(w, r, "saved queries", queries, err)
 }
 
 func (h *savedQueryHandlers) handleCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/trace_exclusions.go
+++ b/internal/api/trace_exclusions.go
@@ -48,14 +48,7 @@ func (h *traceExclusionHandlers) ServeHTTP(w http.ResponseWriter, r *http.Reques
 func (h *traceExclusionHandlers) handleList(w http.ResponseWriter, r *http.Request) {
 	projectID := parseInt64Param(r, "project_id", 1)
 	exclusions, err := h.repo.ListTraceExclusions(projectID)
-	if err != nil {
-		writeServerError(w, r, "failed to list trace exclusions", err)
-		return
-	}
-	if exclusions == nil {
-		exclusions = []repository.TraceExclusion{}
-	}
-	writeJSON(w, http.StatusOK, exclusions)
+	writeListJSON(w, r, "trace exclusions", exclusions, err)
 }
 
 func (h *traceExclusionHandlers) handleCreate(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,130 +7,167 @@ import (
 	"strings"
 )
 
+// RetentionConfig groups the data-retention windows.
+type RetentionConfig struct {
+	FullHours          int // SPANBARN_RETENTION_FULL_HOURS
+	AggregatedDays     int // SPANBARN_RETENTION_AGGREGATED_DAYS
+	ErrorDays          int // SPANBARN_RETENTION_ERROR_DAYS
+	InterestingHours   int // SPANBARN_RETENTION_INTERESTING_HOURS
+	BoringMinutes      int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
+	MetricsDays        int // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
+	LogHours           int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
+	ErrorLogDays       int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
+	DeleteBatchYieldMS int // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
+}
+
+// OIDCConfig groups the IamBarn OIDC integration settings. When Issuer,
+// ClientID, ClientSecret and RedirectURL are all set, OIDC login is offered
+// alongside local auth.
+type OIDCConfig struct {
+	Issuer            string   // SPANBARN_OIDC_ISSUER
+	ClientID          string   // SPANBARN_OIDC_CLIENT_ID
+	ClientSecret      string   // SPANBARN_OIDC_CLIENT_SECRET
+	RedirectURL       string   // SPANBARN_OIDC_REDIRECT_URL
+	RequiredGroup     string   // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
+	ResourceAudiences []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
+	CLIClientID       string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
+}
+
+// SelfConfig groups self-instrumentation (SpanBarn reporting to itself/BugBarn).
+type SelfConfig struct {
+	Endpoint           string // SPANBARN_SELF_ENDPOINT
+	APIKey             string // SPANBARN_SELF_API_KEY
+	MetricsIntervalSec int    // SPANBARN_SELF_METRICS_INTERVAL_SECONDS — self-metrics export cadence (default 30)
+	MetricsDisabled    bool   // SPANBARN_SELF_METRICS_DISABLED — disable self-metrics export
+}
+
+// BugBarnConfig groups error self-reporting to BugBarn.
+type BugBarnConfig struct {
+	Endpoint string // SPANBARN_BUGBARN_ENDPOINT
+	APIKey   string // SPANBARN_BUGBARN_API_KEY
+}
+
+// FunnelBarnConfig groups analytics self-reporting to FunnelBarn.
+type FunnelBarnConfig struct {
+	Endpoint string // SPANBARN_FUNNELBARN_ENDPOINT
+	APIKey   string // SPANBARN_FUNNELBARN_API_KEY
+	Project  string // SPANBARN_FUNNELBARN_PROJECT
+}
+
 // Config holds all SPANBARN_* environment variables with sensible defaults.
 type Config struct {
-	Addr                        string
-	PublicURL                   string
-	DBPath                      string
-	SpoolDir                    string
-	APIKey                      string
-	APIKeySHA256                string
-	AdminUsername               string
-	AdminPassword               string
-	AdminPasswordBcrypt         string
-	SessionSecret               string
-	SessionTTLSeconds           int
-	MaxBodyBytes                int64
-	MaxSpoolBytes               int64
-	RetentionFullHours          int
-	RetentionAggregatedDays     int
-	RetentionErrorDays          int
-	RetentionInterestingHours   int
-	BoringRetentionMinutes      int  // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
-	MetricsRetentionDays        int  // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
-	LogRetentionHours           int  // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
-	ErrorLogRetentionDays       int  // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
-	RetentionDeleteBatchYieldMS int  // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
-	WALTruncateThresholdMB      int  // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
-	CheckpointSkipQueueDepth    int  // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints (which can block the single connection up to busy_timeout) so it can pour throughput into draining the backlog; it still forces an occasional checkpoint to bound the WAL (default 100; 0 disables gating)
-	SpanStagingEnabled          bool // SPANBARN_SPAN_STAGING_ENABLED — when true, the redis worker appends consumed spans to spans_staging (cheap) and a background flusher does accumulation+classification+indexed storage per complete trace off the hot path (default false)
-	TraceBufferWindowSeconds    int  // SPANBARN_TRACE_BUFFER_WINDOW_SECONDS — how long a trace's spans buffer in spans_staging before the flusher treats the trace as complete (default 90)
-	StagingMaxAgeSeconds        int  // SPANBARN_STAGING_MAX_AGE_SECONDS — hard backstop: spans_staging rows older than this are dropped unconditionally so the table can never grow without bound (default 900)
-	IngestSampleRate            float64
-	SlowThresholdMS             int
-	AggregationInterval         string
-	AllowedOrigins              []string
-	SelfEndpoint                string
-	SelfAPIKey                  string
-	SelfMetricsIntervalSec      int  // SPANBARN_SELF_METRICS_INTERVAL_SECONDS — self-metrics export cadence (default 30)
-	SelfMetricsDisabled         bool // SPANBARN_SELF_METRICS_DISABLED — disable self-metrics export
-	BugBarnEndpoint             string
-	BugBarnAPIKey               string
-	FunnelBarnEndpoint          string
-	FunnelBarnAPIKey            string
-	FunnelBarnProject           string
-	Environment                 string
-	LoginRatePerMinute          int
-	IngestRatePerMinute         int
-	APIRatePerMinute            int
-	MetricsToken                string
-	QueryTimeoutSeconds         int
-	RedisURL                    string
-	RedisQueueURL               string // SPANBARN_REDIS_QUEUE_URL — write queue Redis (separate from cache)
-	CacheTTLSeconds             int
-	Mode                        string   // "standalone" (default), "reader", "writer", or "ingest" (legacy)
-	WriterURL                   string   // URL of writer pod, used when Mode=ingest (legacy)
-	OIDCIssuer                  string   // SPANBARN_OIDC_ISSUER — when all four OIDC vars are set, OIDC login is offered alongside local auth
-	OIDCClientID                string   // SPANBARN_OIDC_CLIENT_ID
-	OIDCClientSecret            string   // SPANBARN_OIDC_CLIENT_SECRET
-	OIDCRedirectURL             string   // SPANBARN_OIDC_REDIRECT_URL
-	OIDCRequiredGroup           string   // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
-	OIDCResourceAudiences       []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
-	OIDCCLIClientID             string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
-	GRPCAddr                    string   // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
-	TrustProxy                  bool     // SPANBARN_TRUST_PROXY — trust X-Forwarded-For/X-Real-IP for client IP (rate limiting); defaults to true outside dev
+	Addr                     string
+	PublicURL                string
+	DBPath                   string
+	SpoolDir                 string
+	APIKey                   string
+	APIKeySHA256             string
+	AdminUsername            string
+	AdminPassword            string
+	AdminPasswordBcrypt      string
+	SessionSecret            string
+	SessionTTLSeconds        int
+	MaxBodyBytes             int64
+	MaxSpoolBytes            int64
+	Retention                RetentionConfig
+	WALTruncateThresholdMB   int  // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
+	CheckpointSkipQueueDepth int  // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints so it can drain the backlog (default 100; 0 disables gating)
+	SpanStagingEnabled       bool // SPANBARN_SPAN_STAGING_ENABLED — when true, the redis worker appends consumed spans to spans_staging (cheap) and a background flusher does accumulation+classification+indexed storage per complete trace off the hot path (default false)
+	TraceBufferWindowSeconds int  // SPANBARN_TRACE_BUFFER_WINDOW_SECONDS — how long a trace's spans buffer in spans_staging before the flusher treats the trace as complete (default 90)
+	StagingMaxAgeSeconds     int  // SPANBARN_STAGING_MAX_AGE_SECONDS — hard backstop: spans_staging rows older than this are dropped unconditionally so the table can never grow without bound (default 900)
+	IngestSampleRate         float64
+	SlowThresholdMS          int
+	AggregationInterval      string
+	AllowedOrigins           []string
+	Self                     SelfConfig
+	BugBarn                  BugBarnConfig
+	FunnelBarn               FunnelBarnConfig
+	Environment              string
+	LoginRatePerMinute       int
+	IngestRatePerMinute      int
+	APIRatePerMinute         int
+	MetricsToken             string
+	QueryTimeoutSeconds      int
+	RedisURL                 string
+	RedisQueueURL            string // SPANBARN_REDIS_QUEUE_URL — write queue Redis (separate from cache)
+	CacheTTLSeconds          int
+	Mode                     string // "standalone" (default), "reader", "writer", or "ingest" (legacy)
+	WriterURL                string // URL of writer pod, used when Mode=ingest (legacy)
+	OIDC                     OIDCConfig
+	GRPCAddr                 string // SPANBARN_GRPC_ADDR — gRPC listener for OTLP; empty = disabled
+	TrustProxy               bool   // SPANBARN_TRUST_PROXY — trust X-Forwarded-For/X-Real-IP for client IP (rate limiting); defaults to true outside dev
 }
 
 // Load reads configuration from SPANBARN_* environment variables with defaults.
 func Load() Config {
 	cfg := Config{
-		Addr:                        getenv("SPANBARN_ADDR", ":8080"),
-		PublicURL:                   os.Getenv("SPANBARN_PUBLIC_URL"),
-		DBPath:                      getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
-		SpoolDir:                    getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
-		APIKey:                      os.Getenv("SPANBARN_API_KEY"),
-		APIKeySHA256:                os.Getenv("SPANBARN_API_KEY_SHA256"),
-		AdminUsername:               os.Getenv("SPANBARN_ADMIN_USERNAME"),
-		AdminPassword:               os.Getenv("SPANBARN_ADMIN_PASSWORD"),
-		AdminPasswordBcrypt:         os.Getenv("SPANBARN_ADMIN_PASSWORD_BCRYPT"),
-		SessionSecret:               os.Getenv("SPANBARN_SESSION_SECRET"),
-		SessionTTLSeconds:           getenvInt("SPANBARN_SESSION_TTL_SECONDS", 43200),
-		MaxBodyBytes:                getenvInt64("SPANBARN_MAX_BODY_BYTES", 1<<20),
-		MaxSpoolBytes:               getenvInt64("SPANBARN_MAX_SPOOL_BYTES", 0),
-		RetentionFullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
-		RetentionAggregatedDays:     getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
-		RetentionErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
-		RetentionInterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
-		BoringRetentionMinutes:      getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
-		MetricsRetentionDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
-		LogRetentionHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
-		ErrorLogRetentionDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
-		RetentionDeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
-		WALTruncateThresholdMB:      getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
-		CheckpointSkipQueueDepth:    getenvInt("SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH", 100),
-		SpanStagingEnabled:          getenvInt("SPANBARN_SPAN_STAGING_ENABLED", 0) != 0,
-		TraceBufferWindowSeconds:    getenvInt("SPANBARN_TRACE_BUFFER_WINDOW_SECONDS", 90),
-		StagingMaxAgeSeconds:        getenvInt("SPANBARN_STAGING_MAX_AGE_SECONDS", 900),
-		IngestSampleRate:            getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
-		SlowThresholdMS:             getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
-		AggregationInterval:         getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),
-		SelfEndpoint:                os.Getenv("SPANBARN_SELF_ENDPOINT"),
-		SelfAPIKey:                  os.Getenv("SPANBARN_SELF_API_KEY"),
-		SelfMetricsIntervalSec:      getenvInt("SPANBARN_SELF_METRICS_INTERVAL_SECONDS", 30),
-		SelfMetricsDisabled:         getenvInt("SPANBARN_SELF_METRICS_DISABLED", 0) != 0,
-		BugBarnEndpoint:             os.Getenv("SPANBARN_BUGBARN_ENDPOINT"),
-		BugBarnAPIKey:               os.Getenv("SPANBARN_BUGBARN_API_KEY"),
-		FunnelBarnEndpoint:          os.Getenv("SPANBARN_FUNNELBARN_ENDPOINT"),
-		FunnelBarnAPIKey:            os.Getenv("SPANBARN_FUNNELBARN_API_KEY"),
-		FunnelBarnProject:           getenv("SPANBARN_FUNNELBARN_PROJECT", "spanbarn"),
-		Environment:                 getenv("SPANBARN_ENVIRONMENT", "development"),
-		LoginRatePerMinute:          getenvInt("SPANBARN_LOGIN_RATE_PER_MINUTE", 10),
-		IngestRatePerMinute:         getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),
-		APIRatePerMinute:            getenvInt("SPANBARN_API_RATE_PER_MINUTE", 300),
-		MetricsToken:                os.Getenv("SPANBARN_METRICS_TOKEN"),
-		QueryTimeoutSeconds:         getenvInt("SPANBARN_QUERY_TIMEOUT_SECONDS", 30),
-		RedisURL:                    os.Getenv("SPANBARN_REDIS_URL"),
-		RedisQueueURL:               os.Getenv("SPANBARN_REDIS_QUEUE_URL"),
-		CacheTTLSeconds:             getenvInt("SPANBARN_CACHE_TTL_SECONDS", 30),
-		Mode:                        getenv("SPANBARN_MODE", "standalone"),
-		WriterURL:                   os.Getenv("SPANBARN_WRITER_URL"),
-		OIDCIssuer:                  os.Getenv("SPANBARN_OIDC_ISSUER"),
-		OIDCClientID:                os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
-		OIDCClientSecret:            os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
-		OIDCRedirectURL:             os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
-		OIDCRequiredGroup:           getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
-		OIDCCLIClientID:             os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
-		GRPCAddr:                    getenv("SPANBARN_GRPC_ADDR", ":4317"),
+		Addr:                getenv("SPANBARN_ADDR", ":8080"),
+		PublicURL:           os.Getenv("SPANBARN_PUBLIC_URL"),
+		DBPath:              getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
+		SpoolDir:            getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
+		APIKey:              os.Getenv("SPANBARN_API_KEY"),
+		APIKeySHA256:        os.Getenv("SPANBARN_API_KEY_SHA256"),
+		AdminUsername:       os.Getenv("SPANBARN_ADMIN_USERNAME"),
+		AdminPassword:       os.Getenv("SPANBARN_ADMIN_PASSWORD"),
+		AdminPasswordBcrypt: os.Getenv("SPANBARN_ADMIN_PASSWORD_BCRYPT"),
+		SessionSecret:       os.Getenv("SPANBARN_SESSION_SECRET"),
+		SessionTTLSeconds:   getenvInt("SPANBARN_SESSION_TTL_SECONDS", 43200),
+		MaxBodyBytes:        getenvInt64("SPANBARN_MAX_BODY_BYTES", 1<<20),
+		MaxSpoolBytes:       getenvInt64("SPANBARN_MAX_SPOOL_BYTES", 0),
+		Retention: RetentionConfig{
+			FullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
+			AggregatedDays:     getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
+			ErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
+			InterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
+			BoringMinutes:      getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
+			MetricsDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
+			LogHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
+			ErrorLogDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
+			DeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
+		},
+		WALTruncateThresholdMB:   getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
+		CheckpointSkipQueueDepth: getenvInt("SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH", 100),
+		SpanStagingEnabled:       getenvInt("SPANBARN_SPAN_STAGING_ENABLED", 0) != 0,
+		TraceBufferWindowSeconds: getenvInt("SPANBARN_TRACE_BUFFER_WINDOW_SECONDS", 90),
+		StagingMaxAgeSeconds:     getenvInt("SPANBARN_STAGING_MAX_AGE_SECONDS", 900),
+		IngestSampleRate:         getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
+		SlowThresholdMS:          getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
+		AggregationInterval:      getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),
+		Self: SelfConfig{
+			Endpoint:           os.Getenv("SPANBARN_SELF_ENDPOINT"),
+			APIKey:             os.Getenv("SPANBARN_SELF_API_KEY"),
+			MetricsIntervalSec: getenvInt("SPANBARN_SELF_METRICS_INTERVAL_SECONDS", 30),
+			MetricsDisabled:    getenvInt("SPANBARN_SELF_METRICS_DISABLED", 0) != 0,
+		},
+		BugBarn: BugBarnConfig{
+			Endpoint: os.Getenv("SPANBARN_BUGBARN_ENDPOINT"),
+			APIKey:   os.Getenv("SPANBARN_BUGBARN_API_KEY"),
+		},
+		FunnelBarn: FunnelBarnConfig{
+			Endpoint: os.Getenv("SPANBARN_FUNNELBARN_ENDPOINT"),
+			APIKey:   os.Getenv("SPANBARN_FUNNELBARN_API_KEY"),
+			Project:  getenv("SPANBARN_FUNNELBARN_PROJECT", "spanbarn"),
+		},
+		Environment:         getenv("SPANBARN_ENVIRONMENT", "development"),
+		LoginRatePerMinute:  getenvInt("SPANBARN_LOGIN_RATE_PER_MINUTE", 10),
+		IngestRatePerMinute: getenvInt("SPANBARN_INGEST_RATE_PER_MINUTE", 1000),
+		APIRatePerMinute:    getenvInt("SPANBARN_API_RATE_PER_MINUTE", 300),
+		MetricsToken:        os.Getenv("SPANBARN_METRICS_TOKEN"),
+		QueryTimeoutSeconds: getenvInt("SPANBARN_QUERY_TIMEOUT_SECONDS", 30),
+		RedisURL:            os.Getenv("SPANBARN_REDIS_URL"),
+		RedisQueueURL:       os.Getenv("SPANBARN_REDIS_QUEUE_URL"),
+		CacheTTLSeconds:     getenvInt("SPANBARN_CACHE_TTL_SECONDS", 30),
+		Mode:                getenv("SPANBARN_MODE", "standalone"),
+		WriterURL:           os.Getenv("SPANBARN_WRITER_URL"),
+		OIDC: OIDCConfig{
+			Issuer:        os.Getenv("SPANBARN_OIDC_ISSUER"),
+			ClientID:      os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
+			ClientSecret:  os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
+			RedirectURL:   os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
+			RequiredGroup: getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
+			CLIClientID:   os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
+		},
+		GRPCAddr: getenv("SPANBARN_GRPC_ADDR", ":4317"),
 	}
 
 	if raw := os.Getenv("SPANBARN_ALLOWED_ORIGINS"); raw != "" {
@@ -144,7 +181,7 @@ func Load() Config {
 	if raw := os.Getenv("SPANBARN_OIDC_RESOURCE_AUDIENCES"); raw != "" {
 		for _, a := range strings.Split(raw, ",") {
 			if trimmed := strings.TrimSpace(a); trimmed != "" {
-				cfg.OIDCResourceAudiences = append(cfg.OIDCResourceAudiences, trimmed)
+				cfg.OIDC.ResourceAudiences = append(cfg.OIDC.ResourceAudiences, trimmed)
 			}
 		}
 	}

--- a/internal/queue/batch.go
+++ b/internal/queue/batch.go
@@ -1,0 +1,47 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// publishBatch marshals records to JSON and LPUSHes them to key in batches of
+// batchSize. label names the record kind in error messages. Shared by the
+// per-type Publish* methods, which otherwise differ only in record type, queue
+// key, batch size and label.
+func publishBatch[T any](ctx context.Context, q *RedisQueue, key, label string, batchSize int, records []T) error {
+	for i := 0; i < len(records); i += batchSize {
+		end := i + batchSize
+		if end > len(records) {
+			end = len(records)
+		}
+		data, err := json.Marshal(records[i:end])
+		if err != nil {
+			return fmt.Errorf("queue: marshal %s: %w", label, err)
+		}
+		if err := q.client.LPush(ctx, key, data).Err(); err != nil {
+			return fmt.Errorf("queue: lpush %s: %w", label, err)
+		}
+	}
+	return nil
+}
+
+// consumeBatch blocks up to brpopTimeout for one batch from key, returning
+// nil, nil when the queue is empty.
+func consumeBatch[T any](ctx context.Context, q *RedisQueue, key, label string) ([]T, error) {
+	result, err := q.client.BRPop(ctx, brpopTimeout, key).Result()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("queue: brpop %s: %w", label, err)
+	}
+	var records []T
+	if err := json.Unmarshal([]byte(result[1]), &records); err != nil {
+		return nil, fmt.Errorf("queue: unmarshal %s: %w", label, err)
+	}
+	return records, nil
+}

--- a/internal/queue/redis_logs_queue.go
+++ b/internal/queue/redis_logs_queue.go
@@ -2,10 +2,6 @@ package queue
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-
-	"github.com/redis/go-redis/v9"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 )
@@ -18,38 +14,14 @@ const (
 // PublishLogs serialises log records as JSON and LPUSHes them to the logs queue
 // in batches. Called by the reader pod's LogsHandler.
 func (q *RedisQueue) PublishLogs(ctx context.Context, records []model.LogRecord) error {
-	for i := 0; i < len(records); i += logsQueueBatchSize {
-		end := i + logsQueueBatchSize
-		if end > len(records) {
-			end = len(records)
-		}
-		data, err := json.Marshal(records[i:end])
-		if err != nil {
-			return fmt.Errorf("queue: marshal logs: %w", err)
-		}
-		if err := q.client.LPush(ctx, LogsQueueKey, data).Err(); err != nil {
-			return fmt.Errorf("queue: lpush logs: %w", err)
-		}
-	}
-	return nil
+	return publishBatch(ctx, q, LogsQueueKey, "logs", logsQueueBatchSize, records)
 }
 
 // ConsumeLogs blocks for up to brpopTimeout waiting for a batch from the logs
 // queue. Returns nil, nil when the queue is empty.
 // Called by the writer pod's logs consumer goroutine.
 func (q *RedisQueue) ConsumeLogs(ctx context.Context) ([]model.LogRecord, error) {
-	result, err := q.client.BRPop(ctx, brpopTimeout, LogsQueueKey).Result()
-	if err == redis.Nil {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("queue: brpop logs: %w", err)
-	}
-	var records []model.LogRecord
-	if err := json.Unmarshal([]byte(result[1]), &records); err != nil {
-		return nil, fmt.Errorf("queue: unmarshal logs: %w", err)
-	}
-	return records, nil
+	return consumeBatch[model.LogRecord](ctx, q, LogsQueueKey, "logs")
 }
 
 // LogsPublisher implements ingest.LogsRepository by publishing records to the

--- a/internal/queue/redis_metrics_queue.go
+++ b/internal/queue/redis_metrics_queue.go
@@ -2,10 +2,6 @@ package queue
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-
-	"github.com/redis/go-redis/v9"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 )
@@ -18,38 +14,14 @@ const (
 // PublishMetrics serialises metric records as JSON and LPUSHes them to the
 // metrics queue in batches. Called by the reader pod's MetricsHandler.
 func (q *RedisQueue) PublishMetrics(ctx context.Context, records []model.MetricRecord) error {
-	for i := 0; i < len(records); i += metricsQueueBatchSize {
-		end := i + metricsQueueBatchSize
-		if end > len(records) {
-			end = len(records)
-		}
-		data, err := json.Marshal(records[i:end])
-		if err != nil {
-			return fmt.Errorf("queue: marshal metrics: %w", err)
-		}
-		if err := q.client.LPush(ctx, MetricsQueueKey, data).Err(); err != nil {
-			return fmt.Errorf("queue: lpush metrics: %w", err)
-		}
-	}
-	return nil
+	return publishBatch(ctx, q, MetricsQueueKey, "metrics", metricsQueueBatchSize, records)
 }
 
 // ConsumeMetrics blocks for up to brpopTimeout waiting for a batch from the
 // metrics queue. Returns nil, nil when the queue is empty.
 // Called by the writer pod's metrics consumer goroutine.
 func (q *RedisQueue) ConsumeMetrics(ctx context.Context) ([]model.MetricRecord, error) {
-	result, err := q.client.BRPop(ctx, brpopTimeout, MetricsQueueKey).Result()
-	if err == redis.Nil {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("queue: brpop metrics: %w", err)
-	}
-	var records []model.MetricRecord
-	if err := json.Unmarshal([]byte(result[1]), &records); err != nil {
-		return nil, fmt.Errorf("queue: unmarshal metrics: %w", err)
-	}
-	return records, nil
+	return consumeBatch[model.MetricRecord](ctx, q, MetricsQueueKey, "metrics")
 }
 
 // MetricsPublisher implements ingest.MetricsRepository by publishing records to

--- a/internal/repository/repo_apikeys.go
+++ b/internal/repository/repo_apikeys.go
@@ -1,7 +1,5 @@
 package repository
 
-import "database/sql"
-
 func (r *Repository) CreateAPIKey(projectID int64, name, keyHash, scope string) (int64, error) {
 	var id int64
 	err := r.execHigh(func() error {
@@ -74,15 +72,5 @@ func (r *Repository) ListAllAPIKeys() ([]APIKey, error) {
 }
 
 func (r *Repository) RevokeAPIKey(id int64) error {
-	return r.execHigh(func() error {
-		res, err := r.db.Exec("DELETE FROM api_keys WHERE id = ?", id)
-		if err != nil {
-			return err
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return sql.ErrNoRows
-		}
-		return nil
-	})
+	return r.execHighExpectingRows("DELETE FROM api_keys WHERE id = ?", id)
 }

--- a/internal/repository/repo_e2e.go
+++ b/internal/repository/repo_e2e.go
@@ -38,17 +38,6 @@ func (r *Repository) UpsertE2EUser(username string, expiresAt time.Time) (User, 
 // DeleteExpiredE2EUsers removes all users whose e2e_expires_at is in the past.
 // Returns the number of rows deleted.
 func (r *Repository) DeleteExpiredE2EUsers(now time.Time) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec(
-			"DELETE FROM users WHERE e2e_expires_at IS NOT NULL AND e2e_expires_at < ?",
-			now,
-		)
-		if e != nil {
-			return e
-		}
-		n, _ = res.RowsAffected()
-		return nil
-	})
-	return n, err
+	return r.execLowAffecting(
+		"DELETE FROM users WHERE e2e_expires_at IS NOT NULL AND e2e_expires_at < ?", now)
 }

--- a/internal/repository/repo_e2e_test.go
+++ b/internal/repository/repo_e2e_test.go
@@ -1,0 +1,48 @@
+package repository
+
+import (
+	"testing"
+	"time"
+)
+
+func TestUpsertE2EUserAndExpiry(t *testing.T) {
+	repo := setupTestDB(t)
+	now := time.Now().UTC()
+
+	// Create an E2E user; it should be retrievable and carry no usable password.
+	u, err := repo.UpsertE2EUser("e2e-alice", now.Add(E2EAccountTTL))
+	if err != nil {
+		t.Fatalf("UpsertE2EUser: %v", err)
+	}
+	if u.Username != "e2e-alice" {
+		t.Errorf("username = %q, want e2e-alice", u.Username)
+	}
+	if u.PasswordHash != "" {
+		t.Errorf("E2E user password hash should be empty, got %q", u.PasswordHash)
+	}
+
+	// Upsert again with a new expiry — must not create a duplicate.
+	if _, err := repo.UpsertE2EUser("e2e-alice", now.Add(2*E2EAccountTTL)); err != nil {
+		t.Fatalf("UpsertE2EUser (refresh): %v", err)
+	}
+
+	// A second, already-expired E2E user.
+	if _, err := repo.UpsertE2EUser("e2e-bob", now.Add(-time.Hour)); err != nil {
+		t.Fatalf("UpsertE2EUser (expired): %v", err)
+	}
+
+	// Only the expired one is swept.
+	n, err := repo.DeleteExpiredE2EUsers(now)
+	if err != nil {
+		t.Fatalf("DeleteExpiredE2EUsers: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted %d expired E2E users, want 1", n)
+	}
+	if _, err := repo.GetUserByUsername("e2e-alice"); err != nil {
+		t.Errorf("non-expired e2e-alice should remain: %v", err)
+	}
+	if _, err := repo.GetUserByUsername("e2e-bob"); err == nil {
+		t.Error("expired e2e-bob should have been deleted")
+	}
+}

--- a/internal/repository/repo_projects.go
+++ b/internal/repository/repo_projects.go
@@ -21,11 +21,21 @@ func (r *Repository) CreateProject(slug, name string) (Project, error) {
 	return r.getProjectByID(id)
 }
 
-func (r *Repository) getProjectByID(id int64) (Project, error) {
+// projectColumns is the SELECT list every project read shares; scanProject
+// consumes it in the same field order, so the column list and scan targets stay
+// defined in exactly one place.
+const projectColumns = "id, slug, name, status, e2e_enabled, created_at"
+
+type rowScanner interface{ Scan(dest ...any) error }
+
+func scanProject(row rowScanner) (Project, error) {
 	var p Project
-	err := r.db.QueryRow("SELECT id, slug, name, status, e2e_enabled, created_at FROM projects WHERE id = ?", id).
-		Scan(&p.ID, &p.Slug, &p.Name, &p.Status, &p.E2EEnabled, &p.CreatedAt)
+	err := row.Scan(&p.ID, &p.Slug, &p.Name, &p.Status, &p.E2EEnabled, &p.CreatedAt)
 	return p, err
+}
+
+func (r *Repository) getProjectByID(id int64) (Project, error) {
+	return scanProject(r.db.QueryRow("SELECT "+projectColumns+" FROM projects WHERE id = ?", id))
 }
 
 func (r *Repository) GetProjectByID(id int64) (Project, error) {
@@ -33,22 +43,19 @@ func (r *Repository) GetProjectByID(id int64) (Project, error) {
 }
 
 func (r *Repository) GetProjectBySlug(slug string) (Project, error) {
-	var p Project
-	err := r.db.QueryRow("SELECT id, slug, name, status, e2e_enabled, created_at FROM projects WHERE slug = ?", slug).
-		Scan(&p.ID, &p.Slug, &p.Name, &p.Status, &p.E2EEnabled, &p.CreatedAt)
-	return p, err
+	return scanProject(r.db.QueryRow("SELECT "+projectColumns+" FROM projects WHERE slug = ?", slug))
 }
 
 func (r *Repository) ListProjects() ([]Project, error) {
-	rows, err := r.db.Query("SELECT id, slug, name, status, e2e_enabled, created_at FROM projects ORDER BY id")
+	rows, err := r.db.Query("SELECT " + projectColumns + " FROM projects ORDER BY id")
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	var out []Project
 	for rows.Next() {
-		var p Project
-		if err := rows.Scan(&p.ID, &p.Slug, &p.Name, &p.Status, &p.E2EEnabled, &p.CreatedAt); err != nil {
+		p, err := scanProject(rows)
+		if err != nil {
 			return nil, err
 		}
 		out = append(out, p)
@@ -57,21 +64,11 @@ func (r *Repository) ListProjects() ([]Project, error) {
 }
 
 func (r *Repository) SetProjectE2E(id int64, enabled bool) error {
-	return r.execHigh(func() error {
-		v := 0
-		if enabled {
-			v = 1
-		}
-		res, err := r.db.Exec("UPDATE projects SET e2e_enabled = ? WHERE id = ?", v, id)
-		if err != nil {
-			return err
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return sql.ErrNoRows
-		}
-		return nil
-	})
+	v := 0
+	if enabled {
+		v = 1
+	}
+	return r.execHighExpectingRows("UPDATE projects SET e2e_enabled = ? WHERE id = ?", v, id)
 }
 
 func (r *Repository) ListProjectIDs() ([]int64, error) {
@@ -108,18 +105,7 @@ func (r *Repository) EnsureProjectPending(slug, name string) (Project, error) {
 }
 
 func (r *Repository) ApproveProject(id int64) (Project, error) {
-	err := r.execHigh(func() error {
-		res, e := r.db.Exec("UPDATE projects SET status = 'active' WHERE id = ?", id)
-		if e != nil {
-			return e
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return sql.ErrNoRows
-		}
-		return nil
-	})
-	if err != nil {
+	if err := r.execHighExpectingRows("UPDATE projects SET status = 'active' WHERE id = ?", id); err != nil {
 		return Project{}, err
 	}
 	return r.getProjectByID(id)

--- a/internal/repository/repo_prompts.go
+++ b/internal/repository/repo_prompts.go
@@ -153,16 +153,7 @@ func (r *Repository) GetPromptRecordsByTraceID(traceID string) ([]PromptRecord, 
 }
 
 func (r *Repository) DeletePromptRecordsOlderThan(cutoff time.Time) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec("DELETE FROM prompt_records WHERE ingested_at < ?", cutoff)
-		if e != nil {
-			return e
-		}
-		n, _ = res.RowsAffected()
-		return nil
-	})
-	return n, err
+	return r.execLowAffecting("DELETE FROM prompt_records WHERE ingested_at < ?", cutoff)
 }
 
 func (r *Repository) scanPromptRecords(query string, args ...any) ([]PromptRecord, error) {

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -160,16 +160,7 @@ func (r *Repository) DeleteSpansByIDs(ids []int64) (int64, error) {
 }
 
 func (r *Repository) DeleteSpansByMaxID(maxID int64) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec("DELETE FROM spans WHERE id <= ?", maxID)
-		if e != nil {
-			return e
-		}
-		n, _ = res.RowsAffected()
-		return nil
-	})
-	return n, err
+	return r.execLowAffecting("DELETE FROM spans WHERE id <= ?", maxID)
 }
 
 func (r *Repository) DeleteBoringTraces(olderThan, newerThan time.Time, slowThresholdUS int64) (int64, error) {
@@ -203,16 +194,7 @@ func (r *Repository) DeleteBoringTraces(olderThan, newerThan time.Time, slowThre
 }
 
 func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
-	var n int64
-	err := r.execLow(func() error {
-		res, e := r.db.Exec("DELETE FROM spans WHERE ingested_at < ?", cutoff)
-		if e != nil {
-			return e
-		}
-		n, _ = res.RowsAffected()
-		return nil
-	})
-	return n, err
+	return r.execLowAffecting("DELETE FROM spans WHERE ingested_at < ?", cutoff)
 }
 
 // DeleteBoringSpansOlderThan removes non-error, fast spans ingested before cutoff.

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -48,17 +48,15 @@ func (r *Repository) InsertSpansContext(ctx context.Context, spans []Span) error
 	})
 }
 
-func (r *Repository) QuerySpans(f SpanFilter) ([]Span, error) {
-	var where []string
-	var args []any
-
+// appendCommonWhere appends the optional span filters shared by the span/trace
+// query methods — project, service, operation, status, minimum duration and the
+// ingested_at time range — as parameterised predicates. Method-specific filters
+// (trace ID, operation exclusions) are added separately by the caller. All
+// predicates are ANDed, so the append order does not affect results.
+func (f SpanFilter) appendCommonWhere(where []string, args []any) ([]string, []any) {
 	if f.ProjectID != 0 {
 		where = append(where, "project_id = ?")
 		args = append(args, f.ProjectID)
-	}
-	if f.TraceID != "" {
-		where = append(where, "trace_id = ?")
-		args = append(args, f.TraceID)
 	}
 	if f.Service != "" {
 		where = append(where, "service = ?")
@@ -83,6 +81,18 @@ func (r *Repository) QuerySpans(f SpanFilter) ([]Span, error) {
 	if !f.To.IsZero() {
 		where = append(where, "ingested_at <= ?")
 		args = append(args, f.To)
+	}
+	return where, args
+}
+
+func (r *Repository) QuerySpans(f SpanFilter) ([]Span, error) {
+	var where []string
+	var args []any
+
+	where, args = f.appendCommonWhere(where, args)
+	if f.TraceID != "" {
+		where = append(where, "trace_id = ?")
+		args = append(args, f.TraceID)
 	}
 
 	q := "SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at FROM spans"
@@ -273,26 +283,7 @@ type TraceSummaryRow struct {
 func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSummaryRow, error) {
 	var where []string
 	var args []any
-	if f.ProjectID != 0 {
-		where = append(where, "project_id = ?")
-		args = append(args, f.ProjectID)
-	}
-	if f.Service != "" {
-		where = append(where, "service = ?")
-		args = append(args, f.Service)
-	}
-	if f.Operation != "" {
-		where = append(where, "name = ?")
-		args = append(args, f.Operation)
-	}
-	if f.Status != "" {
-		where = append(where, "status = ?")
-		args = append(args, f.Status)
-	}
-	if f.MinDuration > 0 {
-		where = append(where, "duration_us >= ?")
-		args = append(args, f.MinDuration)
-	}
+	where, args = f.appendCommonWhere(where, args)
 	if len(f.ExcludeOperations) > 0 {
 		placeholders := strings.Repeat("?,", len(f.ExcludeOperations))
 		placeholders = placeholders[:len(placeholders)-1]
@@ -300,14 +291,6 @@ func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSu
 		for _, op := range f.ExcludeOperations {
 			args = append(args, op)
 		}
-	}
-	if !f.From.IsZero() {
-		where = append(where, "ingested_at >= ?")
-		args = append(args, f.From)
-	}
-	if !f.To.IsZero() {
-		where = append(where, "ingested_at <= ?")
-		args = append(args, f.To)
 	}
 	whereSQL := ""
 	if len(where) > 0 {
@@ -497,34 +480,7 @@ func (r *Repository) StreamSpans(f SpanFilter, fn func(Span) error) error {
 	var where []string
 	var args []any
 
-	if f.ProjectID != 0 {
-		where = append(where, "project_id = ?")
-		args = append(args, f.ProjectID)
-	}
-	if f.Service != "" {
-		where = append(where, "service = ?")
-		args = append(args, f.Service)
-	}
-	if f.Operation != "" {
-		where = append(where, "name = ?")
-		args = append(args, f.Operation)
-	}
-	if f.Status != "" {
-		where = append(where, "status = ?")
-		args = append(args, f.Status)
-	}
-	if f.MinDuration > 0 {
-		where = append(where, "duration_us >= ?")
-		args = append(args, f.MinDuration)
-	}
-	if !f.From.IsZero() {
-		where = append(where, "ingested_at >= ?")
-		args = append(args, f.From)
-	}
-	if !f.To.IsZero() {
-		where = append(where, "ingested_at <= ?")
-		args = append(args, f.To)
-	}
+	where, args = f.appendCommonWhere(where, args)
 
 	q := "SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at FROM spans"
 	if len(where) > 0 {

--- a/internal/repository/repo_users.go
+++ b/internal/repository/repo_users.go
@@ -1,7 +1,5 @@
 package repository
 
-import "database/sql"
-
 func (r *Repository) CreateUser(username, passwordHash string) error {
 	return r.execHigh(func() error {
 		_, err := r.db.Exec("INSERT INTO users (username, password_hash) VALUES (?, ?)", username, passwordHash)
@@ -17,31 +15,11 @@ func (r *Repository) GetUserByUsername(username string) (User, error) {
 }
 
 func (r *Repository) UpdateUserPassword(username, passwordHash string) error {
-	return r.execHigh(func() error {
-		res, err := r.db.Exec("UPDATE users SET password_hash = ? WHERE username = ?", passwordHash, username)
-		if err != nil {
-			return err
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return sql.ErrNoRows
-		}
-		return nil
-	})
+	return r.execHighExpectingRows("UPDATE users SET password_hash = ? WHERE username = ?", passwordHash, username)
 }
 
 func (r *Repository) DeleteUser(username string) error {
-	return r.execHigh(func() error {
-		res, err := r.db.Exec("DELETE FROM users WHERE username = ?", username)
-		if err != nil {
-			return err
-		}
-		n, _ := res.RowsAffected()
-		if n == 0 {
-			return sql.ErrNoRows
-		}
-		return nil
-	})
+	return r.execHighExpectingRows("DELETE FROM users WHERE username = ?", username)
 }
 
 func (r *Repository) ListUsers() ([]User, error) {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -88,6 +88,22 @@ func (r *Repository) execLow(fn func() error) error {
 	return r.scheduler.Submit(context.Background(), writescheduler.Low, fn)
 }
 
+// execLowAffecting runs a single low-priority write statement and returns the
+// number of rows it affected. It captures the execLow+Exec+RowsAffected boiler-
+// plate shared by the retention DeleteXOlderThan / DeleteXByY methods.
+func (r *Repository) execLowAffecting(query string, args ...any) (int64, error) {
+	var n int64
+	err := r.execLow(func() error {
+		res, e := r.db.Exec(query, args...)
+		if e != nil {
+			return e
+		}
+		n, _ = res.RowsAffected()
+		return nil
+	})
+	return n, err
+}
+
 // SetDeleteBatchYield sets how long batchedDelete pauses between batches. The
 // pause releases the write lock so the periodic WAL checkpoint and read-only
 // queries get a turn during a large retention purge. 0 (the default) disables

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -104,6 +104,22 @@ func (r *Repository) execLowAffecting(query string, args ...any) (int64, error) 
 	return n, err
 }
 
+// execHighExpectingRows runs a single high-priority write (admin update/delete
+// by key) and returns sql.ErrNoRows when it affected no rows, i.e. the target
+// row did not exist. Shared by the admin CRUD methods.
+func (r *Repository) execHighExpectingRows(query string, args ...any) error {
+	return r.execHigh(func() error {
+		res, err := r.db.Exec(query, args...)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n == 0 {
+			return sql.ErrNoRows
+		}
+		return nil
+	})
+}
+
 // SetDeleteBatchYield sets how long batchedDelete pauses between batches. The
 // pause releases the write lock so the periodic WAL checkpoint and read-only
 // queries get a turn during a large retention purge. 0 (the default) disables

--- a/internal/service/normalize.go
+++ b/internal/service/normalize.go
@@ -18,87 +18,106 @@ func NormalizeSQL(sql string) string {
 
 	var b strings.Builder
 	b.Grow(len(sql))
-	i := 0
-	n := len(sql)
+	i, n := 0, len(sql)
 
 	for i < n {
-		ch := sql[i]
-
-		// Single-quoted string literal → ?
-		if ch == '\'' {
+		switch ch := sql[i]; {
+		case ch == '\'':
+			i = scanStringLiteral(sql, i, &b)
+		case ch == '$' && i+1 < n && sql[i+1] >= '1' && sql[i+1] <= '9':
+			i = scanPgParam(sql, i, &b)
+		case ch >= '0' && ch <= '9' && (i == 0 || !isIdentChar(sql[i-1])):
+			i = scanNumber(sql, i, &b)
+		case isSpace(ch):
+			i = scanWhitespace(sql, i, &b)
+		case ch == '"':
+			i = scanQuotedIdent(sql, i, &b)
+		default:
+			b.WriteRune(unicode.ToLower(rune(ch)))
 			i++
-			for i < n {
-				if sql[i] == '\'' {
-					i++
-					if i < n && sql[i] == '\'' {
-						i++ // escaped quote ''
-						continue
-					}
-					break
-				}
-				i++
-			}
-			b.WriteByte('?')
-			continue
 		}
-
-		// Postgres $N parameter → ?
-		if ch == '$' && i+1 < n && sql[i+1] >= '1' && sql[i+1] <= '9' {
-			i++
-			for i < n && sql[i] >= '0' && sql[i] <= '9' {
-				i++
-			}
-			// Handle ::TYPE cast after parameter
-			if i+1 < n && sql[i] == ':' && sql[i+1] == ':' {
-				i += 2
-				for i < n && (isIdentChar(sql[i])) {
-					i++
-				}
-			}
-			b.WriteByte('?')
-			continue
-		}
-
-		// Numeric literal (not part of identifier) → ?
-		if (ch >= '0' && ch <= '9') && (i == 0 || !isIdentChar(sql[i-1])) {
-			for i < n && ((sql[i] >= '0' && sql[i] <= '9') || sql[i] == '.') {
-				i++
-			}
-			b.WriteByte('?')
-			continue
-		}
-
-		// Whitespace → single space
-		if ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' {
-			i++
-			for i < n && (sql[i] == ' ' || sql[i] == '\t' || sql[i] == '\n' || sql[i] == '\r') {
-				i++
-			}
-			b.WriteByte(' ')
-			continue
-		}
-
-		// Double-quoted identifier — preserve as-is
-		if ch == '"' {
-			b.WriteByte(ch)
-			i++
-			for i < n && sql[i] != '"' {
-				b.WriteByte(sql[i])
-				i++
-			}
-			if i < n {
-				b.WriteByte(sql[i])
-				i++
-			}
-			continue
-		}
-
-		// Regular character — lowercase
-		b.WriteRune(unicode.ToLower(rune(ch)))
-		i++
 	}
 
 	return strings.TrimSpace(b.String())
+}
+
+// Each scanXxx consumes one token starting at i, writes its canonical form to b,
+// and returns the index just past the token.
+
+// scanStringLiteral collapses a single-quoted string literal (with ” escapes) to ?.
+func scanStringLiteral(sql string, i int, b *strings.Builder) int {
+	n := len(sql)
+	i++ // opening quote
+	for i < n {
+		if sql[i] == '\'' {
+			i++
+			if i < n && sql[i] == '\'' {
+				i++ // escaped quote ''
+				continue
+			}
+			break
+		}
+		i++
+	}
+	b.WriteByte('?')
+	return i
+}
+
+// scanPgParam collapses a Postgres $N parameter (with optional ::TYPE cast) to ?.
+func scanPgParam(sql string, i int, b *strings.Builder) int {
+	n := len(sql)
+	i++ // '$'
+	for i < n && sql[i] >= '0' && sql[i] <= '9' {
+		i++
+	}
+	if i+1 < n && sql[i] == ':' && sql[i+1] == ':' {
+		i += 2
+		for i < n && isIdentChar(sql[i]) {
+			i++
+		}
+	}
+	b.WriteByte('?')
+	return i
+}
+
+// scanNumber collapses a numeric literal in value position to ?.
+func scanNumber(sql string, i int, b *strings.Builder) int {
+	n := len(sql)
+	for i < n && ((sql[i] >= '0' && sql[i] <= '9') || sql[i] == '.') {
+		i++
+	}
+	b.WriteByte('?')
+	return i
+}
+
+// scanWhitespace collapses a whitespace run to a single space.
+func scanWhitespace(sql string, i int, b *strings.Builder) int {
+	n := len(sql)
+	for i < n && isSpace(sql[i]) {
+		i++
+	}
+	b.WriteByte(' ')
+	return i
+}
+
+// scanQuotedIdent preserves a double-quoted identifier verbatim.
+func scanQuotedIdent(sql string, i int, b *strings.Builder) int {
+	n := len(sql)
+	b.WriteByte(sql[i]) // opening quote
+	i++
+	for i < n && sql[i] != '"' {
+		b.WriteByte(sql[i])
+		i++
+	}
+	if i < n {
+		b.WriteByte(sql[i]) // closing quote
+		i++
+	}
+	return i
+}
+
+func isSpace(ch byte) bool {
+	return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r'
 }
 
 func isIdentChar(ch byte) bool {

--- a/internal/service/query_database_test.go
+++ b/internal/service/query_database_test.go
@@ -1,11 +1,126 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/wiebe-xyz/spanbarn/internal/cache"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
+
+func dbTestSpans(now time.Time) []repository.Span {
+	// Parent server span (caller context) + client DB spans. Two SELECTs share a
+	// normalized pattern (different literals); one INSERT is a separate pattern.
+	return []repository.Span{
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "p1", Name: "GET /orders", Service: "web",
+			Kind: "server", Status: "ok", StartTimeUs: now.UnixMicro(), DurationUs: 900,
+			Attributes: "{}", Events: "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "s1", ParentSpanID: "p1", Name: "db.query", Service: "web",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro() + 10, DurationUs: 500,
+			Attributes: `{"db.system":"postgresql","db.statement":"SELECT * FROM orders WHERE id = 1","db.name":"shop"}`,
+			Events:     "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t2", SpanID: "s2", ParentSpanID: "p1", Name: "db.query", Service: "web",
+			Kind: "client", Status: "error", StartTimeUs: now.UnixMicro() + 20, DurationUs: 800,
+			Attributes: `{"db.system":"postgresql","db.statement":"SELECT * FROM orders WHERE id = 2","exception.message":"boom"}`,
+			Events:     "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t3", SpanID: "s3", Name: "db.query", Service: "web",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro() + 30, DurationUs: 100,
+			Attributes: `{"db.system":"postgresql","db.statement":"INSERT INTO logs (msg) VALUES ('x')"}`,
+			Events:     "[]", IngestedAt: now,
+		},
+		{
+			// Non-DB client span — must be ignored (no db.system).
+			ProjectID: 1, TraceID: "t4", SpanID: "s4", Name: "http.get", Service: "web",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro() + 40, DurationUs: 50,
+			Attributes: `{"http.method":"GET"}`, Events: "[]", IngestedAt: now,
+		},
+	}
+}
+
+func TestListDatabaseQueries(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := NewQueryService(repo, nil, nil)
+	now := time.Now()
+	if err := repo.InsertSpans(dbTestSpans(now)); err != nil {
+		t.Fatalf("InsertSpans: %v", err)
+	}
+
+	// Zero from/to skips the ingested_at filter (see GetServiceMap test).
+	out, err := svc.ListDatabaseQueries(context.Background(), 1, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListDatabaseQueries: %v", err)
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 query patterns (SELECT + INSERT), got %d: %+v", len(out), out)
+	}
+
+	byOp := map[string]DatabaseQuerySummary{}
+	for _, q := range out {
+		byOp[q.Operation] = q
+	}
+	sel, ok := byOp["SELECT"]
+	if !ok {
+		t.Fatalf("expected a SELECT summary, got %+v", out)
+	}
+	if sel.CallCount != 2 {
+		t.Errorf("SELECT CallCount = %d, want 2", sel.CallCount)
+	}
+	if sel.ErrorCount != 1 {
+		t.Errorf("SELECT ErrorCount = %d, want 1", sel.ErrorCount)
+	}
+	if sel.DBSystem != "postgresql" {
+		t.Errorf("SELECT DBSystem = %q, want postgresql", sel.DBSystem)
+	}
+	if _, ok := byOp["INSERT"]; !ok {
+		t.Errorf("expected an INSERT summary, got %+v", out)
+	}
+}
+
+func TestGetDatabaseQuerySpans(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := NewQueryService(repo, nil, nil)
+	now := time.Now()
+	if err := repo.InsertSpans(dbTestSpans(now)); err != nil {
+		t.Fatalf("InsertSpans: %v", err)
+	}
+
+	pattern := NormalizeSQL("SELECT * FROM orders WHERE id = 1")
+	spans, err := svc.GetDatabaseQuerySpans(context.Background(), 1, time.Time{}, time.Time{}, pattern, "")
+	if err != nil {
+		t.Fatalf("GetDatabaseQuerySpans: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("want 2 spans for the SELECT pattern, got %d: %+v", len(spans), spans)
+	}
+
+	// Caller enrichment comes from the parent server span p1.
+	for _, s := range spans {
+		if s.CallerName != "GET /orders" || s.CallerService != "web" {
+			t.Errorf("span %s: caller = %q/%q, want 'GET /orders'/'web'", s.SpanID, s.CallerName, s.CallerService)
+		}
+	}
+	// The errored execution must carry its message through.
+	var sawErr bool
+	for _, s := range spans {
+		if s.Status == "error" {
+			sawErr = true
+			if s.ErrorMessage != "boom" {
+				t.Errorf("error span message = %q, want boom", s.ErrorMessage)
+			}
+		}
+	}
+	if !sawErr {
+		t.Error("expected one errored span in results")
+	}
+}
 
 func TestParseAttrs(t *testing.T) {
 	t.Run("empty string", func(t *testing.T) {

--- a/internal/service/query_service_map_test.go
+++ b/internal/service/query_service_map_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+func TestGetServiceMap(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := NewQueryService(repo, nil, nil)
+
+	now := time.Now()
+	// web (server) → api (cross-service child) → client span out of api.
+	spans := []repository.Span{
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "s1", Name: "GET /", Service: "web",
+			Kind: "server", Status: "ok", StartTimeUs: now.UnixMicro(), DurationUs: 1000,
+			Attributes: "{}", Events: "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "s2", ParentSpanID: "s1", Name: "handle", Service: "api",
+			Kind: "server", Status: "error", StartTimeUs: now.UnixMicro() + 100, DurationUs: 500,
+			Attributes: "{}", Events: "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "s3", ParentSpanID: "s2", Name: "SELECT", Service: "api",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro() + 200, DurationUs: 300,
+			Attributes: "{}", Events: "[]", IngestedAt: now,
+		},
+	}
+	if err := repo.InsertSpans(spans); err != nil {
+		t.Fatalf("InsertSpans: %v", err)
+	}
+
+	// Zero from/to skips the ingested_at filter so the map is built from all
+	// spans in the project, independent of insert-time storage format.
+	m, err := svc.GetServiceMap(context.Background(), 1, time.Time{}, time.Time{})
+	if err != nil {
+		t.Fatalf("GetServiceMap: %v", err)
+	}
+	if m == nil {
+		t.Fatal("expected non-nil service map")
+	}
+
+	nodeByID := map[string]ServiceMapNode{}
+	for _, n := range m.Nodes {
+		nodeByID[n.ID] = n
+	}
+	if _, ok := nodeByID["web"]; !ok {
+		t.Errorf("expected a 'web' node, got %+v", m.Nodes)
+	}
+	if _, ok := nodeByID["api"]; !ok {
+		t.Errorf("expected an 'api' node, got %+v", m.Nodes)
+	}
+
+	// The cross-service parent/child link (web → api) must produce a service edge.
+	var found bool
+	for _, e := range m.Edges {
+		if e.Source == "web" && e.Target == "api" {
+			found = true
+			if e.CallCount != 1 {
+				t.Errorf("web→api CallCount = %d, want 1", e.CallCount)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a web→api edge, got %+v", m.Edges)
+	}
+}

--- a/internal/service/query_services.go
+++ b/internal/service/query_services.go
@@ -19,6 +19,39 @@ import (
 // and was the cause of the "context deadline exceeded" issues (SPA-13/14/17).
 const spanFallbackWindow = 90 * time.Second
 
+// aggStats accumulates count, error count and count-weighted percentile sums so
+// a weighted p50/p95/p99 can be derived. ListServices, ListOperations and
+// GetTimeseries build the same rollup, keyed by service / operation / bucket.
+type aggStats struct {
+	count, errorCount               int64
+	aggP50Sum, aggP95Sum, aggP99Sum int64
+	aggCount                        int64
+}
+
+// foldAggregate folds a pre-aggregated row in; its percentiles are always
+// meaningful, so they are always count-weighted into the sums.
+func (a *aggStats) foldAggregate(count, errorCount, p50, p95, p99 int64) {
+	a.count += count
+	a.errorCount += errorCount
+	a.aggP50Sum += p50 * count
+	a.aggP95Sum += p95 * count
+	a.aggP99Sum += p99 * count
+	a.aggCount += count
+}
+
+// foldSpanFallback folds a raw-span-derived row in. Such rows may carry no
+// percentile data, so the percentile sums are only weighted in when present.
+func (a *aggStats) foldSpanFallback(count, errorCount, p50, p95, p99 int64) {
+	a.count += count
+	a.errorCount += errorCount
+	if p50 > 0 || p95 > 0 || p99 > 0 {
+		a.aggP50Sum += p50 * count
+		a.aggP95Sum += p95 * count
+		a.aggP99Sum += p99 * count
+		a.aggCount += count
+	}
+}
+
 // narrowFallback clamps `from` to be no earlier than now-spanFallbackWindow.
 // If `to` is older than that window, returns ok=false so the caller can skip
 // the raw-span query entirely.
@@ -101,15 +134,10 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 		st.buckets += a.Count
 	}
 
-	type mergedStats struct {
-		count, errorCount               int64
-		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                        int64
-	}
-	merged := make(map[string]*mergedStats)
+	merged := make(map[string]*aggStats)
 
 	for svc, st := range byService {
-		merged[svc] = &mergedStats{
+		merged[svc] = &aggStats{
 			count:      st.count,
 			errorCount: st.errorCount,
 			aggP50Sum:  st.p50Sum,
@@ -128,15 +156,10 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 			}) {
 				ms := merged[a.Service]
 				if ms == nil {
-					ms = &mergedStats{}
+					ms = &aggStats{}
 					merged[a.Service] = ms
 				}
-				ms.count += a.Count
-				ms.errorCount += a.ErrorCount
-				ms.aggP50Sum += a.P50Us * a.Count
-				ms.aggP95Sum += a.P95Us * a.Count
-				ms.aggP99Sum += a.P99Us * a.Count
-				ms.aggCount += a.Count
+				ms.foldAggregate(a.Count, a.ErrorCount, a.P50Us, a.P95Us, a.P99Us)
 			}
 		} else {
 			spanStats, err := s.repo.QueryServiceStatsFromSpans(projectID, fbFrom, to, kind)
@@ -146,17 +169,10 @@ func (s *QueryService) listServicesUncached(ctx context.Context, projectID int64
 			for _, ss := range spanStats {
 				ms := merged[ss.Service]
 				if ms == nil {
-					ms = &mergedStats{}
+					ms = &aggStats{}
 					merged[ss.Service] = ms
 				}
-				ms.count += ss.Count
-				ms.errorCount += ss.ErrorCount
-				if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
-					ms.aggP50Sum += ss.P50Us * ss.Count
-					ms.aggP95Sum += ss.P95Us * ss.Count
-					ms.aggP99Sum += ss.P99Us * ss.Count
-					ms.aggCount += ss.Count
-				}
+				ms.foldSpanFallback(ss.Count, ss.ErrorCount, ss.P50Us, ss.P95Us, ss.P99Us)
 			}
 		}
 	}
@@ -222,25 +238,15 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 	type opKey struct {
 		operation, resource, kind string
 	}
-	type opStats struct {
-		count, errorCount               int64
-		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                        int64
-	}
-	byOp := make(map[opKey]*opStats)
+	byOp := make(map[opKey]*aggStats)
 	for _, a := range aggs {
 		k := opKey{a.Operation, a.Resource, a.Kind}
 		st, ok := byOp[k]
 		if !ok {
-			st = &opStats{}
+			st = &aggStats{}
 			byOp[k] = st
 		}
-		st.count += a.Count
-		st.errorCount += a.ErrorCount
-		st.aggP50Sum += a.P50Us * a.Count
-		st.aggP95Sum += a.P95Us * a.Count
-		st.aggP99Sum += a.P99Us * a.Count
-		st.aggCount += a.Count
+		st.foldAggregate(a.Count, a.ErrorCount, a.P50Us, a.P95Us, a.P99Us)
 	}
 
 	if fbFrom, ok := narrowFallback(from, to); ok {
@@ -251,15 +257,10 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 				k := opKey{a.Operation, a.Resource, a.Kind}
 				st := byOp[k]
 				if st == nil {
-					st = &opStats{}
+					st = &aggStats{}
 					byOp[k] = st
 				}
-				st.count += a.Count
-				st.errorCount += a.ErrorCount
-				st.aggP50Sum += a.P50Us * a.Count
-				st.aggP95Sum += a.P95Us * a.Count
-				st.aggP99Sum += a.P99Us * a.Count
-				st.aggCount += a.Count
+				st.foldAggregate(a.Count, a.ErrorCount, a.P50Us, a.P95Us, a.P99Us)
 			}
 		} else {
 			spanStats, err := s.repo.QueryOperationStatsFromSpans(projectID, service, fbFrom, to, kind)
@@ -270,17 +271,10 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 				k := opKey{ss.Operation, ss.Resource, ss.Kind}
 				st := byOp[k]
 				if st == nil {
-					st = &opStats{}
+					st = &aggStats{}
 					byOp[k] = st
 				}
-				st.count += ss.Count
-				st.errorCount += ss.ErrorCount
-				if ss.P50Us > 0 || ss.P95Us > 0 || ss.P99Us > 0 {
-					st.aggP50Sum += ss.P50Us * ss.Count
-					st.aggP95Sum += ss.P95Us * ss.Count
-					st.aggP99Sum += ss.P99Us * ss.Count
-					st.aggCount += ss.Count
-				}
+				st.foldSpanFallback(ss.Count, ss.ErrorCount, ss.P50Us, ss.P95Us, ss.P99Us)
 			}
 		}
 	}
@@ -346,25 +340,15 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 		return nil, err
 	}
 
-	type bucketStats struct {
-		count, errorCount               int64
-		aggP50Sum, aggP95Sum, aggP99Sum int64
-		aggCount                        int64
-	}
-	byBucket := make(map[time.Time]*bucketStats)
+	byBucket := make(map[time.Time]*aggStats)
 	for _, a := range aggs {
 		b := a.Bucket.Truncate(interval)
 		st, ok := byBucket[b]
 		if !ok {
-			st = &bucketStats{}
+			st = &aggStats{}
 			byBucket[b] = st
 		}
-		st.count += a.Count
-		st.errorCount += a.ErrorCount
-		st.aggP50Sum += a.P50Us * a.Count
-		st.aggP95Sum += a.P95Us * a.Count
-		st.aggP99Sum += a.P99Us * a.Count
-		st.aggCount += a.Count
+		st.foldAggregate(a.Count, a.ErrorCount, a.P50Us, a.P95Us, a.P99Us)
 	}
 
 	if fbFrom, ok := narrowFallback(from, to); ok {
@@ -375,15 +359,10 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 				b := a.Bucket.Truncate(interval)
 				st := byBucket[b]
 				if st == nil {
-					st = &bucketStats{}
+					st = &aggStats{}
 					byBucket[b] = st
 				}
-				st.count += a.Count
-				st.errorCount += a.ErrorCount
-				st.aggP50Sum += a.P50Us * a.Count
-				st.aggP95Sum += a.P95Us * a.Count
-				st.aggP99Sum += a.P99Us * a.Count
-				st.aggCount += a.Count
+				st.foldAggregate(a.Count, a.ErrorCount, a.P50Us, a.P95Us, a.P99Us)
 			}
 		} else {
 			spanBuckets, err := s.repo.QuerySpanTimeseries(projectID, svcName, operation, fbFrom, to, int64(interval.Seconds()))
@@ -394,17 +373,10 @@ func (s *QueryService) GetTimeseries(ctx context.Context, projectID int64, svcNa
 				b := sb.Bucket.Truncate(interval)
 				st := byBucket[b]
 				if st == nil {
-					st = &bucketStats{}
+					st = &aggStats{}
 					byBucket[b] = st
 				}
-				st.count += sb.Count
-				st.errorCount += sb.ErrorCount
-				if sb.P50Us > 0 || sb.P95Us > 0 || sb.P99Us > 0 {
-					st.aggP50Sum += sb.P50Us * sb.Count
-					st.aggP95Sum += sb.P95Us * sb.Count
-					st.aggP99Sum += sb.P99Us * sb.Count
-					st.aggCount += sb.Count
-				}
+				st.foldSpanFallback(sb.Count, sb.ErrorCount, sb.P50Us, sb.P95Us, sb.P99Us)
 			}
 		}
 	}

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -22,7 +22,7 @@ GOCYCLO="go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0"
 DUPL="go run github.com/mibk/dupl@v1.1.0"
 
 # ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
-COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-77.1}
+COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-79.5}
 COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-69.0}
 # Per-file floor: no single source file in the gated packages may sit at/under
 # this coverage, so a fully-untested file can't hide behind well-covered
@@ -31,14 +31,14 @@ COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-69.0}
 MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-57.5}
 
 COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
-CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-27} # max functions allowed over COMPLEXITY
+CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-25} # max functions allowed over COMPLEXITY
 
 FILE_LINES=${FILE_LINES:-500}         # a file this long counts as "large"
-FILELEN_MAX_COUNT=${FILELEN_MAX_COUNT:-6} # max large files allowed
+FILELEN_MAX_COUNT=${FILELEN_MAX_COUNT:-5} # max large files allowed
 FILE_HARD_CAP=${FILE_HARD_CAP:-1200}  # no single file may exceed this
 
 DUPL_TOKENS=${DUPL_TOKENS:-100}       # dupl clone-detection threshold (tokens)
-DUPL_MAX_GROUPS=${DUPL_MAX_GROUPS:-17} # max duplicate clone groups allowed
+DUPL_MAX_GROUPS=${DUPL_MAX_GROUPS:-16} # max duplicate clone groups allowed
 # ---------------------------------------------------------------------------
 
 # Directories of Go source to inspect (production + CLI).

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -38,7 +38,7 @@ FILELEN_MAX_COUNT=${FILELEN_MAX_COUNT:-5} # max large files allowed
 FILE_HARD_CAP=${FILE_HARD_CAP:-1200}  # no single file may exceed this
 
 DUPL_TOKENS=${DUPL_TOKENS:-100}       # dupl clone-detection threshold (tokens)
-DUPL_MAX_GROUPS=${DUPL_MAX_GROUPS:-16} # max duplicate clone groups allowed
+DUPL_MAX_GROUPS=${DUPL_MAX_GROUPS:-17} # max duplicate clone groups allowed
 # ---------------------------------------------------------------------------
 
 # Directories of Go source to inspect (production + CLI).

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -31,7 +31,7 @@ COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-69.0}
 MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-57.5}
 
 COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
-CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-25} # max functions allowed over COMPLEXITY
+CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-24} # max functions allowed over COMPLEXITY
 
 FILE_LINES=${FILE_LINES:-500}         # a file this long counts as "large"
 FILELEN_MAX_COUNT=${FILELEN_MAX_COUNT:-5} # max large files allowed

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# quality-gate.sh — enforces that code-quality metrics do not regress.
+#
+# Each metric has a baseline set at the level the codebase reached after the
+# July 2026 audit cleanup. CI fails if any metric gets worse. When you
+# legitimately improve a metric (e.g. refactor a complex function), ratchet the
+# corresponding baseline DOWN in this file so the win is locked in; the baselines
+# are only ever meant to move in the improving direction.
+#
+# Metrics:
+#   1. Coverage      — service & repository packages stay at/above a floor.
+#   2. Cyclomatic    — count of functions over COMPLEXITY may not grow.
+#   3. File length   — count of large files may not grow; no file may exceed a cap.
+#   4. Duplication   — count of duplicate clone groups may not grow.
+#
+# Run locally with `make quality-gate`.
+set -euo pipefail
+
+# Pinned tool versions (avoid @latest drift across CI runs).
+GOCYCLO="go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0"
+DUPL="go run github.com/mibk/dupl@v1.1.0"
+
+# ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
+COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-65.0}
+COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-66.0}
+
+COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
+CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-27} # max functions allowed over COMPLEXITY
+
+FILE_LINES=${FILE_LINES:-500}         # a file this long counts as "large"
+FILELEN_MAX_COUNT=${FILELEN_MAX_COUNT:-6} # max large files allowed
+FILE_HARD_CAP=${FILE_HARD_CAP:-1200}  # no single file may exceed this
+
+DUPL_TOKENS=${DUPL_TOKENS:-100}       # dupl clone-detection threshold (tokens)
+DUPL_MAX_GROUPS=${DUPL_MAX_GROUPS:-17} # max duplicate clone groups allowed
+# ---------------------------------------------------------------------------
+
+# Directories of Go source to inspect (production + CLI).
+SRC_DIRS="internal cmd"
+
+fail=0
+note() { printf '  %-42s %s\n' "$1" "$2"; }
+
+# geq compares two decimals: returns 0 (true) if $1 >= $2.
+geq() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a+0 >= b+0)}'; }
+
+echo "== quality gate =="
+
+# --- 1. Coverage ------------------------------------------------------------
+# The trailing whitespace class ([[:space:]]) matches the package line
+# (".../internal/repository<TAB>...") without matching the ".../repository/migrations" line.
+cov_out=$(go test -cover ./internal/service/... ./internal/repository/... 2>/dev/null)
+svc_cov=$(echo "$cov_out" | grep -E 'internal/service[[:space:]]' | grep -oE '[0-9.]+% of statements' | grep -oE '[0-9.]+' | head -1)
+repo_cov=$(echo "$cov_out" | grep -E 'internal/repository[[:space:]]' | grep -oE '[0-9.]+% of statements' | grep -oE '[0-9.]+' | head -1)
+: "${svc_cov:=0}"; : "${repo_cov:=0}"
+
+if geq "$svc_cov" "$COVERAGE_SERVICE_MIN"; then
+  note "coverage service:      $svc_cov% (min $COVERAGE_SERVICE_MIN%)" "OK"
+else
+  note "coverage service:      $svc_cov% (min $COVERAGE_SERVICE_MIN%)" "FAIL"; fail=1
+fi
+if geq "$repo_cov" "$COVERAGE_REPOSITORY_MIN"; then
+  note "coverage repository:   $repo_cov% (min $COVERAGE_REPOSITORY_MIN%)" "OK"
+else
+  note "coverage repository:   $repo_cov% (min $COVERAGE_REPOSITORY_MIN%)" "FAIL"; fail=1
+fi
+
+# --- 2. Cyclomatic complexity (production code only) ------------------------
+# gocyclo -over exits non-zero when it finds matches; capture output regardless.
+cyclo_out=$($GOCYCLO -over "$COMPLEXITY" -ignore '_test\.go' $SRC_DIRS 2>/dev/null || true)
+cyclo_count=$(printf '%s' "$cyclo_out" | grep -c . || true)
+if [ "$cyclo_count" -le "$CYCLO_MAX_COUNT" ]; then
+  note "functions over cyclo $COMPLEXITY: $cyclo_count (max $CYCLO_MAX_COUNT)" "OK"
+else
+  note "functions over cyclo $COMPLEXITY: $cyclo_count (max $CYCLO_MAX_COUNT)" "FAIL"; fail=1
+  echo "    offenders:"; printf '%s\n' "$cyclo_out" | sed 's/^/      /'
+fi
+
+# --- 3. File length (production code only) ----------------------------------
+big_files=$(find $SRC_DIRS -name '*.go' -not -name '*_test.go' | xargs wc -l 2>/dev/null \
+  | awk -v t="$FILE_LINES" '$2!="total" && $1>t {print $1" "$2}')
+big_count=$(printf '%s' "$big_files" | grep -c . || true)
+over_cap=$(printf '%s\n' "$big_files" | awk -v cap="$FILE_HARD_CAP" '$1>cap {print}')
+if [ "$big_count" -le "$FILELEN_MAX_COUNT" ] && [ -z "$over_cap" ]; then
+  note "files over $FILE_LINES lines:    $big_count (max $FILELEN_MAX_COUNT, cap ${FILE_HARD_CAP})" "OK"
+else
+  note "files over $FILE_LINES lines:    $big_count (max $FILELEN_MAX_COUNT, cap ${FILE_HARD_CAP})" "FAIL"; fail=1
+  [ -n "$over_cap" ] && { echo "    over hard cap ${FILE_HARD_CAP}:"; printf '%s\n' "$over_cap" | sed 's/^/      /'; }
+fi
+
+# --- 4. Duplication ---------------------------------------------------------
+dupl_out=$($DUPL -threshold "$DUPL_TOKENS" $(printf './%s ' $SRC_DIRS) 2>/dev/null || true)
+dupl_groups=$(printf '%s' "$dupl_out" | grep -c '^found' || true)
+if [ "$dupl_groups" -le "$DUPL_MAX_GROUPS" ]; then
+  note "dupl clone groups (@$DUPL_TOKENS):  $dupl_groups (max $DUPL_MAX_GROUPS)" "OK"
+else
+  note "dupl clone groups (@$DUPL_TOKENS):  $dupl_groups (max $DUPL_MAX_GROUPS)" "FAIL"; fail=1
+fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "quality gate FAILED — a metric regressed past its baseline (see scripts/quality-gate.sh)."
+  exit 1
+fi
+echo "quality gate passed."

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -24,6 +24,11 @@ DUPL="go run github.com/mibk/dupl@v1.1.0"
 # ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
 COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-65.0}
 COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-66.0}
+# Per-file floor: no single source file in the gated packages may sit at/under
+# this coverage, so a fully-untested file can't hide behind well-covered
+# siblings in the same package aggregate. Migration DDL and test files are
+# excluded. "0% files" are the primary target.
+MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-1.0}
 
 COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
 CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-27} # max functions allowed over COMPLEXITY
@@ -47,10 +52,12 @@ geq() { awk -v a="$1" -v b="$2" 'BEGIN{exit !(a+0 >= b+0)}'; }
 
 echo "== quality gate =="
 
-# --- 1. Coverage ------------------------------------------------------------
+# --- 1. Coverage (per-package aggregate + per-file floor) -------------------
 # The trailing whitespace class ([[:space:]]) matches the package line
 # (".../internal/repository<TAB>...") without matching the ".../repository/migrations" line.
-cov_out=$(go test -cover ./internal/service/... ./internal/repository/... 2>/dev/null)
+cover_profile=$(mktemp)
+trap 'rm -f "$cover_profile"' EXIT
+cov_out=$(go test -cover -coverprofile="$cover_profile" ./internal/service/... ./internal/repository/... 2>/dev/null)
 svc_cov=$(echo "$cov_out" | grep -E 'internal/service[[:space:]]' | grep -oE '[0-9.]+% of statements' | grep -oE '[0-9.]+' | head -1)
 repo_cov=$(echo "$cov_out" | grep -E 'internal/repository[[:space:]]' | grep -oE '[0-9.]+% of statements' | grep -oE '[0-9.]+' | head -1)
 : "${svc_cov:=0}"; : "${repo_cov:=0}"
@@ -64,6 +71,28 @@ if geq "$repo_cov" "$COVERAGE_REPOSITORY_MIN"; then
   note "coverage repository:   $repo_cov% (min $COVERAGE_REPOSITORY_MIN%)" "OK"
 else
   note "coverage repository:   $repo_cov% (min $COVERAGE_REPOSITORY_MIN%)" "FAIL"; fail=1
+fi
+
+# Per-file floor — aggregate the profile per file (excluding migration DDL and
+# test files) and flag any at/under MIN_FILE_COVERAGE.
+under_floor=$(awk -v min="$MIN_FILE_COVERAGE" '
+  NR>1 {
+    split($1, a, ":"); f=a[1];
+    if (index(f, "/migrations/") > 0) next;
+    if (f ~ /_test\.go$/) next;
+    total[f]+=$2; if ($3>0) covered[f]+=$2;
+  }
+  END {
+    for (f in total) {
+      pct = total[f]>0 ? 100*covered[f]/total[f] : 100;
+      if (pct <= min+0) printf "%.1f%%  %s\n", pct, f;
+    }
+  }' "$cover_profile" | sort -n)
+if [ -z "$under_floor" ]; then
+  note "per-file floor $MIN_FILE_COVERAGE% (no 0% files):" "OK"
+else
+  note "per-file floor $MIN_FILE_COVERAGE% (no 0% files):" "FAIL"; fail=1
+  echo "    files at/under floor:"; printf '%s\n' "$under_floor" | sed 's/^/      /'
 fi
 
 # --- 2. Cyclomatic complexity (production code only) ------------------------

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -23,7 +23,7 @@ DUPL="go run github.com/mibk/dupl@v1.1.0"
 
 # ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
 COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-77.1}
-COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-68.8}
+COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-69.0}
 # Per-file floor: no single source file in the gated packages may sit at/under
 # this coverage, so a fully-untested file can't hide behind well-covered
 # siblings in the same package aggregate. Migration DDL and test files are

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -22,13 +22,13 @@ GOCYCLO="go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0"
 DUPL="go run github.com/mibk/dupl@v1.1.0"
 
 # ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
-COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-65.0}
-COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-66.0}
+COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-75.0}
+COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-67.0}
 # Per-file floor: no single source file in the gated packages may sit at/under
 # this coverage, so a fully-untested file can't hide behind well-covered
 # siblings in the same package aggregate. Migration DDL and test files are
-# excluded. "0% files" are the primary target.
-MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-1.0}
+# excluded.
+MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-50.0}
 
 COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
 CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-27} # max functions allowed over COMPLEXITY

--- a/scripts/quality-gate.sh
+++ b/scripts/quality-gate.sh
@@ -22,13 +22,13 @@ GOCYCLO="go run github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0"
 DUPL="go run github.com/mibk/dupl@v1.1.0"
 
 # ---- Baselines (ratchet DOWN as the codebase improves) ---------------------
-COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-75.0}
-COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-67.0}
+COVERAGE_SERVICE_MIN=${COVERAGE_SERVICE_MIN:-77.1}
+COVERAGE_REPOSITORY_MIN=${COVERAGE_REPOSITORY_MIN:-68.8}
 # Per-file floor: no single source file in the gated packages may sit at/under
 # this coverage, so a fully-untested file can't hide behind well-covered
 # siblings in the same package aggregate. Migration DDL and test files are
 # excluded.
-MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-50.0}
+MIN_FILE_COVERAGE=${MIN_FILE_COVERAGE:-57.5}
 
 COMPLEXITY=${COMPLEXITY:-15}          # gocyclo score considered "complex"
 CYCLO_MAX_COUNT=${CYCLO_MAX_COUNT:-27} # max functions allowed over COMPLEXITY


### PR DESCRIPTION
## Summary

Code-quality refactors from the audit. Behavior-neutral (`go test -race ./...` green); env var names unchanged.

> Stacked on #119 (`security/audit-hardening`). Retarget to `main` once #119 merges.

### NormalizeSQL — gocyclo 41 → 14
The worst-complexity function was one loop with six inline token scanners. Each token class is now a small `scanXxx(sql, i, b)` helper dispatched from a `switch`; output identical (covered by `TestNormalizeSQL`).

### Span WHERE-builder dedup
The optional-filter WHERE assembly (project/service/operation/status/min-duration/time-range) was copy-pasted across `QuerySpans`, `SearchTraceSummaries`, `StreamSpans`. Extracted `SpanFilter.appendCommonWhere`; callers add only their own predicates. Predicates are ANDed, result sets unchanged (`SearchTraceSummaries` 36 → 29).

### config.Config God object → sub-structs
Grouped the flat 56-field struct into `Retention`, `OIDC`, `Self`, `BugBarn`, `FunnelBarn`. **Env var names are unchanged** — only Go field access nests (`cfg.OIDCIssuer` → `cfg.OIDC.Issuer`), so deploy config is untouched.

### Bootstrap dedup (`main.go`)
Extracted `retentionConfigFrom` (retention mapping duplicated in standalone + writer) and `serverConfigFrom` (the `api.ServerConfig` literal duplicated across all four modes). `serverConfigFrom` leaves `MetricsToken` unset so standalone/writer opt in explicitly and reader/ingest keep their existing open `/metrics` — no behavior change.

> Note: the four `runXMode` functions remain individually complex (their cyclomatic count comes from sequential config-validation guards, not the extracted duplication). A full `buildRuntime` extraction that collapses their goroutine/context/defer orchestration is intentionally **not** attempted here — it can't be verified without exercising each deploy mode against real infra, so it's better as a dedicated, separately-verified change.

## Testing
`go test -race ./...` green; `go vet` + `gofmt` clean.
---

## CI quality gate (new)

Added `scripts/quality-gate.sh` — a **ratchet** run by `make quality-gate` and a new `quality` CI job — that fails when any code-quality metric regresses past a committed baseline. Baselines only move in the improving direction.

| Metric | Baseline (fails if worse) |
|---|---|
| Coverage — `internal/service` | ≥ 65% (currently 66.2%) |
| Coverage — `internal/repository` | ≥ 66% (currently 67.7%) |
| Functions over gocyclo 15 (non-test) | ≤ 27 |
| Files over 500 lines (non-test) | ≤ 6, and no file > 1200 lines |
| `dupl` clone groups (threshold 100) | ≤ 17 |

The documented "service+repository ≥ 60%" gate was never actually enforced and service was at **59.0%** — added a `GetServiceMap` test that lifts service coverage to **66.2%**, so the gate is now real and green. Verified the gate fails on simulated coverage/complexity/duplication regressions.