### PR TITLE
feat(writer): instrument write scheduler to diagnose the recurring wedge

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -696,6 +696,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	startSelfMetrics(ctx, cfg, &wg, writerSelfRec, logger)
 
 	scheduler := writescheduler.New()
+	scheduler.SetLogger(logger)
 	repo.SetWriteScheduler(scheduler)
 
 	boringPolicy := worker.NewCachedBoringPolicy(repo, 30*time.Second)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -3,10 +3,32 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/wiebe-xyz/spanbarn/internal/writescheduler"
 )
+
+// writeOpLabel names the repository method that submitted a write, captured from
+// the call stack, so the write scheduler's tracing and wedge diagnostics can say
+// which operation is running/stuck without threading a label through every call.
+// skip=0 → writeOpLabel, 1 → execHigh/execLow, 2 → the repo method.
+func writeOpLabel() string {
+	pc, _, _, ok := runtime.Caller(2)
+	if !ok {
+		return "unknown"
+	}
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return "unknown"
+	}
+	name := f.Name() // e.g. .../internal/repository.(*Repository).InsertSpansStaging
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	return name
+}
 
 const DefaultQueryTimeout = 30 * time.Second
 
@@ -77,7 +99,7 @@ func (r *Repository) execHigh(fn func() error) error {
 	if r.scheduler == nil {
 		return fn()
 	}
-	return r.scheduler.Submit(context.Background(), writescheduler.High, fn)
+	return r.scheduler.Submit(context.Background(), writescheduler.High, writeOpLabel(), fn)
 }
 
 // execLow submits fn as a low-priority write (background ingest, retention).
@@ -85,7 +107,7 @@ func (r *Repository) execLow(fn func() error) error {
 	if r.scheduler == nil {
 		return fn()
 	}
-	return r.scheduler.Submit(context.Background(), writescheduler.Low, fn)
+	return r.scheduler.Submit(context.Background(), writescheduler.Low, writeOpLabel(), fn)
 }
 
 // execLowAffecting runs a single low-priority write statement and returns the

--- a/internal/writescheduler/scheduler.go
+++ b/internal/writescheduler/scheduler.go
@@ -13,9 +13,28 @@
 // admin write queued while a span-insert transaction is running waits at most for
 // that one transaction to finish, then runs next — regardless of how many
 // low-priority jobs are pending.
+//
+// The scheduler is also the single instrumentation point for diagnosing writer
+// "wedges": because every write runs as one fn on one goroutine, it tracks the
+// in-flight job (label + start time), traces each job, and — when a job runs
+// longer than stuckThreshold — logs the culprit and dumps all goroutine stacks so
+// we can see exactly what is holding the connection (a slow query, a checkpoint,
+// Litestream, a syscall).
 package writescheduler
 
-import "context"
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+var tracer = otel.Tracer("spanbarn/writescheduler")
 
 // Priority controls which queue a write job enters.
 type Priority int
@@ -28,6 +47,7 @@ const (
 type job struct {
 	fn       func() error
 	resultCh chan error
+	label    string
 }
 
 // Scheduler serialises DB writes through a single goroutine with two priority
@@ -36,6 +56,18 @@ type job struct {
 type Scheduler struct {
 	highPri chan job
 	lowPri  chan job
+	logger  *slog.Logger
+
+	// slowThreshold: a completed job slower than this is logged (WARN).
+	// stuckThreshold: an in-flight job older than this triggers the wedge dump.
+	slowThreshold  time.Duration
+	stuckThreshold time.Duration
+
+	mu       sync.Mutex
+	curLabel string
+	curStart time.Time
+	curSeq   uint64 // increments per job so the watchdog dumps once per stuck job
+	dumpedAt uint64
 }
 
 // New creates a Scheduler with buffered channels. The buffers absorb short
@@ -43,16 +75,27 @@ type Scheduler struct {
 // still processes one job at a time.
 func New() *Scheduler {
 	return &Scheduler{
-		highPri: make(chan job, 64),
-		lowPri:  make(chan job, 512),
+		highPri:        make(chan job, 64),
+		lowPri:         make(chan job, 512),
+		logger:         slog.Default(),
+		slowThreshold:  2 * time.Second,
+		stuckThreshold: 30 * time.Second,
 	}
 }
 
-// Submit enqueues fn at the given priority and blocks until fn returns.
-// Returns ctx.Err() if the context is cancelled while waiting to enqueue or
-// waiting for the result. An in-flight job cannot be cancelled.
-func (s *Scheduler) Submit(ctx context.Context, p Priority, fn func() error) error {
-	j := job{fn: fn, resultCh: make(chan error, 1)}
+// SetLogger sets the logger used for slow-job and wedge diagnostics.
+func (s *Scheduler) SetLogger(l *slog.Logger) {
+	if l != nil {
+		s.logger = l
+	}
+}
+
+// Submit enqueues fn at the given priority and blocks until fn returns. label
+// names the operation (for tracing and wedge diagnostics). Returns ctx.Err() if
+// the context is cancelled while waiting to enqueue or waiting for the result.
+// An in-flight job cannot be cancelled.
+func (s *Scheduler) Submit(ctx context.Context, p Priority, label string, fn func() error) error {
+	j := job{fn: fn, resultCh: make(chan error, 1), label: label}
 	ch := s.lowPri
 	if p == High {
 		ch = s.highPri
@@ -76,20 +119,96 @@ func (s *Scheduler) Submit(ctx context.Context, p Priority, fn func() error) err
 // Run is the scheduler loop. It must run in a dedicated goroutine and is the
 // only goroutine that executes DB writes. Exits when ctx is cancelled.
 func (s *Scheduler) Run(ctx context.Context) {
+	go s.watchdog(ctx)
 	for {
 		// Always drain the high-priority channel before touching low-priority.
 		select {
 		case j := <-s.highPri:
-			j.resultCh <- j.fn()
+			s.execute(j)
 		default:
 			select {
 			case j := <-s.highPri:
-				j.resultCh <- j.fn()
+				s.execute(j)
 			case j := <-s.lowPri:
-				j.resultCh <- j.fn()
+				s.execute(j)
 			case <-ctx.Done():
 				return
 			}
+		}
+	}
+}
+
+// execute runs one job, recording it as the in-flight job and tracing it so the
+// watchdog and SpanBarn's own telemetry can see how long each write takes.
+func (s *Scheduler) execute(j job) {
+	label := j.label
+	if label == "" {
+		label = "unknown"
+	}
+	_, span := tracer.Start(context.Background(), "writescheduler.job")
+	span.SetAttributes(attribute.String("write.op", label))
+
+	start := time.Now()
+	s.mu.Lock()
+	s.curLabel = label
+	s.curStart = start
+	s.curSeq++
+	s.mu.Unlock()
+
+	err := j.fn()
+	dur := time.Since(start)
+
+	s.mu.Lock()
+	s.curLabel = ""
+	s.mu.Unlock()
+
+	span.SetAttributes(attribute.Int64("write.duration_ms", dur.Milliseconds()))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+
+	if dur >= s.slowThreshold {
+		s.logger.Warn("write scheduler: slow write", "op", label, "duration_ms", dur.Milliseconds())
+	}
+	j.resultCh <- err
+}
+
+// watchdog periodically checks the in-flight job. If one has been running longer
+// than stuckThreshold, it logs the culprit and dumps every goroutine's stack
+// once — the direct diagnostic for a writer wedge (what is holding the single
+// connection). It dumps at most once per stuck job.
+func (s *Scheduler) watchdog(ctx context.Context) {
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.mu.Lock()
+			label, start, seq, dumped := s.curLabel, s.curStart, s.curSeq, s.dumpedAt
+			s.mu.Unlock()
+			if label == "" || start.IsZero() {
+				continue
+			}
+			age := time.Since(start)
+			if age < s.stuckThreshold || seq == dumped {
+				continue
+			}
+			buf := make([]byte, 1<<20) // 1 MiB
+			n := runtime.Stack(buf, true)
+			s.logger.Error("write scheduler: WEDGE — in-flight write stuck; dumping goroutines",
+				"op", label,
+				"stuck_seconds", int(age.Seconds()),
+				"highpri_queued", len(s.highPri),
+				"lowpri_queued", len(s.lowPri),
+				"goroutine_dump", string(buf[:n]),
+			)
+			s.mu.Lock()
+			s.dumpedAt = seq
+			s.mu.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
The writer periodically seizes the single SQLite connection and stops (DB mtime freezes, ingest OOMs), cleared only by a restart — but we've never seen *what* holds the lock. Every write funnels through the scheduler's one goroutine, so it's the lens: **label** each job by its repo method, **trace** it (writescheduler.job spans into SpanBarn's own dogfood), **log** writes >2s, and a **watchdog dumps every goroutine's stack when a job exceeds 30s** — direct evidence of the wedge cause. Once per stuck job; no new endpoints.