### PR TITLE
fix(retention): per-project metrics/rollups delete (seek the existing index)

### DIFF
--- a/internal/repository/repo_metric_rollups.go
+++ b/internal/repository/repo_metric_rollups.go
@@ -183,15 +183,7 @@ func (r *Repository) QueryProjectRollups(ctx context.Context, projectID int64, f
 // DeleteMetricRollupsOlderThan removes rollup buckets older than cutoff, in
 // bounded chunks so the write lock is never held long enough to block ingest.
 func (r *Repository) DeleteMetricRollupsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.batchedDelete(ctx, func() (int64, error) {
-		res, e := r.db.ExecContext(ctx,
-			"DELETE FROM metric_rollups WHERE rowid IN (SELECT rowid FROM metric_rollups WHERE bucket < ? LIMIT ?)",
-			cutoff, retentionDeleteBatch,
-		)
-		if e != nil {
-			return 0, e
-		}
-		n, _ := res.RowsAffected()
-		return n, nil
-	})
+	// Per project so each batch seeks idx_metric_rollups_project_bucket instead
+	// of full-scanning the table (bucket has no standalone index).
+	return r.deleteOlderThanPerProject(ctx, "metric_rollups", "bucket", cutoff)
 }

--- a/internal/repository/repo_metrics.go
+++ b/internal/repository/repo_metrics.go
@@ -201,16 +201,9 @@ func (r *Repository) QueryMetricSeries(ctx context.Context, f MetricFilter) ([]M
 // in bounded chunks so a large backlog never holds the write lock long enough to
 // block ingest (an unbatched DELETE here previously stalled writes for minutes).
 func (r *Repository) DeleteMetricsOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	return r.batchedDelete(ctx, func() (int64, error) {
-		res, e := r.db.ExecContext(ctx,
-			`DELETE FROM metrics WHERE rowid IN (SELECT rowid FROM metrics WHERE ingested_at < ? LIMIT ?)`,
-			cutoff, retentionDeleteBatch)
-		if e != nil {
-			return 0, e
-		}
-		n, _ := res.RowsAffected()
-		return n, nil
-	})
+	// Per project so each batch seeks idx_metrics_project_ingested instead of
+	// full-scanning the (large) metrics table — see deleteOlderThanPerProject.
+	return r.deleteOlderThanPerProject(ctx, "metrics", "ingested_at", cutoff)
 }
 
 // MarshalMetricExtra serialises the Extra field of a MetricRow for JSON responses.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -149,6 +149,65 @@ func (r *Repository) execHighExpectingRows(query string, args ...any) error {
 // guarantees the checkpoint a contention-free window.
 func (r *Repository) SetDeleteBatchYield(d time.Duration) { r.deleteBatchYield = d }
 
+// deleteOlderThanPerProject deletes rows older than cutoff from a project-keyed
+// table one project at a time. A global `WHERE timeCol < ?` cannot use these
+// tables' indexes (they all lead with project_id) and so full-scans the whole
+// table every batch — on a large table that holds the single write connection
+// for minutes and wedges the writer (observed: DeleteMetricsOlderThan at 469s).
+// Adding `project_id = ?` lets each bounded DELETE SEEK the (project_id, timeCol)
+// index instead.
+//
+// The distinct project_ids are enumerated with a loose-index-scan (each step
+// seeks the next project_id via the leading index column), so it is cheap even
+// on a huge table and — unlike reading the projects table — also covers rows of
+// deleted projects. table and timeCol are trusted internal constants.
+func (r *Repository) deleteOlderThanPerProject(ctx context.Context, table, timeCol string, cutoff time.Time) (int64, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		WITH RECURSIVE dp(pid) AS (
+			SELECT MIN(project_id) FROM `+table+`
+			UNION ALL
+			SELECT (SELECT MIN(project_id) FROM `+table+` WHERE project_id > dp.pid)
+			FROM dp WHERE dp.pid IS NOT NULL
+		)
+		SELECT pid FROM dp WHERE pid IS NOT NULL`)
+	if err != nil {
+		return 0, err
+	}
+	var pids []int64
+	for rows.Next() {
+		var pid int64
+		if err := rows.Scan(&pid); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		pids = append(pids, pid)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	q := "DELETE FROM " + table + " WHERE rowid IN (SELECT rowid FROM " + table +
+		" WHERE project_id = ? AND " + timeCol + " < ? LIMIT ?)"
+	var total int64
+	for _, pid := range pids {
+		pid := pid
+		n, err := r.batchedDelete(ctx, func() (int64, error) {
+			res, e := r.db.ExecContext(ctx, q, pid, cutoff, retentionDeleteBatch)
+			if e != nil {
+				return 0, e
+			}
+			m, _ := res.RowsAffected()
+			return m, nil
+		})
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+	return total, nil
+}
+
 // batchedDelete repeatedly runs exec — a single retentionDeleteBatch-bounded
 // DELETE returning the rows it affected — through the low-priority write queue
 // until a batch deletes fewer than retentionDeleteBatch rows (i.e. the tail is


### PR DESCRIPTION
Wedge cause #2, caught by the #124 instrumentation: `DeleteMetricsOlderThan` held the write connection **469 s**. Root cause is **not** the dropped spans index — `metrics`/`metric_rollups` only have `project_id`-leading indexes, so a global `WHERE ingested_at</bucket < ?` can't seek and **full-scans** the huge table every batch. Fix (per your suggestion — use the existing index): `deleteOlderThanPerProject` enumerates project_ids via a loose-index-scan and deletes per-project with `project_id = ? AND timeCol < ?` → **SEARCH not SCAN** (verified on prod EXPLAIN). No new indexes. Logs delete (correlated subqueries) left as a follow-up.