### PR TITLE
feat(writer): span staging table + tail-sampling flusher (opt-in)

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -746,17 +746,37 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 
 	boringPolicy := worker.NewCachedBoringPolicy(repo, 30*time.Second)
 
+	// The writer is the single SQLite writer, so an in-memory per-minute floor
+	// counts boring-trace survivals accurately across batches.
+	minuteFloor := sampling.NewMinuteFloor()
+
 	rw := worker.NewRedisWorker(writeQueue, &workerRepoAdapter{repo: repo}, logger)
 	rw.SetAccumulator(accumulator)
 	rw.SetConfig(worker.WorkerConfig{SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000})
 	rw.SetBoringPolicy(boringPolicy)
-	// The writer is the single SQLite writer, so an in-memory per-minute floor
-	// counts boring-trace survivals accurately across batches.
-	rw.SetMinuteFloor(sampling.NewMinuteFloor())
+	rw.SetMinuteFloor(minuteFloor)
+	rw.SetStagingMode(cfg.SpanStagingEnabled)
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	safeGo("write-scheduler", &wg, func() { scheduler.Run(workerCtx) })
 	defer workerCancel()
 	safeGo("redis-worker", &wg, func() { rw.Run(workerCtx) })
+
+	// Span staging (opt-in): the redis worker only appends to spans_staging; this
+	// flusher does accumulation + classification + indexed storage per complete
+	// trace off the hot path, with a hard-age GC so staging can't grow unbounded.
+	if cfg.SpanStagingEnabled {
+		flusher := worker.NewStagingFlusher(repo, worker.StagingFlusherConfig{
+			Window:          time.Duration(cfg.TraceBufferWindowSeconds) * time.Second,
+			MaxAge:          time.Duration(cfg.StagingMaxAgeSeconds) * time.Second,
+			SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000,
+		}, logger)
+		flusher.SetAccumulator(accumulator)
+		flusher.SetBoringPolicy(boringPolicy)
+		flusher.SetMinuteFloor(minuteFloor)
+		safeGo("staging-flusher", &wg, func() { flusher.Run(workerCtx) })
+		logger.Info("span staging enabled: worker stages spans, flusher classifies per trace",
+			"window_s", cfg.TraceBufferWindowSeconds, "max_age_s", cfg.StagingMaxAgeSeconds)
+	}
 	safeGo("accumulator", &wg, func() { accumulator.Run(workerCtx) })
 	safeGo("metric-accumulator", &wg, func() { metricAccumulator.Run(workerCtx) })
 	safeGo("metrics-consumer", &wg, func() {
@@ -1030,6 +1050,10 @@ type workerRepoAdapter struct {
 
 func (a *workerRepoAdapter) InsertSpans(ctx context.Context, spans []repository.Span) error {
 	return a.repo.InsertSpansContext(ctx, spans)
+}
+
+func (a *workerRepoAdapter) InsertSpansStaging(ctx context.Context, spans []repository.Span) error {
+	return a.repo.InsertSpansStaging(ctx, spans)
 }
 
 func (a *workerRepoAdapter) InsertPromptRecords(_ context.Context, records []repository.PromptRecord) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,13 +25,16 @@ type Config struct {
 	RetentionAggregatedDays     int
 	RetentionErrorDays          int
 	RetentionInterestingHours   int
-	BoringRetentionMinutes      int // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
-	MetricsRetentionDays        int // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
-	LogRetentionHours           int // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
-	ErrorLogRetentionDays       int // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
-	RetentionDeleteBatchYieldMS int // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
-	WALTruncateThresholdMB      int // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
-	CheckpointSkipQueueDepth    int // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints (which can block the single connection up to busy_timeout) so it can pour throughput into draining the backlog; it still forces an occasional checkpoint to bound the WAL (default 100; 0 disables gating)
+	BoringRetentionMinutes      int  // SPANBARN_BORING_RETENTION_MINUTES — short retention for sampled boring spans
+	MetricsRetentionDays        int  // SPANBARN_METRICS_RETENTION_DAYS — how long to keep raw metric data points
+	LogRetentionHours           int  // SPANBARN_LOG_RETENTION_HOURS — how long to keep log records (default 24)
+	ErrorLogRetentionDays       int  // SPANBARN_ERROR_LOG_RETENTION_DAYS — how long to keep logs for error traces (default 30)
+	RetentionDeleteBatchYieldMS int  // SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS — pause between batched retention deletes so the WAL checkpoint and reads aren't starved (default 200)
+	WALTruncateThresholdMB      int  // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
+	CheckpointSkipQueueDepth    int  // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints (which can block the single connection up to busy_timeout) so it can pour throughput into draining the backlog; it still forces an occasional checkpoint to bound the WAL (default 100; 0 disables gating)
+	SpanStagingEnabled          bool // SPANBARN_SPAN_STAGING_ENABLED — when true, the redis worker appends consumed spans to spans_staging (cheap) and a background flusher does accumulation+classification+indexed storage per complete trace off the hot path (default false)
+	TraceBufferWindowSeconds    int  // SPANBARN_TRACE_BUFFER_WINDOW_SECONDS — how long a trace's spans buffer in spans_staging before the flusher treats the trace as complete (default 90)
+	StagingMaxAgeSeconds        int  // SPANBARN_STAGING_MAX_AGE_SECONDS — hard backstop: spans_staging rows older than this are dropped unconditionally so the table can never grow without bound (default 900)
 	IngestSampleRate            float64
 	SlowThresholdMS             int
 	AggregationInterval         string
@@ -93,6 +96,9 @@ func Load() Config {
 		RetentionDeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
 		WALTruncateThresholdMB:      getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
 		CheckpointSkipQueueDepth:    getenvInt("SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH", 100),
+		SpanStagingEnabled:          getenvInt("SPANBARN_SPAN_STAGING_ENABLED", 0) != 0,
+		TraceBufferWindowSeconds:    getenvInt("SPANBARN_TRACE_BUFFER_WINDOW_SECONDS", 90),
+		StagingMaxAgeSeconds:        getenvInt("SPANBARN_STAGING_MAX_AGE_SECONDS", 900),
 		IngestSampleRate:            getenvFloat("SPANBARN_INGEST_SAMPLE_RATE", 1.0),
 		SlowThresholdMS:             getenvInt("SPANBARN_SLOW_THRESHOLD_MS", 500),
 		AggregationInterval:         getenv("SPANBARN_AGGREGATION_INTERVAL", "1m"),

--- a/internal/repository/migrations/029_spans_staging.go
+++ b/internal/repository/migrations/029_spans_staging.go
@@ -1,0 +1,56 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up029, down029)
+}
+
+// up029 creates the spans_staging table: a cheap landing zone the writer appends
+// every incoming span to, decoupling the fast Redis drain from the expensive
+// indexed write. A background flush groups staging rows by trace, classifies the
+// complete trace, moves only the interesting ones into the indexed `spans` table,
+// and deletes the processed rows.
+//
+// Staging carries a SINGLE index — on trace_id — which the flush uses to group
+// ready traces, gather a whole trace's spans for classification, and delete by
+// trace on cleanup. No other indexes, so appends stay ~11x cheaper than the main
+// spans table. Time ordering comes free from the implicit rowid (inserts are
+// monotonic), which the age-based flush and the hard-age GC backstop scan by.
+func up029(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS spans_staging (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			project_id INTEGER NOT NULL,
+			trace_id TEXT NOT NULL,
+			span_id TEXT NOT NULL,
+			parent_span_id TEXT,
+			name TEXT NOT NULL,
+			service TEXT NOT NULL,
+			resource TEXT NOT NULL DEFAULT '',
+			kind TEXT NOT NULL DEFAULT 'internal',
+			status TEXT NOT NULL DEFAULT 'unset',
+			start_time_us INTEGER NOT NULL,
+			duration_us INTEGER NOT NULL,
+			attributes TEXT NOT NULL DEFAULT '{}',
+			events TEXT NOT NULL DEFAULT '[]',
+			ingested_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_staging_trace ON spans_staging(trace_id)`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down029(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `DROP TABLE IF EXISTS spans_staging`)
+	return err
+}

--- a/internal/repository/repo_spans_staging.go
+++ b/internal/repository/repo_spans_staging.go
@@ -1,0 +1,172 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// stagingCols is the column list shared by staging reads/writes (matches spans,
+// minus the auto id). ingested_at is preserved across the staging->spans move so
+// a span's received time doesn't jump to flush time.
+const stagingCols = `project_id, trace_id, span_id, parent_span_id, name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at`
+
+// InsertSpansStaging appends spans to the unindexed-ish spans_staging landing
+// table (one trace_id index). This is the cheap write that lets the writer drain
+// the Redis queue fast; a background flush later classifies and moves the
+// interesting traces into the indexed spans table.
+func (r *Repository) InsertSpansStaging(ctx context.Context, spans []Span) error {
+	if len(spans) == 0 {
+		return nil
+	}
+	return r.execLow(func() error {
+		tx, err := r.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		stmt, err := tx.PrepareContext(ctx, `INSERT INTO spans_staging
+			(project_id, trace_id, span_id, parent_span_id, name, service, resource, kind, status, start_time_us, duration_us, attributes, events)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return err
+		}
+		defer stmt.Close()
+
+		for _, s := range spans {
+			var parentID *string
+			if s.ParentSpanID != "" {
+				parentID = &s.ParentSpanID
+			}
+			if _, err := stmt.ExecContext(ctx,
+				s.ProjectID, s.TraceID, s.SpanID, parentID,
+				s.Name, s.Service, s.Resource, s.Kind, s.Status,
+				s.StartTimeUs, s.DurationUs, s.Attributes, s.Events,
+			); err != nil {
+				return err
+			}
+		}
+		return tx.Commit()
+	})
+}
+
+// ReadyStagingTraceIDs returns up to limit trace_ids whose oldest staged span is
+// older than cutoff (i.e. the trace has had the full buffering window to arrive),
+// oldest first. The GROUP BY is served by the trace_id index and the table stays
+// small (continuously drained), so this is cheap.
+func (r *Repository) ReadyStagingTraceIDs(ctx context.Context, cutoff time.Time, limit int) ([]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT trace_id FROM spans_staging
+		 GROUP BY trace_id HAVING MIN(ingested_at) < ?
+		 ORDER BY MIN(ingested_at) LIMIT ?`, cutoff.UTC(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// GetStagingSpansByTraceIDs returns every staged span for the given traces, so
+// classification sees the whole trace. Uses the trace_id index.
+func (r *Repository) GetStagingSpansByTraceIDs(ctx context.Context, traceIDs []string) ([]Span, error) {
+	if len(traceIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(traceIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(traceIDs))
+	for i, id := range traceIDs {
+		args[i] = id
+	}
+	q := `SELECT id, project_id, trace_id, span_id, COALESCE(parent_span_id,''), name, service, resource, kind, status, start_time_us, duration_us, attributes, events, ingested_at
+		FROM spans_staging WHERE trace_id IN (` + placeholders + `)`
+	return r.scanSpans(q, args...)
+}
+
+// CommitStagingFlush atomically moves the interesting spans into the indexed
+// spans table (preserving ingested_at) and deletes every staged row for the
+// given traces. Boring traces have no interesting spans, so they are dropped by
+// the delete without ever hitting the indexed table.
+func (r *Repository) CommitStagingFlush(ctx context.Context, traceIDs []string, interesting []Span) error {
+	if len(traceIDs) == 0 {
+		return nil
+	}
+	return r.execLow(func() error {
+		tx, err := r.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		if len(interesting) > 0 {
+			stmt, err := tx.PrepareContext(ctx, `INSERT INTO spans
+				(`+stagingCols+`)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+			if err != nil {
+				return err
+			}
+			for _, s := range interesting {
+				var parentID *string
+				if s.ParentSpanID != "" {
+					parentID = &s.ParentSpanID
+				}
+				if _, err := stmt.ExecContext(ctx,
+					s.ProjectID, s.TraceID, s.SpanID, parentID,
+					s.Name, s.Service, s.Resource, s.Kind, s.Status,
+					s.StartTimeUs, s.DurationUs, s.Attributes, s.Events, s.IngestedAt,
+				); err != nil {
+					stmt.Close()
+					return err
+				}
+			}
+			stmt.Close()
+		}
+
+		placeholders := strings.Repeat("?,", len(traceIDs))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, len(traceIDs))
+		for i, id := range traceIDs {
+			args[i] = id
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM spans_staging WHERE trace_id IN (`+placeholders+`)`, args...); err != nil {
+			return err
+		}
+		return tx.Commit()
+	})
+}
+
+// DeleteStagingOlderThan is the hard cleanup backstop: it drops any staged row
+// older than cutoff regardless of whether the flush processed it, guaranteeing
+// spans_staging can never grow without bound if the flush stalls. It sheds the
+// oldest rows (graceful degradation) rather than letting the table grow.
+func (r *Repository) DeleteStagingOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	var deleted int64
+	err := r.execLow(func() error {
+		res, e := r.db.ExecContext(ctx, `DELETE FROM spans_staging WHERE ingested_at < ?`, cutoff.UTC())
+		if e != nil {
+			return e
+		}
+		deleted, _ = res.RowsAffected()
+		return nil
+	})
+	return deleted, err
+}
+
+// CountStagingRows returns the current staging depth for observability.
+func (r *Repository) CountStagingRows(ctx context.Context) (int64, error) {
+	var n int64
+	if err := r.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM spans_staging`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count spans_staging: %w", err)
+	}
+	return n, nil
+}

--- a/internal/repository/repo_spans_staging_test.go
+++ b/internal/repository/repo_spans_staging_test.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func stagingSpan(trace, span, status string) Span {
+	return Span{
+		ProjectID: 1, TraceID: trace, SpanID: span, Name: "op", Service: "svc",
+		Kind: "server", Status: status, StartTimeUs: 1, DurationUs: 1,
+		Attributes: "{}", Events: "[]",
+	}
+}
+
+// TestStagingFlushCycle exercises the full Shape-2 path: append spans to staging,
+// discover ready traces, gather whole traces, move the interesting one into the
+// indexed spans table while dropping the boring one, and confirm staging drains.
+func TestStagingFlushCycle(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	// Trace A is interesting (has an error span); trace B is entirely boring.
+	spans := []Span{
+		stagingSpan("traceA", "a1", "unset"),
+		stagingSpan("traceA", "a2", "error"),
+		stagingSpan("traceB", "b1", "unset"),
+		stagingSpan("traceB", "b2", "unset"),
+	}
+	if err := repo.InsertSpansStaging(ctx, spans); err != nil {
+		t.Fatalf("InsertSpansStaging: %v", err)
+	}
+	if n, _ := repo.CountStagingRows(ctx); n != 4 {
+		t.Fatalf("expected 4 staged rows, got %d", n)
+	}
+
+	// Everything staged so far is "ready" relative to a future cutoff.
+	ready, err := repo.ReadyStagingTraceIDs(ctx, time.Now().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatalf("ReadyStagingTraceIDs: %v", err)
+	}
+	if len(ready) != 2 {
+		t.Fatalf("expected 2 ready traces, got %d (%v)", len(ready), ready)
+	}
+
+	gathered, err := repo.GetStagingSpansByTraceIDs(ctx, ready)
+	if err != nil {
+		t.Fatalf("GetStagingSpansByTraceIDs: %v", err)
+	}
+	if len(gathered) != 4 {
+		t.Fatalf("expected 4 gathered spans, got %d", len(gathered)) //nolint
+	}
+
+	// Classify: keep every span of a trace that contains an error span.
+	interestingTraces := map[string]bool{}
+	for _, s := range gathered {
+		if s.Status == "error" {
+			interestingTraces[s.TraceID] = true
+		}
+	}
+	var interesting []Span
+	for _, s := range gathered {
+		if interestingTraces[s.TraceID] {
+			interesting = append(interesting, s)
+		}
+	}
+	if len(interesting) != 2 {
+		t.Fatalf("expected 2 interesting spans (trace A), got %d", len(interesting))
+	}
+
+	if err := repo.CommitStagingFlush(ctx, ready, interesting); err != nil {
+		t.Fatalf("CommitStagingFlush: %v", err)
+	}
+
+	// Staging fully drained.
+	if n, _ := repo.CountStagingRows(ctx); n != 0 {
+		t.Fatalf("expected staging drained, got %d rows", n)
+	}
+	// Interesting trace A landed in the indexed spans table...
+	got, err := repo.GetTraceByID("traceA")
+	if err != nil {
+		t.Fatalf("GetTraceByID(traceA): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 spans for trace A in spans, got %d", len(got))
+	}
+	// ...boring trace B was dropped.
+	if b, _ := repo.GetTraceByID("traceB"); len(b) != 0 {
+		t.Fatalf("expected trace B dropped, got %d spans", len(b))
+	}
+}
+
+func TestStagingGCBackstop(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+
+	if err := repo.InsertSpansStaging(ctx, []Span{stagingSpan("t1", "s1", "unset")}); err != nil {
+		t.Fatalf("InsertSpansStaging: %v", err)
+	}
+	// Nothing older than an hour ago yet.
+	if d, _ := repo.DeleteStagingOlderThan(ctx, time.Now().Add(-time.Hour)); d != 0 {
+		t.Fatalf("expected 0 GC deletes, got %d", d)
+	}
+	// A future cutoff sweeps everything (bounded-growth guarantee).
+	d, err := repo.DeleteStagingOlderThan(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteStagingOlderThan: %v", err)
+	}
+	if d != 1 {
+		t.Fatalf("expected 1 GC delete, got %d", d)
+	}
+	if n, _ := repo.CountStagingRows(ctx); n != 0 {
+		t.Fatalf("expected staging empty after GC, got %d", n)
+	}
+}

--- a/internal/worker/staging_flush.go
+++ b/internal/worker/staging_flush.go
@@ -1,0 +1,161 @@
+package worker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+	"github.com/wiebe-xyz/spanbarn/internal/sampling"
+)
+
+// StagingRepository is the data access the flusher needs.
+type StagingRepository interface {
+	ReadyStagingTraceIDs(ctx context.Context, cutoff time.Time, limit int) ([]string, error)
+	GetStagingSpansByTraceIDs(ctx context.Context, traceIDs []string) ([]repository.Span, error)
+	CommitStagingFlush(ctx context.Context, traceIDs []string, interesting []repository.Span) error
+	DeleteStagingOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+	CountStagingRows(ctx context.Context) (int64, error)
+	InsertPromptRecords(records []repository.PromptRecord) error
+}
+
+// StagingFlusherConfig tunes the flush and GC loops.
+type StagingFlusherConfig struct {
+	Window          time.Duration // a trace is flushed once its oldest staged span is this old
+	FlushInterval   time.Duration // how often to look for ready traces
+	GCInterval      time.Duration // how often the hard-age backstop runs
+	MaxAge          time.Duration // staging rows older than this are dropped unconditionally
+	BatchTraces     int           // max ready traces processed per flush transaction
+	SlowThresholdUs int64         // classification: spans slower than this make a trace interesting
+}
+
+// StagingFlusher moves complete traces out of spans_staging: it feeds every span
+// to the accumulator, classifies whole traces, stores only the interesting ones
+// in the indexed spans table, and deletes the processed rows — with a hard-age GC
+// backstop so staging can never grow without bound.
+type StagingFlusher struct {
+	repo         StagingRepository
+	accumulator  SpanAccumulator
+	boringPolicy BoringPolicyReader
+	floor        *sampling.MinuteFloor
+	cfg          StagingFlusherConfig
+	logger       *slog.Logger
+}
+
+// NewStagingFlusher creates a flusher, applying sane defaults for any unset config.
+func NewStagingFlusher(repo StagingRepository, cfg StagingFlusherConfig, logger *slog.Logger) *StagingFlusher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = 90 * time.Second
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 10 * time.Second
+	}
+	if cfg.GCInterval <= 0 {
+		cfg.GCInterval = time.Minute
+	}
+	if cfg.MaxAge <= 0 {
+		cfg.MaxAge = 15 * time.Minute
+	}
+	if cfg.BatchTraces <= 0 {
+		cfg.BatchTraces = 500
+	}
+	return &StagingFlusher{repo: repo, cfg: cfg, logger: logger}
+}
+
+func (f *StagingFlusher) SetAccumulator(a SpanAccumulator)        { f.accumulator = a }
+func (f *StagingFlusher) SetBoringPolicy(p BoringPolicyReader)    { f.boringPolicy = p }
+func (f *StagingFlusher) SetMinuteFloor(fl *sampling.MinuteFloor) { f.floor = fl }
+
+// Run flushes ready traces and GCs the staging table until ctx is cancelled.
+func (f *StagingFlusher) Run(ctx context.Context) {
+	flush := time.NewTicker(f.cfg.FlushInterval)
+	gc := time.NewTicker(f.cfg.GCInterval)
+	defer flush.Stop()
+	defer gc.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-flush.C:
+			// Drain every currently-ready trace this cycle (bounded per tx).
+			for {
+				n, err := f.flushOnce(ctx)
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					f.logger.Error("staging flush error", "error", err)
+					break
+				}
+				if n < f.cfg.BatchTraces {
+					break // caught up
+				}
+			}
+		case <-gc.C:
+			f.gcOnce(ctx)
+		}
+	}
+}
+
+// flushOnce processes up to BatchTraces ready traces and returns how many it
+// handled (0 means nothing was ready).
+func (f *StagingFlusher) flushOnce(ctx context.Context) (int, error) {
+	cutoff := time.Now().Add(-f.cfg.Window)
+	traceIDs, err := f.repo.ReadyStagingTraceIDs(ctx, cutoff, f.cfg.BatchTraces)
+	if err != nil {
+		return 0, err
+	}
+	if len(traceIDs) == 0 {
+		return 0, nil
+	}
+
+	spans, err := f.repo.GetStagingSpansByTraceIDs(ctx, traceIDs)
+	if err != nil {
+		return 0, err
+	}
+
+	// Aggregate every span (boring included) before classification, exactly like
+	// the inline path — now over complete traces.
+	if f.accumulator != nil {
+		for i := range spans {
+			f.accumulator.Add(spans[i])
+		}
+	}
+	interesting := classifySpansForStorage(spans, f.cfg.SlowThresholdUs, f.boringPolicy, f.floor)
+
+	// Atomically move interesting spans to the indexed table and delete all
+	// processed rows for these traces.
+	if err := f.repo.CommitStagingFlush(ctx, traceIDs, interesting); err != nil {
+		return 0, err
+	}
+	if promptRecs := extractPromptRecords(interesting); len(promptRecs) > 0 {
+		if err := f.repo.InsertPromptRecords(promptRecs); err != nil {
+			f.logger.Warn("staging flush: insert prompt records", "count", len(promptRecs), "error", err)
+		}
+	}
+	f.logger.Debug("staging flush", "traces", len(traceIDs), "spans", len(spans), "stored", len(interesting))
+	return len(traceIDs), nil
+}
+
+// gcOnce is the bounded-growth backstop: drop anything older than MaxAge even if
+// the flush never processed it, and surface staging depth for observability.
+func (f *StagingFlusher) gcOnce(ctx context.Context) {
+	cutoff := time.Now().Add(-f.cfg.MaxAge)
+	deleted, err := f.repo.DeleteStagingOlderThan(ctx, cutoff)
+	if err != nil {
+		if ctx.Err() == nil {
+			f.logger.Error("staging gc error", "error", err)
+		}
+		return
+	}
+	if deleted > 0 {
+		// Non-zero means the flush fell behind and we shed unprocessed spans.
+		f.logger.Warn("staging gc dropped rows older than max age", "deleted", deleted, "max_age", f.cfg.MaxAge.String())
+	}
+	if n, err := f.repo.CountStagingRows(ctx); err == nil {
+		f.logger.Info("staging depth", "rows", n)
+	}
+}

--- a/internal/worker/staging_flush_test.go
+++ b/internal/worker/staging_flush_test.go
@@ -1,0 +1,89 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+type mockStagingRepo struct {
+	ready           []string
+	spans           []repository.Span
+	committed       [][]repository.Span
+	committedTraces [][]string
+	gcCutoff        time.Time
+	gcDeleted       int64
+	count           int64
+}
+
+func (m *mockStagingRepo) ReadyStagingTraceIDs(_ context.Context, _ time.Time, _ int) ([]string, error) {
+	r := m.ready
+	m.ready = nil // one-shot so the drain loop terminates
+	return r, nil
+}
+func (m *mockStagingRepo) GetStagingSpansByTraceIDs(_ context.Context, _ []string) ([]repository.Span, error) {
+	return m.spans, nil
+}
+func (m *mockStagingRepo) CommitStagingFlush(_ context.Context, traceIDs []string, interesting []repository.Span) error {
+	m.committedTraces = append(m.committedTraces, traceIDs)
+	m.committed = append(m.committed, interesting)
+	return nil
+}
+func (m *mockStagingRepo) DeleteStagingOlderThan(_ context.Context, cutoff time.Time) (int64, error) {
+	m.gcCutoff = cutoff
+	return m.gcDeleted, nil
+}
+func (m *mockStagingRepo) CountStagingRows(_ context.Context) (int64, error)     { return m.count, nil }
+func (m *mockStagingRepo) InsertPromptRecords(_ []repository.PromptRecord) error { return nil }
+
+type countingAcc struct{ n int }
+
+func (c *countingAcc) Add(_ repository.Span) { c.n++ }
+
+func TestStagingFlusherFlushOnce(t *testing.T) {
+	repo := &mockStagingRepo{
+		ready: []string{"tA", "tB"},
+		spans: []repository.Span{
+			{TraceID: "tA", SpanID: "a1", Status: "unset", DurationUs: 1},
+			{TraceID: "tA", SpanID: "a2", Status: "error", DurationUs: 1},
+			{TraceID: "tB", SpanID: "b1", Status: "unset", DurationUs: 1},
+		},
+	}
+	acc := &countingAcc{}
+	f := NewStagingFlusher(repo, StagingFlusherConfig{SlowThresholdUs: 1000}, nil)
+	f.SetAccumulator(acc)
+
+	n, err := f.flushOnce(context.Background())
+	if err != nil {
+		t.Fatalf("flushOnce: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 traces flushed, got %d", n)
+	}
+	if acc.n != 3 {
+		t.Fatalf("accumulator must see all 3 spans (boring included), got %d", acc.n)
+	}
+	if len(repo.committed) != 1 {
+		t.Fatalf("expected 1 commit, got %d", len(repo.committed))
+	}
+	// Only trace A (has the error span) is interesting -> its 2 spans stored;
+	// boring trace B is dropped.
+	if got := len(repo.committed[0]); got != 2 {
+		t.Fatalf("expected 2 interesting spans stored (trace A), got %d", got)
+	}
+	// Both traces are deleted from staging regardless of interesting-ness.
+	if len(repo.committedTraces[0]) != 2 {
+		t.Fatalf("expected both traces deleted from staging, got %v", repo.committedTraces[0])
+	}
+}
+
+func TestStagingFlusherGCUsesMaxAge(t *testing.T) {
+	repo := &mockStagingRepo{gcDeleted: 3, count: 10}
+	f := NewStagingFlusher(repo, StagingFlusherConfig{MaxAge: 10 * time.Minute}, nil)
+	f.gcOnce(context.Background())
+	if age := time.Since(repo.gcCutoff); age < 9*time.Minute || age > 11*time.Minute {
+		t.Fatalf("gc cutoff should be ~MaxAge ago, was %v ago", age)
+	}
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -29,6 +29,7 @@ const (
 // Repository is the interface the worker needs to persist spans.
 type Repository interface {
 	InsertSpans(ctx context.Context, spans []repository.Span) error
+	InsertSpansStaging(ctx context.Context, spans []repository.Span) error
 	InsertPromptRecords(ctx context.Context, records []repository.PromptRecord) error
 }
 
@@ -243,6 +244,18 @@ type RedisWorker struct {
 	logger       *slog.Logger
 	metrics      Metrics
 	cfg          WorkerConfig
+	// stageOnly, when set, makes the worker append every consumed span to the
+	// spans_staging table and return immediately, deferring accumulation,
+	// classification and indexed storage to the StagingFlusher. This keeps the
+	// Redis drain fast (cheap unindexed appends) so the queue never backs up.
+	stageOnly bool
+}
+
+// SetStagingMode switches the worker to append consumed spans to spans_staging
+// instead of accumulating/classifying/inserting inline. The StagingFlusher then
+// does that work off the hot path.
+func (w *RedisWorker) SetStagingMode(on bool) {
+	w.stageOnly = on
 }
 
 // NewRedisWorker creates a worker that drains the Redis write queue.
@@ -316,6 +329,14 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 
 	spans := convertRecords(records)
 
+	// Staging mode: cheap append to spans_staging and return. The StagingFlusher
+	// picks these up per complete trace and does accumulation + classification +
+	// indexed storage off the hot path.
+	if w.stageOnly {
+		w.stageSpans(ctx, spans)
+		return
+	}
+
 	// Feed every span to the accumulator for in-memory aggregation, including
 	// boring spans that will not reach SQLite.
 	if w.accumulator != nil {
@@ -388,13 +409,57 @@ func (w *RedisWorker) processBatch(ctx context.Context, records []model.SpanReco
 	}
 }
 
+// stageSpans appends every span to spans_staging with the same bounded retry as
+// the inline path. This is the cheap Redis-draining write; the StagingFlusher
+// does the expensive classification + indexed storage later.
+func (w *RedisWorker) stageSpans(ctx context.Context, spans []repository.Span) {
+	ctx, span := tracer.Start(ctx, "redis_worker.stage_spans")
+	defer span.End()
+	span.SetAttributes(attribute.Int("batch.size", len(spans)))
+
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := w.repo.InsertSpansStaging(ctx, spans); err != nil {
+			lastErr = err
+			backoff := time.Duration(attempt*attempt) * 500 * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+			continue
+		}
+		lastErr = nil
+		break
+	}
+	if lastErr != nil {
+		span.RecordError(lastErr)
+		span.SetStatus(codes.Error, lastErr.Error())
+		w.logger.Error("redis worker: staging insert failed after retries", "count", len(spans), "error", lastErr)
+		w.metrics.mu.Lock()
+		w.metrics.ErrorCount += int64(len(spans))
+		w.metrics.mu.Unlock()
+		return
+	}
+	w.metrics.mu.Lock()
+	w.metrics.ProcessedCount += int64(len(spans))
+	w.metrics.mu.Unlock()
+}
+
 // classifyForStorage builds the set of spans to write to SQLite.
 // All spans in error/slow traces are included unconditionally. Spans in
 // verbose-mode projects bypass boring classification. Remaining boring traces
 // are sampled whole at the per-project ratio — the die is rolled once per
 // trace_id, and either all spans in that trace are kept or none are.
 func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.Span {
-	if w.cfg.SlowThresholdUs <= 0 {
+	return classifySpansForStorage(spans, w.cfg.SlowThresholdUs, w.boringPolicy, w.floor)
+}
+
+// classifySpansForStorage builds the set of spans to persist from a set of spans
+// that ideally covers whole traces. Extracted so the staging flusher can reuse
+// the exact same trace-level classification the inline worker path uses.
+func classifySpansForStorage(spans []repository.Span, slowThresholdUs int64, boringPolicy BoringPolicyReader, floor *sampling.MinuteFloor) []repository.Span {
+	if slowThresholdUs <= 0 {
 		return spans
 	}
 
@@ -402,10 +467,10 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 
 	// Determine which projects are in verbose mode (record all spans).
 	verboseProject := make(map[int64]bool, 2)
-	if w.boringPolicy != nil {
+	if boringPolicy != nil {
 		for _, s := range spans {
 			if _, seen := verboseProject[s.ProjectID]; !seen {
-				until := w.boringPolicy.VerboseUntil(s.ProjectID)
+				until := boringPolicy.VerboseUntil(s.ProjectID)
 				verboseProject[s.ProjectID] = !until.IsZero() && now.Before(until)
 			}
 		}
@@ -414,7 +479,7 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 	// First pass: find trace IDs that are definitely interesting.
 	interestingTraces := make(map[string]struct{}, len(spans))
 	for _, s := range spans {
-		if verboseProject[s.ProjectID] || s.Status == "error" || s.DurationUs > w.cfg.SlowThresholdUs {
+		if verboseProject[s.ProjectID] || s.Status == "error" || s.DurationUs > slowThresholdUs {
 			interestingTraces[s.TraceID] = struct{}{}
 		}
 	}
@@ -443,7 +508,7 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 	}
 
 	// Sample whole boring traces per project policy.
-	if w.boringPolicy == nil || len(boringTraceOrder) == 0 {
+	if boringPolicy == nil || len(boringTraceOrder) == 0 {
 		return result
 	}
 	ratioCache := make(map[int64]int, 2)
@@ -452,7 +517,7 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 		bt := boringTraceMap[traceID]
 		ratio, ok := ratioCache[bt.projectID]
 		if !ok {
-			ratio = w.boringPolicy.SampleRatio(bt.projectID)
+			ratio = boringPolicy.SampleRatio(bt.projectID)
 			ratioCache[bt.projectID] = ratio
 		}
 
@@ -468,14 +533,14 @@ func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.S
 		// The per-(project, operation) minute floor rescues a minimum number of
 		// boring traces each minute so quiet operations never vanish entirely —
 		// even when ratio == 0 would otherwise drop every boring trace.
-		if w.floor != nil {
+		if floor != nil {
 			min, ok := minCache[bt.projectID]
 			if !ok {
-				min = w.boringPolicy.MinTracesPerMinute(bt.projectID)
+				min = boringPolicy.MinTracesPerMinute(bt.projectID)
 				minCache[bt.projectID] = min
 			}
 			op, minute := boringTraceKey(bt.spans)
-			if w.floor.ShouldKeep(bt.projectID, op, minute, min, ratioKeep) {
+			if floor.ShouldKeep(bt.projectID, op, minute, min, ratioKeep) {
 				result = append(result, bt.spans...)
 			}
 			continue

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -33,6 +33,17 @@ func (m *mockRepo) InsertSpans(_ context.Context, spans []repository.Span) error
 	return nil
 }
 
+func (m *mockRepo) InsertSpansStaging(_ context.Context, spans []repository.Span) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.err != nil {
+		return m.err
+	}
+	m.spans = append(m.spans, spans...)
+	return nil
+}
+
 func (m *mockRepo) InsertPromptRecords(_ context.Context, _ []repository.PromptRecord) error {
 	return nil
 }


### PR DESCRIPTION
Shape 2 for the recurring writer backup — decouple the fast Redis drain from the expensive indexed write, so the queue never backs up to the `noeviction` cap (which is what drops logs). **Feature-flagged off by default**; to be validated on staging before prod.

## How it works
- **Migration 029** — `spans_staging`: a rowid table with a **single `trace_id` index**.
- **Redis worker staging mode** (`SetStagingMode`) — just appends consumed spans to `spans_staging` (cheap, one index) and returns. The Redis drain stays fast regardless of indexed-write cost, so the queue stops backing up.
- **`StagingFlusher`** (background) — finds ready traces (oldest staged span older than the window), gathers each **complete** trace via the `trace_id` index, feeds all spans to the accumulator, classifies whole traces (reusing the extracted `classifySpansForStorage`), **atomically** moves only interesting traces into the indexed `spans` table (preserving `ingested_at`) and deletes the processed rows.

## Bounded-growth guarantees (the staging-cleanup requirement)
1. Atomic move-and-delete in one tx — no row processed twice or leaked.
2. Flush drains **all** ready traces each cycle → steady-state staging < one window of data.
3. **Hard-age GC backstop** — `DeleteStagingOlderThan(MaxAge)` drops anything older than `MaxAge` unconditionally, so staging can never grow without bound; it sheds the *oldest* under overload rather than capping everything (incl. logs).
4. Staging depth logged each GC cycle.

## Safety / rollout
- `SPANBARN_SPAN_STAGING_ENABLED` (default **false**) — inline path + its tests unchanged.
- Tunables: `SPANBARN_TRACE_BUFFER_WINDOW_SECONDS` (90), `SPANBARN_STAGING_MAX_AGE_SECONDS` (900).
- Plan: merge (flag off, no behavior change) → enable on **staging** with real traffic → watch staging drain, aggregates stay correct, `spans_staging` stays bounded, GC holds → then enable in prod.

## Tests
`TestStagingFlushCycle`, `TestStagingGCBackstop` (repo), `TestStagingFlusherFlushOnce`, `TestStagingFlusherGCUsesMaxAge` (worker); full suite green (15 pkg).