### PR TITLE
fix(retention): log-delete exemptions seek error_samples instead of full-scanning it

### DIFF
--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -229,8 +229,16 @@ func (r *Repository) LogHistogram(ctx context.Context, f LogFilter, bucketSecs i
 func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error) {
 	// Per project so each batch seeks idx_logs_project_ingested instead of
 	// full-scanning the logs table on a global `WHERE ingested_at < ?` (logs has
-	// no standalone ingested_at index). The correlated subqueries still filter on
-	// logs.project_id, which is the fixed project within each pass.
+	// no standalone ingested_at index).
+	//
+	// The exemptions use NOT EXISTS (indexed seek per candidate row) rather than
+	// `trace_id NOT IN (SELECT ... FROM error_samples ...)`. The NOT IN form
+	// materialised the whole error_samples table (270k+ rows, a full scan with a
+	// per-row sampled_at fetch) on EVERY batch of EVERY project — a single batch
+	// took 90s+ and held the one write slot the whole time, wedging the writer.
+	// NOT EXISTS seeks idx_error_samples_trace by the candidate row's trace_id, so
+	// the cost scales with the small logs set, not the large error_samples table.
+	// It is also NULL-safe (NOT IN deletes nothing if the subquery yields a NULL).
 	pids, err := r.distinctProjectIDs(ctx, "logs")
 	if err != nil {
 		return 0, err
@@ -244,13 +252,15 @@ func (r *Repository) DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCu
 				    SELECT rowid FROM logs
 				    WHERE project_id = ? AND ingested_at < ?
 				    AND (trace_id IS NULL
-				         OR (trace_id NOT IN (
-				                 SELECT trace_id FROM pinned_traces
-				                 WHERE project_id = logs.project_id
+				         OR (NOT EXISTS (
+				                 SELECT 1 FROM pinned_traces p
+				                 WHERE p.project_id = logs.project_id
+				                   AND p.trace_id = logs.trace_id
 				             )
-				             AND trace_id NOT IN (
-				                 SELECT DISTINCT trace_id FROM error_samples
-				                 WHERE sampled_at > ?
+				             AND NOT EXISTS (
+				                 SELECT 1 FROM error_samples e
+				                 WHERE e.trace_id = logs.trace_id
+				                   AND e.sampled_at > ?
 				             )
 				         )
 				    )

--- a/internal/repository/repo_spans_staging.go
+++ b/internal/repository/repo_spans_staging.go
@@ -150,16 +150,22 @@ func (r *Repository) CommitStagingFlush(ctx context.Context, traceIDs []string, 
 // spans_staging can never grow without bound if the flush stalls. It sheds the
 // oldest rows (graceful degradation) rather than letting the table grow.
 func (r *Repository) DeleteStagingOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
-	var deleted int64
-	err := r.execLow(func() error {
-		res, e := r.db.ExecContext(ctx, `DELETE FROM spans_staging WHERE ingested_at < ?`, cutoff.UTC())
+	// Batched so a large backlog (e.g. rows accumulated across a restart) is never
+	// deleted in one statement that holds the single write connection for tens of
+	// seconds and wedges the writer. Rows are inserted in ~ingested_at order
+	// (monotonic rowid), so each LIMIT batch's scan hits the oldest rows first and
+	// returns fast even without a standalone ingested_at index on staging.
+	c := cutoff.UTC()
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			`DELETE FROM spans_staging WHERE rowid IN (SELECT rowid FROM spans_staging WHERE ingested_at < ? LIMIT ?)`,
+			c, retentionDeleteBatch)
 		if e != nil {
-			return e
+			return 0, e
 		}
-		deleted, _ = res.RowsAffected()
-		return nil
+		n, _ := res.RowsAffected()
+		return n, nil
 	})
-	return deleted, err
 }
 
 // CountStagingRows returns the current staging depth for observability.


### PR DESCRIPTION
## Root cause (production writer wedge)

The writer periodically froze — both redis write-queues flat, ingest dropping at the redis cap. A goroutine dump caught the single write-scheduler slot held for 30s+ by a `DeleteLogsOlderThan` batch churning btree pages, with `InsertSpansStaging` and every other write blocked in `Submit` behind it. That's the freeze: the RedisWorker can't consume because its own staging write is stuck behind the delete.

### Why the delete was slow
`DeleteLogsOlderThan` excluded pinned and error-sampled traces with:
```sql
trace_id NOT IN (SELECT DISTINCT trace_id FROM error_samples WHERE sampled_at > ?)
```
That's a `LIST SUBQUERY` — SQLite materialises it by scanning the **entire error_samples table (270,497 rows)** with a per-row `sampled_at` fetch, **on every batch of every project**. The `logs` table is only ~21k rows, so the cost is completely inverted. Profiled read-only on prod: a single `LIMIT 1000` batch **timed out at >90s**.

### Fix
Rewrite both exemptions as `NOT EXISTS` correlated subqueries that **seek** `idx_error_samples_trace` (and the `pinned_traces` PK) by the candidate row's `trace_id`:
```
EXPLAIN: SEARCH e USING INDEX idx_error_samples_trace (trace_id=?)
```
The same batch returns **sub-second** read-only. Cost now scales with the small logs set, not the large error_samples table. `NOT EXISTS` is also NULL-safe — the old `NOT IN` silently deletes nothing if the subquery ever yields a NULL `trace_id`.

## Semantics
Unchanged. `TestDeleteLogsOlderThan_Basic`, `_SkipsPinned`, `_SkipsErrorSampled` all pass — pinned and recently-error-sampled trace logs are still retained.

## Follow-ups (not in this PR)
- Ingest should preempt retention in the scheduler (defence in depth; resolves itself once deletes are fast).
- Remove the checkpoint-skip gating that lets the WAL bloat while the backlog is deep.
- One-time VACUUM to compact the fragmented 3.8GB DB.