### PR TITLE
fix(retention): logs delete per-project (completes the wedge fix)

### DIFF
--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -227,31 +227,48 @@ func (r *Repository) LogHistogram(ctx context.Context, f LogFilter, bucketSecs i
 // DeleteLogsOlderThan removes log records ingested before cutoff, skipping logs
 // whose trace_id is pinned or appears in recently-sampled error_samples.
 func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error) {
-	return r.batchedDelete(ctx, func() (int64, error) {
-		res, e := r.db.ExecContext(ctx, `
-			DELETE FROM logs WHERE rowid IN (
-			    SELECT rowid FROM logs
-			    WHERE ingested_at < ?
-			    AND (trace_id IS NULL
-			         OR (trace_id NOT IN (
-			                 SELECT trace_id FROM pinned_traces
-			                 WHERE project_id = logs.project_id
-			             )
-			             AND trace_id NOT IN (
-			                 SELECT DISTINCT trace_id FROM error_samples
-			                 WHERE sampled_at > ?
-			             )
-			         )
-			    )
-			    LIMIT ?)`,
-			cutoff, errorLogCutoff, retentionDeleteBatch,
-		)
-		if e != nil {
-			return 0, e
+	// Per project so each batch seeks idx_logs_project_ingested instead of
+	// full-scanning the logs table on a global `WHERE ingested_at < ?` (logs has
+	// no standalone ingested_at index). The correlated subqueries still filter on
+	// logs.project_id, which is the fixed project within each pass.
+	pids, err := r.distinctProjectIDs(ctx, "logs")
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, pid := range pids {
+		pid := pid
+		n, err := r.batchedDelete(ctx, func() (int64, error) {
+			res, e := r.db.ExecContext(ctx, `
+				DELETE FROM logs WHERE rowid IN (
+				    SELECT rowid FROM logs
+				    WHERE project_id = ? AND ingested_at < ?
+				    AND (trace_id IS NULL
+				         OR (trace_id NOT IN (
+				                 SELECT trace_id FROM pinned_traces
+				                 WHERE project_id = logs.project_id
+				             )
+				             AND trace_id NOT IN (
+				                 SELECT DISTINCT trace_id FROM error_samples
+				                 WHERE sampled_at > ?
+				             )
+				         )
+				    )
+				    LIMIT ?)`,
+				pid, cutoff, errorLogCutoff, retentionDeleteBatch,
+			)
+			if e != nil {
+				return 0, e
+			}
+			n, _ := res.RowsAffected()
+			return n, nil
+		})
+		total += n
+		if err != nil {
+			return total, err
 		}
-		n, _ := res.RowsAffected()
-		return n, nil
-	})
+	}
+	return total, nil
 }
 
 // --- Pinned Traces ---

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -149,6 +149,35 @@ func (r *Repository) execHighExpectingRows(query string, args ...any) error {
 // guarantees the checkpoint a contention-free window.
 func (r *Repository) SetDeleteBatchYield(d time.Duration) { r.deleteBatchYield = d }
 
+// distinctProjectIDs enumerates the distinct project_ids present in a
+// project-keyed table using a loose-index-scan: each step seeks the next
+// project_id via the leading index column, so it is cheap even on a huge table
+// and — unlike reading the projects table — also covers rows of deleted
+// projects. table is a trusted internal constant, never user input.
+func (r *Repository) distinctProjectIDs(ctx context.Context, table string) ([]int64, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		WITH RECURSIVE dp(pid) AS (
+			SELECT MIN(project_id) FROM `+table+`
+			UNION ALL
+			SELECT (SELECT MIN(project_id) FROM `+table+` WHERE project_id > dp.pid)
+			FROM dp WHERE dp.pid IS NOT NULL
+		)
+		SELECT pid FROM dp WHERE pid IS NOT NULL`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var pids []int64
+	for rows.Next() {
+		var pid int64
+		if err := rows.Scan(&pid); err != nil {
+			return nil, err
+		}
+		pids = append(pids, pid)
+	}
+	return pids, rows.Err()
+}
+
 // deleteOlderThanPerProject deletes rows older than cutoff from a project-keyed
 // table one project at a time. A global `WHERE timeCol < ?` cannot use these
 // tables' indexes (they all lead with project_id) and so full-scans the whole
@@ -162,28 +191,8 @@ func (r *Repository) SetDeleteBatchYield(d time.Duration) { r.deleteBatchYield =
 // on a huge table and — unlike reading the projects table — also covers rows of
 // deleted projects. table and timeCol are trusted internal constants.
 func (r *Repository) deleteOlderThanPerProject(ctx context.Context, table, timeCol string, cutoff time.Time) (int64, error) {
-	rows, err := r.db.QueryContext(ctx, `
-		WITH RECURSIVE dp(pid) AS (
-			SELECT MIN(project_id) FROM `+table+`
-			UNION ALL
-			SELECT (SELECT MIN(project_id) FROM `+table+` WHERE project_id > dp.pid)
-			FROM dp WHERE dp.pid IS NOT NULL
-		)
-		SELECT pid FROM dp WHERE pid IS NOT NULL`)
+	pids, err := r.distinctProjectIDs(ctx, table)
 	if err != nil {
-		return 0, err
-	}
-	var pids []int64
-	for rows.Next() {
-		var pid int64
-		if err := rows.Scan(&pid); err != nil {
-			rows.Close()
-			return 0, err
-		}
-		pids = append(pids, pid)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
Completes the retention wedge fix from #126. `DeleteLogsOlderThan` had the same full-scan shape as metrics — global `WHERE ingested_at < ?` can't use the `project_id`-leading logs indexes. Now per-project via the shared `distinctProjectIDs` loose-index-scan + `project_id = ? AND ingested_at < ?` → **SEARCH not SCAN** (verified on prod EXPLAIN). Correlated pinned/error-sample subqueries preserved. All three offending retention deletes (metrics, metric_rollups, logs) now seek; aggregates already did.