### PR TITLE
perf(retention): stamp boring spans with expires_at (indexed cleanup, no scan)

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -707,7 +707,10 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 
 	rw := worker.NewRedisWorker(writeQueue, &workerRepoAdapter{repo: repo}, logger)
 	rw.SetAccumulator(accumulator)
-	rw.SetConfig(worker.WorkerConfig{SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000})
+	rw.SetConfig(worker.WorkerConfig{
+		SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000,
+		BoringRetention: time.Duration(cfg.Retention.BoringMinutes) * time.Minute,
+	})
 	rw.SetBoringPolicy(boringPolicy)
 	rw.SetMinuteFloor(minuteFloor)
 	rw.SetStagingMode(cfg.SpanStagingEnabled)
@@ -724,6 +727,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 			Window:          time.Duration(cfg.TraceBufferWindowSeconds) * time.Second,
 			MaxAge:          time.Duration(cfg.StagingMaxAgeSeconds) * time.Second,
 			SlowThresholdUs: int64(cfg.SlowThresholdMS) * 1000,
+			BoringRetention: time.Duration(cfg.Retention.BoringMinutes) * time.Minute,
 		}, logger)
 		flusher.SetAccumulator(accumulator)
 		flusher.SetBoringPolicy(boringPolicy)

--- a/internal/repository/migrations/030_span_expires_at.go
+++ b/internal/repository/migrations/030_span_expires_at.go
@@ -1,0 +1,49 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up030, down030)
+}
+
+// up030 adds a nullable expires_at stamp to spans so the boring-span cleanup is a
+// trivial indexed range delete instead of a status/duration classification scan.
+//
+// The staging flush stamps expires_at on the spans it stores: sampled-boring spans
+// get ingested_at + the boring retention window (short); interesting spans (kept
+// full until the aggregate-then-delete pass) are left NULL. Cleanup then runs
+// `DELETE FROM spans WHERE expires_at < now`, seeking the partial index below —
+// no scan of the whole table fetching duration_us per row (which had grown to a
+// 30s+ write-slot wedge). Pre-existing rows keep expires_at NULL and drain via
+// the normal aggregate-then-delete path, so no backfill is needed.
+//
+// ADD COLUMN with a NULL default is a metadata-only change (no row rewrite), and
+// the index is partial (only stamped rows), so both are cheap even mid-flight.
+func up030(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`ALTER TABLE spans ADD COLUMN expires_at DATETIME`,
+		`CREATE INDEX IF NOT EXISTS idx_spans_expires ON spans(expires_at) WHERE expires_at IS NOT NULL`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down030(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`DROP INDEX IF EXISTS idx_spans_expires`,
+		`ALTER TABLE spans DROP COLUMN expires_at`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -48,6 +48,10 @@ type Span struct {
 	Attributes   string    `json:"attributes"`
 	Events       string    `json:"events"`
 	IngestedAt   time.Time `json:"ingestedAt"`
+	// ExpiresAt, when non-nil, is the time after which the boring-span cleanup may
+	// delete this span (set by classification for sampled-boring spans). Interesting
+	// spans leave it nil and are removed by the aggregate-then-delete pass instead.
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 }
 
 type Aggregate struct {

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -24,8 +24,8 @@ func (r *Repository) InsertSpansContext(ctx context.Context, spans []Span) error
 		defer tx.Rollback()
 
 		stmt, err := tx.PrepareContext(ctx, `INSERT INTO spans
-			(project_id, trace_id, span_id, parent_span_id, name, service, resource, kind, status, start_time_us, duration_us, attributes, events)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+			(project_id, trace_id, span_id, parent_span_id, name, service, resource, kind, status, start_time_us, duration_us, attributes, events, expires_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 		if err != nil {
 			return err
 		}
@@ -39,7 +39,7 @@ func (r *Repository) InsertSpansContext(ctx context.Context, spans []Span) error
 			if _, err := stmt.ExecContext(ctx,
 				s.ProjectID, s.TraceID, s.SpanID, parentID,
 				s.Name, s.Service, s.Resource, s.Kind, s.Status,
-				s.StartTimeUs, s.DurationUs, s.Attributes, s.Events,
+				s.StartTimeUs, s.DurationUs, s.Attributes, s.Events, s.ExpiresAt,
 			); err != nil {
 				return err
 			}
@@ -197,18 +197,22 @@ func (r *Repository) DeleteSpansOlderThan(cutoff time.Time) (int64, error) {
 	return r.execLowAffecting("DELETE FROM spans WHERE ingested_at < ?", cutoff)
 }
 
-// DeleteBoringSpansOlderThan removes non-error, fast spans ingested before cutoff.
-// Uses idx_spans_ingested (ingested_at) for the range scan. The delete is batched
-// (retentionDeleteBatch rows per statement) so a large purge never holds the
-// write lock long enough to block the WAL checkpoint or read-only queries.
-func (r *Repository) DeleteBoringSpansOlderThan(ctx context.Context, cutoff time.Time, slowThresholdUs int64) (int64, error) {
+// DeleteExpiredBoringSpans deletes sampled-boring spans whose stamped expires_at
+// has passed. Classification stamps expires_at at storage time, so cleanup is a
+// bounded seek of the partial idx_spans_expires index — no scan of the whole
+// table fetching duration_us per row (which had grown into a 30s+ write-slot
+// wedge). Interesting spans carry a NULL expires_at and are removed by the
+// aggregate-then-delete pass instead; pre-migration rows are also NULL and drain
+// that same way.
+func (r *Repository) DeleteExpiredBoringSpans(ctx context.Context, now time.Time) (int64, error) {
+	cutoff := now.UTC()
 	return r.batchedDelete(ctx, func() (int64, error) {
 		res, e := r.db.ExecContext(ctx,
 			`DELETE FROM spans WHERE rowid IN (
 				SELECT rowid FROM spans
-				WHERE ingested_at < ? AND status NOT IN ('error','ERROR','Error') AND duration_us < ?
+				WHERE expires_at IS NOT NULL AND expires_at < ?
 				LIMIT ?)`,
-			cutoff, slowThresholdUs, retentionDeleteBatch,
+			cutoff, retentionDeleteBatch,
 		)
 		if e != nil {
 			return 0, e

--- a/internal/repository/repo_spans_staging.go
+++ b/internal/repository/repo_spans_staging.go
@@ -110,8 +110,8 @@ func (r *Repository) CommitStagingFlush(ctx context.Context, traceIDs []string, 
 
 		if len(interesting) > 0 {
 			stmt, err := tx.PrepareContext(ctx, `INSERT INTO spans
-				(`+stagingCols+`)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+				(`+stagingCols+`, expires_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 			if err != nil {
 				return err
 			}
@@ -124,6 +124,7 @@ func (r *Repository) CommitStagingFlush(ctx context.Context, traceIDs []string, 
 					s.ProjectID, s.TraceID, s.SpanID, parentID,
 					s.Name, s.Service, s.Resource, s.Kind, s.Status,
 					s.StartTimeUs, s.DurationUs, s.Attributes, s.Events, s.IngestedAt,
+					s.ExpiresAt,
 				); err != nil {
 					stmt.Close()
 					return err

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -715,10 +715,11 @@ func TestProjectUsageStatsAll(t *testing.T) {
 	}
 }
 
-// insertBoringSpans inserts count non-error, fast spans backdated to ingestedAt
-// so retention's boring-span cleanup will consider them deletable.
+// insertBoringSpans inserts count sampled-boring spans with a stamped expires_at
+// already in the past, so retention's boring-span cleanup will delete them.
 func insertBoringSpans(t *testing.T, repo *Repository, projectID int64, count int, ingestedAt time.Time) {
 	t.Helper()
+	exp := ingestedAt // expires_at in the past → immediately deletable
 	spans := make([]Span, count)
 	for i := range spans {
 		spans[i] = Span{
@@ -734,6 +735,7 @@ func insertBoringSpans(t *testing.T, repo *Repository, projectID int64, count in
 			DurationUs:  1000, // well under the slow threshold
 			Attributes:  "{}",
 			Events:      "[]",
+			ExpiresAt:   &exp,
 		}
 	}
 	if err := repo.InsertSpans(spans); err != nil {
@@ -771,10 +773,10 @@ func TestDeleteBoringSpansBatchedAndYields(t *testing.T) {
 	repo.SetDeleteBatchYield(yield)
 
 	start := time.Now()
-	n, err := repo.DeleteBoringSpansOlderThan(context.Background(), time.Now(), 1_000_000)
+	n, err := repo.DeleteExpiredBoringSpans(context.Background(), time.Now())
 	elapsed := time.Since(start)
 	if err != nil {
-		t.Fatalf("DeleteBoringSpansOlderThan: %v", err)
+		t.Fatalf("DeleteExpiredBoringSpans: %v", err)
 	}
 	if int(n) != total {
 		t.Fatalf("deleted %d rows, want %d", n, total)
@@ -801,7 +803,7 @@ func TestBatchedDeleteRespectsContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancelled before the first batch
 
-	n, err := repo.DeleteBoringSpansOlderThan(ctx, time.Now(), 1_000_000)
+	n, err := repo.DeleteExpiredBoringSpans(ctx, time.Now())
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -40,7 +40,7 @@ type Repository interface {
 	GetSpansForAggregation(cutoff time.Time, limit int) ([]repository.Span, error)
 	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
-	DeleteBoringSpansOlderThan(ctx context.Context, cutoff time.Time, slowThresholdUs int64) (int64, error)
+	DeleteExpiredBoringSpans(ctx context.Context, now time.Time) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
 	DeleteErrorSamplesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteAggregatesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
@@ -321,16 +321,14 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		}
 	}
 
-	// Fast boring-span cleanup: delete sampled boring spans past their short retention window.
-	// This is a simple indexed range DELETE — no correlated subquery, runs in milliseconds.
-	var boringDeleted int64
-	if cfg.BoringRetentionMinutes > 0 && cfg.SlowThresholdUS > 0 {
-		boringCutoff := now.Add(-time.Duration(cfg.BoringRetentionMinutes) * time.Minute)
-		var boringErr error
-		boringDeleted, boringErr = w.repo.DeleteBoringSpansOlderThan(ctx, boringCutoff, cfg.SlowThresholdUS)
-		if boringErr != nil {
-			return boringErr
-		}
+	// Fast boring-span cleanup: delete sampled-boring spans whose stamped
+	// expires_at has passed. Classification writes expires_at (= ingested_at +
+	// boring retention) at storage time, so this is a bounded seek of the partial
+	// idx_spans_expires index — it no longer scans the table classifying by
+	// status/duration_us (which had wedged the writer for 30s+).
+	boringDeleted, err := w.repo.DeleteExpiredBoringSpans(ctx, now)
+	if err != nil {
+		return err
 	}
 
 	errorSamplesDeleted, err := w.repo.DeleteErrorSamplesOlderThan(ctx, errorCutoff)

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -452,6 +452,26 @@ func TestRunOnceDeletesBoringSpans(t *testing.T) {
 	recentBoring := time.Now().UTC().Add(-5 * time.Minute)
 	insertTestSpans(t, repo, 1, "ok", 100_000, recentBoring)
 
+	// Stamp expires_at on the boring (ok) spans the way classification would at
+	// storage time: ingested_at + the 30-minute boring window. Stamped with Go
+	// time values (matching how the writer stores them) so the delete's time
+	// comparison is format-consistent. The old boring spans get a past expires_at
+	// (deletable); the recent one a future expires_at (kept). Error spans stay
+	// NULL (removed only by the aggregate-then-delete pass).
+	boringSplit := time.Now().UTC().Add(-30 * time.Minute)
+	if _, err := repo.DB().Exec(
+		`UPDATE spans SET expires_at = ? WHERE status = 'ok' AND ingested_at < ?`,
+		time.Now().UTC().Add(-15*time.Minute), boringSplit,
+	); err != nil {
+		t.Fatalf("stamp old boring expires_at: %v", err)
+	}
+	if _, err := repo.DB().Exec(
+		`UPDATE spans SET expires_at = ? WHERE status = 'ok' AND ingested_at >= ?`,
+		time.Now().UTC().Add(25*time.Minute), boringSplit,
+	); err != nil {
+		t.Fatalf("stamp recent boring expires_at: %v", err)
+	}
+
 	if err := worker.RunOnce(context.Background()); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}

--- a/internal/worker/staging_flush.go
+++ b/internal/worker/staging_flush.go
@@ -36,6 +36,7 @@ type StagingFlusherConfig struct {
 	MaxAge          time.Duration // staging rows older than this are dropped unconditionally
 	BatchTraces     int           // max ready traces processed per flush transaction
 	SlowThresholdUs int64         // classification: spans slower than this make a trace interesting
+	BoringRetention time.Duration // sampled-boring spans are stamped expires_at = ingested + this
 }
 
 // StagingFlusher moves complete traces out of spans_staging: it feeds every span
@@ -159,7 +160,7 @@ func (f *StagingFlusher) flushOnce(ctx context.Context) (int, error) {
 			f.accumulator.Add(spans[i])
 		}
 	}
-	interesting := classifySpansForStorage(spans, f.cfg.SlowThresholdUs, f.boringPolicy, f.floor)
+	interesting := classifySpansForStorage(spans, f.cfg.SlowThresholdUs, f.cfg.BoringRetention, f.boringPolicy, f.floor)
 
 	// Atomically move interesting spans to the indexed table and delete all
 	// processed rows for these traces.

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -229,6 +229,10 @@ type WorkerConfig struct {
 	// threshold with no errors are boring and skipped. 0 disables the filter
 	// (all spans are written).
 	SlowThresholdUs int64
+	// BoringRetention is how long a sampled-boring span is kept before the boring
+	// cleanup may delete it (stamped as expires_at at classification). 0 leaves
+	// expires_at unset, so boring spans fall back to the aggregate-then-delete pass.
+	BoringRetention time.Duration
 }
 
 // RedisWorker consumes span batches from a Redis write queue and persists
@@ -452,18 +456,35 @@ func (w *RedisWorker) stageSpans(ctx context.Context, spans []repository.Span) {
 // are sampled whole at the per-project ratio — the die is rolled once per
 // trace_id, and either all spans in that trace are kept or none are.
 func (w *RedisWorker) classifyForStorage(spans []repository.Span) []repository.Span {
-	return classifySpansForStorage(spans, w.cfg.SlowThresholdUs, w.boringPolicy, w.floor)
+	return classifySpansForStorage(spans, w.cfg.SlowThresholdUs, w.cfg.BoringRetention, w.boringPolicy, w.floor)
 }
 
 // classifySpansForStorage builds the set of spans to persist from a set of spans
 // that ideally covers whole traces. Extracted so the staging flusher can reuse
 // the exact same trace-level classification the inline worker path uses.
-func classifySpansForStorage(spans []repository.Span, slowThresholdUs int64, boringPolicy BoringPolicyReader, floor *sampling.MinuteFloor) []repository.Span {
+func classifySpansForStorage(spans []repository.Span, slowThresholdUs int64, boringRetention time.Duration, boringPolicy BoringPolicyReader, floor *sampling.MinuteFloor) []repository.Span {
 	if slowThresholdUs <= 0 {
 		return spans
 	}
 
 	now := time.Now()
+
+	// stampBoring marks sampled-boring spans with an expires_at so the cleanup can
+	// delete them with a plain indexed range scan. A non-positive retention leaves
+	// expires_at nil, so those spans fall back to the aggregate-then-delete pass.
+	stampBoring := func(bs []repository.Span) {
+		if boringRetention <= 0 {
+			return
+		}
+		for i := range bs {
+			base := bs[i].IngestedAt
+			if base.IsZero() {
+				base = now
+			}
+			exp := base.Add(boringRetention)
+			bs[i].ExpiresAt = &exp
+		}
+	}
 
 	// Determine which projects are in verbose mode (record all spans).
 	verboseProject := make(map[int64]bool, 2)
@@ -541,12 +562,14 @@ func classifySpansForStorage(spans []repository.Span, slowThresholdUs int64, bor
 			}
 			op, minute := boringTraceKey(bt.spans)
 			if floor.ShouldKeep(bt.projectID, op, minute, min, ratioKeep) {
+				stampBoring(bt.spans)
 				result = append(result, bt.spans...)
 			}
 			continue
 		}
 
 		if ratioKeep {
+			stampBoring(bt.spans)
 			result = append(result, bt.spans...)
 		}
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -414,6 +414,62 @@ func TestClassifyForStorageBoringPolicy(t *testing.T) {
 	}
 }
 
+// TestClassifyStampsBoringExpiry verifies classification stamps sampled-boring
+// spans with expires_at = ingested_at + BoringRetention, while interesting spans
+// are left unstamped (nil) so only the cheap indexed cleanup — not the aggregate
+// pass — reclaims boring spans.
+func TestClassifyStampsBoringExpiry(t *testing.T) {
+	ingested := time.Now().Add(-time.Minute).UTC()
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "boring", SpanID: "b1", Status: "ok", DurationUs: 100, IngestedAt: ingested},
+		{ProjectID: 1, TraceID: "err", SpanID: "e1", Status: "error", DurationUs: 100, IngestedAt: ingested},
+	}
+
+	rw := &RedisWorker{cfg: WorkerConfig{SlowThresholdUs: 1_000_000, BoringRetention: 30 * time.Minute}}
+	rw.boringPolicy = &mockBoringPolicy{ratio: 1} // keep boring traces
+
+	result := rw.classifyForStorage(spans)
+
+	byID := make(map[string]repository.Span, len(result))
+	for _, s := range result {
+		byID[s.SpanID] = s
+	}
+	boring, ok := byID["b1"]
+	if !ok {
+		t.Fatal("boring span was not kept")
+	}
+	if boring.ExpiresAt == nil {
+		t.Fatal("boring span must be stamped with expires_at")
+	}
+	if want := ingested.Add(30 * time.Minute); !boring.ExpiresAt.Equal(want) {
+		t.Fatalf("boring expires_at = %v, want %v", boring.ExpiresAt, want)
+	}
+	if interesting, ok := byID["e1"]; !ok {
+		t.Fatal("interesting span was not kept")
+	} else if interesting.ExpiresAt != nil {
+		t.Fatalf("interesting span must not be stamped, got %v", interesting.ExpiresAt)
+	}
+}
+
+// TestClassifyNoBoringRetentionLeavesUnstamped verifies that a zero retention
+// leaves boring spans unstamped, so they fall back to the aggregate-then-delete
+// pass rather than being stamped for immediate deletion.
+func TestClassifyNoBoringRetentionLeavesUnstamped(t *testing.T) {
+	spans := []repository.Span{
+		{ProjectID: 1, TraceID: "boring", SpanID: "b1", Status: "ok", DurationUs: 100, IngestedAt: time.Now().UTC()},
+	}
+	rw := &RedisWorker{cfg: WorkerConfig{SlowThresholdUs: 1_000_000, BoringRetention: 0}}
+	rw.boringPolicy = &mockBoringPolicy{ratio: 1}
+
+	result := rw.classifyForStorage(spans)
+	if len(result) != 1 {
+		t.Fatalf("want boring span kept, got %d spans", len(result))
+	}
+	if result[0].ExpiresAt != nil {
+		t.Fatalf("zero retention must leave expires_at nil, got %v", result[0].ExpiresAt)
+	}
+}
+
 func TestClassifyForStorageSamplesWholeTrace(t *testing.T) {
 	// A boring trace with 3 spans — when sampled, all 3 must be included.
 	spans := []repository.Span{


### PR DESCRIPTION
## Root cause
After the log-delete fix (#129), the writer still wedged — this time on `DeleteBoringSpansOlderThan`, a **34 s** batch holding the single write scheduler slot. It deleted with a full scan that classified every candidate by `status` + `duration_us` (a row fetch — `duration_us` is in no index). Post-staging the main `spans` table holds few boring spans, so the scan walked most of the `ingested_at` range to find them.

Same class of problem as logs: **classify at delete time = scan/fetch on the hot path**.

## Fix — mark rows at write time
The staging flush (and inline worker path) already classify interesting-vs-boring per whole trace. So stamp each **sampled-boring** span with `expires_at = ingested_at + boring_retention` as it's stored. Interesting spans stay `NULL` and are reclaimed by the existing aggregate-then-delete pass.

Cleanup collapses to a bounded indexed delete:
```sql
DELETE FROM spans WHERE expires_at IS NOT NULL AND expires_at < now  -- seeks idx_spans_expires
```

## Migration 030
Adds the nullable `expires_at` column (metadata-only, no row rewrite) and a **partial** index `idx_spans_expires` (only stamped rows). Pre-existing spans keep `expires_at = NULL` and drain via the aggregate pass — **no backfill needed**, so the migration is instant even on the large production DB.

## Changes
- `spans.expires_at` column + partial index (migration 030); `Span.ExpiresAt`.
- Classification stamps sampled-boring spans (both staging + inline paths); wired `BoringRetention` through `WorkerConfig`/`StagingFlusherConfig`.
- Both span insert paths persist `expires_at`.
- `DeleteBoringSpansOlderThan` → `DeleteExpiredBoringSpans` (indexed, drops the unused slowThreshold arg).

## Tests
New `TestClassifyStampsBoringExpiry` / `TestClassifyNoBoringRetentionLeavesUnstamped`; updated repository + retention delete tests to the stamped model. Full suite + quality gate pass.

## Follow-up
Logs already use the fast `NOT EXISTS` form (#129); converting logs to the same `expires_at` stamp is a separate PR. Metrics/rollups deletes are size/fragmentation-bound (not join-bound) and are tracked separately.