### PR TITLE
chore(k8s): enable span staging fleet-wide (validated on staging)

### DIFF
--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -10,6 +10,11 @@ data:
   SPANBARN_RETENTION_ERROR_DAYS: "30"
   SPANBARN_RETENTION_AGGREGATED_DAYS: "90"
   SPANBARN_AGGREGATION_INTERVAL: "5m"
+  # Span staging (tail sampling): the writer appends consumed spans to
+  # spans_staging (cheap) and a background flusher classifies whole traces off
+  # the hot path, so the Redis write-queue never backs up to the cap. Validated
+  # on staging 2026-07-09. Window/GC use code defaults (90s / 900s).
+  SPANBARN_SPAN_STAGING_ENABLED: "1"
   SPANBARN_BUGBARN_ENDPOINT: "https://bugbarn.wiebe.xyz"
   SPANBARN_SELF_ENDPOINT: "http://spanbarn-ingest:8080"
   SPANBARN_REDIS_URL: "redis://spanbarn-redis:6379"


### PR DESCRIPTION
Turns on SPANBARN_SPAN_STAGING_ENABLED in the base configmap after a successful staging soak: Redis write-queue drains to 0, spans_staging bounded to ~one 90s window, interesting spans stored, aggregates persist. Delivered by #121 (feature-flagged); this flips it on. Reaches the writer via the existing envFrom spanbarn-config.