### PR TITLE
feat(auth): hosted IAMBarn user badge + RP-initiated logout

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -861,13 +861,14 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 // not crash the process.
 func buildOIDCClient(cfg config.Config, logger *slog.Logger) *auth.OIDCClient {
 	oc := auth.OIDCConfig{
-		Issuer:            cfg.OIDC.Issuer,
-		ClientID:          cfg.OIDC.ClientID,
-		ClientSecret:      cfg.OIDC.ClientSecret,
-		RedirectURL:       cfg.OIDC.RedirectURL,
-		RequiredGroup:     cfg.OIDC.RequiredGroup,
-		ResourceAudiences: cfg.OIDC.ResourceAudiences,
-		CLIClientID:       cfg.OIDC.CLIClientID,
+		Issuer:                cfg.OIDC.Issuer,
+		ClientID:              cfg.OIDC.ClientID,
+		ClientSecret:          cfg.OIDC.ClientSecret,
+		RedirectURL:           cfg.OIDC.RedirectURL,
+		RequiredGroup:         cfg.OIDC.RequiredGroup,
+		ResourceAudiences:     cfg.OIDC.ResourceAudiences,
+		CLIClientID:           cfg.OIDC.CLIClientID,
+		PostLogoutRedirectURI: cfg.OIDC.PostLogoutRedirectURI,
 	}
 	// The sb CLI's device-code tokens carry the CLI client id as their
 	// audience, so accept it as a resource audience automatically.

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -50,10 +50,19 @@ func (s *Server) handleClientConfig(w http.ResponseWriter, _ *http.Request) {
 		}
 		resp["oidc"] = oidcCfg
 		if issuer != "" {
-			resp["iambarn"] = map[string]string{
+			iambarnCfg := map[string]string{
 				"issuer":      issuer,
 				"profile_url": issuer + "/admin#profile",
 			}
+			// Non-secret values the hosted widgets + logout flow need in the
+			// browser: the client id and the post-logout landing URL.
+			if oc.ClientID != "" {
+				iambarnCfg["client_id"] = oc.ClientID
+			}
+			if oc.PostLogoutRedirectURI != "" {
+				iambarnCfg["post_logout_redirect_uri"] = oc.PostLogoutRedirectURI
+			}
+			resp["iambarn"] = iambarnCfg
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -117,6 +117,74 @@ func TestClientConfigIAMBarnProfileURL(t *testing.T) {
 	}
 }
 
+func TestClientConfigIAMBarnWidgetFields(t *testing.T) {
+	srv := newServer(t, "1.0.0")
+	srv.SetOIDCClient(auth.NewOIDCClient(auth.OIDCConfig{
+		Issuer:                "https://iam.example.com/",
+		ClientID:              "spanbarn-web",
+		ClientSecret:          "secret",
+		RedirectURL:           "https://spanbarn.example.com/api/v1/oidc/callback",
+		PostLogoutRedirectURI: "https://spanbarn.example.com/api/v1/oidc/logout-complete",
+	}))
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v1/client-config")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		IAMBarn struct {
+			ClientID              string `json:"client_id"`
+			PostLogoutRedirectURI string `json:"post_logout_redirect_uri"`
+		} `json:"iambarn"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.IAMBarn.ClientID != "spanbarn-web" {
+		t.Fatalf("client_id = %q, want spanbarn-web", body.IAMBarn.ClientID)
+	}
+	if body.IAMBarn.PostLogoutRedirectURI != "https://spanbarn.example.com/api/v1/oidc/logout-complete" {
+		t.Fatalf("post_logout_redirect_uri = %q", body.IAMBarn.PostLogoutRedirectURI)
+	}
+}
+
+func TestOIDCLogoutComplete(t *testing.T) {
+	srv := newServer(t, "1.0.0")
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	resp, err := client.Get(ts.URL + "/api/v1/oidc/logout-complete")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/login" {
+		t.Fatalf("expected redirect to /login, got %q", loc)
+	}
+	cleared := map[string]bool{"session": false, "spanbarn_auth_method": false, "spanbarn_iam_token": false}
+	for _, c := range resp.Cookies() {
+		if _, ok := cleared[c.Name]; ok && c.MaxAge < 0 {
+			cleared[c.Name] = true
+		}
+	}
+	for name, ok := range cleared {
+		if !ok {
+			t.Fatalf("cookie %q was not cleared", name)
+		}
+	}
+}
+
 func TestMeEndpoint(t *testing.T) {
 	sm := auth.NewSessionManager("test-secret", 3600)
 	token, err := sm.Create("alice")

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -106,6 +106,17 @@ func HandleLogout() http.HandlerFunc {
 			MaxAge:   -1,
 			SameSite: http.SameSiteLaxMode,
 		})
+		// Clear the OIDC access token used for iambarn-proxy requests, so a
+		// local logout fully tears down the browser's IamBarn linkage too.
+		http.SetCookie(w, &http.Cookie{
+			Name:     "spanbarn_iam_token",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   isSecureRequest(r),
+			SameSite: http.SameSiteLaxMode,
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -160,6 +160,30 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, next, http.StatusFound)
 }
 
+// handleOIDCLogoutComplete is the landing endpoint IamBarn redirects the
+// browser back to after an RP-initiated /oauth2/end-session logout (it is the
+// registered post_logout_redirect_uri). By the time we get here the IamBarn
+// session is already ended; this clears SpanBarn's own session cookies and
+// sends the user to the login page. It is intentionally public — the whole
+// point is to run while tearing a session down.
+func (s *Server) handleOIDCLogoutComplete(w http.ResponseWriter, r *http.Request) {
+	secure := isSecureRequest(r)
+	for _, name := range []string{"session", "spanbarn_auth_method", "spanbarn_iam_token"} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: name != "spanbarn_auth_method", // the auth-method hint is JS-readable
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+	// Never cache the teardown; a replayed 302 must not resurrect a cleared UI.
+	w.Header().Set("Cache-Control", "no-store")
+	http.Redirect(w, r, "/login", http.StatusFound)
+}
+
 func oidcShortLivedCookie(name, value string, secure bool) *http.Cookie {
 	maxAge := int(oidcCookieTTL.Seconds())
 	if value == "" {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -44,6 +44,9 @@ func (s *Server) registerRoutes() {
 	// configured server-side, so the SPA can fall through to local login.
 	s.mux.HandleFunc("/api/v1/oidc/login", s.handleOIDCLogin)
 	s.mux.HandleFunc("/api/v1/oidc/callback", s.handleOIDCCallback)
+	// Post-logout landing — IamBarn redirects here after end-session; clears
+	// the local session cookies. Public: it runs while tearing a session down.
+	s.mux.HandleFunc("/api/v1/oidc/logout-complete", s.handleOIDCLogoutComplete)
 
 	// Internal ingest endpoint — used by ingest pods to forward spans to writer.
 	// Uses raw API key auth (pod-to-pod, no need for SHA256/DB lookup).

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -33,6 +33,11 @@ type OIDCConfig struct {
 	// CLIClientID is the public IamBarn client the `sb` CLI uses for the
 	// device-code flow. Advertised to the CLI via /api/v1/client-config.
 	CLIClientID string
+
+	// PostLogoutRedirectURI is where IamBarn returns the browser after an
+	// RP-initiated /oauth2/end-session logout. Advertised to the SPA via
+	// /api/v1/client-config so the hosted widgets can build the logout URL.
+	PostLogoutRedirectURI string
 }
 
 // Enabled reports whether all four required fields are present.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -31,6 +32,11 @@ type OIDCConfig struct {
 	RequiredGroup     string   // SPANBARN_OIDC_REQUIRED_GROUP — defaults to "spanbarn-users"
 	ResourceAudiences []string // SPANBARN_OIDC_RESOURCE_AUDIENCES — CSV of audiences accepted on IamBarn access tokens (sb CLI)
 	CLIClientID       string   // SPANBARN_OIDC_CLI_CLIENT_ID — public IamBarn client the sb device-code flow uses
+	// PostLogoutRedirectURI is where IamBarn sends the browser back after an
+	// RP-initiated /oauth2/end-session logout. It must be registered on the
+	// client's post-logout allowlist. SPANBARN_OIDC_POST_LOGOUT_REDIRECT_URI;
+	// defaults to the RedirectURL origin + /api/v1/oidc/logout-complete.
+	PostLogoutRedirectURI string
 }
 
 // SelfConfig groups self-instrumentation (SpanBarn reporting to itself/BugBarn).
@@ -160,12 +166,13 @@ func Load() Config {
 		Mode:                getenv("SPANBARN_MODE", "standalone"),
 		WriterURL:           os.Getenv("SPANBARN_WRITER_URL"),
 		OIDC: OIDCConfig{
-			Issuer:        os.Getenv("SPANBARN_OIDC_ISSUER"),
-			ClientID:      os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
-			ClientSecret:  os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
-			RedirectURL:   os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
-			RequiredGroup: getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
-			CLIClientID:   os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
+			Issuer:                os.Getenv("SPANBARN_OIDC_ISSUER"),
+			ClientID:              os.Getenv("SPANBARN_OIDC_CLIENT_ID"),
+			ClientSecret:          os.Getenv("SPANBARN_OIDC_CLIENT_SECRET"),
+			RedirectURL:           os.Getenv("SPANBARN_OIDC_REDIRECT_URL"),
+			RequiredGroup:         getenv("SPANBARN_OIDC_REQUIRED_GROUP", "spanbarn-users"),
+			CLIClientID:           os.Getenv("SPANBARN_OIDC_CLI_CLIENT_ID"),
+			PostLogoutRedirectURI: os.Getenv("SPANBARN_OIDC_POST_LOGOUT_REDIRECT_URI"),
 		},
 		GRPCAddr: getenv("SPANBARN_GRPC_ADDR", ":4317"),
 	}
@@ -191,6 +198,16 @@ func Load() Config {
 	// app is reached directly and headers would be client-spoofable. Explicit
 	// SPANBARN_TRUST_PROXY overrides either way.
 	cfg.TrustProxy = getenvBool("SPANBARN_TRUST_PROXY", !cfg.IsDevEnvironment())
+
+	// Default the post-logout redirect to this app's own logout-complete
+	// landing (which clears the local session) on the same origin as the OIDC
+	// callback, so RP-initiated logout works with zero extra config and no
+	// hard-coded host.
+	if cfg.OIDC.PostLogoutRedirectURI == "" && cfg.OIDC.RedirectURL != "" {
+		if u, err := url.Parse(cfg.OIDC.RedirectURL); err == nil && u.Scheme != "" && u.Host != "" {
+			cfg.OIDC.PostLogoutRedirectURI = u.Scheme + "://" + u.Host + "/api/v1/oidc/logout-complete"
+		}
+	}
 
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,24 @@ package config
 
 import "testing"
 
+func TestPostLogoutRedirectURIDefault(t *testing.T) {
+	t.Setenv("SPANBARN_OIDC_REDIRECT_URL", "https://spanbarn.example.com/api/v1/oidc/callback")
+	cfg := Load()
+	want := "https://spanbarn.example.com/api/v1/oidc/logout-complete"
+	if cfg.OIDC.PostLogoutRedirectURI != want {
+		t.Fatalf("derived post-logout uri = %q, want %q", cfg.OIDC.PostLogoutRedirectURI, want)
+	}
+}
+
+func TestPostLogoutRedirectURIExplicitWins(t *testing.T) {
+	t.Setenv("SPANBARN_OIDC_REDIRECT_URL", "https://spanbarn.example.com/api/v1/oidc/callback")
+	t.Setenv("SPANBARN_OIDC_POST_LOGOUT_REDIRECT_URI", "https://spanbarn.example.com/bye")
+	cfg := Load()
+	if cfg.OIDC.PostLogoutRedirectURI != "https://spanbarn.example.com/bye" {
+		t.Fatalf("explicit post-logout uri not honoured: %q", cfg.OIDC.PostLogoutRedirectURI)
+	}
+}
+
 func TestValidateSessionSecret(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { DashboardLayout } from './components/DashboardLayout'
 import { TimeRangeProvider } from './contexts/TimeRangeContext'
 
@@ -53,7 +53,9 @@ function App() {
               <Route path="alerts" element={<AlertsPage />} />
               <Route path="metrics" element={<MetricsPage />} />
               <Route path="settings" element={<SettingsPage />} />
-              <Route path="profile" element={<ProfilePage />} />
+              <Route path="account" element={<ProfilePage />} />
+              {/* Back-compat: the account page used to live at /profile. */}
+              <Route path="profile" element={<Navigate to="/account" replace />} />
             </Route>
           </Routes>
         </Suspense>

--- a/web/src/api/clientConfig.ts
+++ b/web/src/api/clientConfig.ts
@@ -5,28 +5,11 @@
 export interface ClientConfig {
   funnelbarn?: { endpoint?: string; api_key?: string; project?: string }
   oidc?: { enabled?: boolean; loginURL?: string }
-  iambarn?: { profile_url?: string; issuer?: string }
-}
-
-export interface IambarnUser {
-  display_name: string
-  email: string
-  picture: string
-}
-
-// Fetch user info from SpanBarn's own session endpoint — same-origin, no
-// cross-origin cookie issues. The issuer parameter is kept for API compat.
-// The issuer parameter is unused — user info now comes from SpanBarn's own
-// session endpoint to avoid cross-origin cookie issues.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function fetchIambarnMe(_issuer: string): Promise<IambarnUser | null> {
-  try {
-    const res = await fetch('/api/v1/me', { credentials: 'same-origin' })
-    if (!res.ok) return null
-    const data = await (res.json() as Promise<{ display_name: string }>)
-    return { display_name: data.display_name, email: '', picture: '' }
-  } catch {
-    return null
+  iambarn?: {
+    profile_url?: string
+    issuer?: string
+    client_id?: string
+    post_logout_redirect_uri?: string
   }
 }
 

--- a/web/src/api/iambarnWidget.ts
+++ b/web/src/api/iambarnWidget.ts
@@ -1,0 +1,113 @@
+// Shared helpers for embedding IAMBarn's hosted web components and driving
+// RP-initiated logout. All widget data flows through SpanBarn's same-origin
+// /api/iam-proxy (see internal/api/iam_proxy.go) so the browser never makes a
+// cross-origin credentialed request to IAMBarn — that path is blocked by
+// Chrome's third-party-cookie partitioning. Only the /oauth2/end-session
+// logout navigation goes to the real issuer, which is fine because it is a
+// top-level navigation, not a fetch.
+
+import { useEffect, useState } from 'react'
+import { api } from './client'
+import { fetchClientConfig, isOIDCSession } from './clientConfig'
+
+// An active IAMBarn-backed session with everything the widgets + logout need.
+export interface IambarnSession {
+  issuer: string
+  proxyUrl: string
+  clientId?: string
+  postLogoutRedirectUri?: string
+}
+
+let scriptPromise: Promise<void> | null = null
+
+// Inject the hosted widget bundle once; every custom element is registered by
+// the single script. Safe to call from multiple components.
+export function loadWidgetScript(issuer: string): Promise<void> {
+  if (!scriptPromise) {
+    scriptPromise = new Promise<void>((resolve, reject) => {
+      if (document.querySelector('script[data-iambarn-widget]')) {
+        resolve()
+        return
+      }
+      const el = document.createElement('script')
+      el.src = `${issuer}/widget/iambarn-widget.iife.js`
+      el.dataset['iambarnWidget'] = ''
+      el.onload = () => resolve()
+      el.onerror = () => {
+        scriptPromise = null
+        reject(new Error('Failed to load iambarn widget'))
+      }
+      document.head.appendChild(el)
+    })
+  }
+  return scriptPromise
+}
+
+// Resolve the current IAMBarn session (null for local-password sessions) and
+// preload the widget bundle so hosted elements upgrade immediately.
+export function useIambarnSession(): IambarnSession | null {
+  const [session, setSession] = useState<IambarnSession | null>(null)
+
+  useEffect(() => {
+    if (!isOIDCSession()) return
+    let cancelled = false
+    void fetchClientConfig().then((cfg) => {
+      const issuer = cfg.iambarn?.issuer
+      if (cancelled || !issuer) return
+      void loadWidgetScript(issuer)
+      setSession({
+        issuer,
+        proxyUrl: window.location.origin + '/api/iam-proxy',
+        clientId: cfg.iambarn?.client_id,
+        postLogoutRedirectUri: cfg.iambarn?.post_logout_redirect_uri,
+      })
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return session
+}
+
+// Build the RP-initiated logout URL on the real issuer. Mirrors the hosted
+// widget's own builder: client_id + post_logout_redirect_uri, no id_token_hint
+// (IAMBarn relies on the browser session cookie + the client's registered
+// post-logout allowlist).
+export function endSessionUrl(
+  issuer: string,
+  opts: { clientId?: string; postLogoutRedirectUri?: string },
+): string {
+  const params = new URLSearchParams()
+  if (opts.clientId) params.set('client_id', opts.clientId)
+  if (opts.postLogoutRedirectUri) params.set('post_logout_redirect_uri', opts.postLogoutRedirectUri)
+  const query = params.toString()
+  return `${issuer}/oauth2/end-session${query ? `?${query}` : ''}`
+}
+
+// Log out. For an IAMBarn session this clears the local session first (best
+// effort) then navigates to the issuer's end-session endpoint; IAMBarn ends its
+// own session and redirects back to post_logout_redirect_uri (SpanBarn's
+// /api/v1/oidc/logout-complete, which re-clears the local cookies). For local
+// sessions — or if the issuer/client config is missing — it falls back to a
+// plain local logout. `fallback` runs the SPA-local navigation to /login.
+export async function iambarnLogout(
+  session: IambarnSession | null,
+  fallback: () => void,
+): Promise<void> {
+  try {
+    await api.logout()
+  } catch {
+    // ignore — end-session (or the fallback) still tears the session down.
+  }
+  if (session?.issuer && session.clientId && session.postLogoutRedirectUri) {
+    window.location.assign(
+      endSessionUrl(session.issuer, {
+        clientId: session.clientId,
+        postLogoutRedirectUri: session.postLogoutRedirectUri,
+      }),
+    )
+    return
+  }
+  fallback()
+}

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -1,11 +1,21 @@
-import { type ReactElement, useEffect, useRef, useState } from 'react'
+import { type CSSProperties, type ReactElement, useEffect, useRef, useState } from 'react'
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { Activity, BarChart2, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe, ScrollText } from 'lucide-react'
-import { api } from '../api/client'
-import { fetchClientConfig, isOIDCSession, fetchIambarnMe, type IambarnUser } from '../api/clientConfig'
+import { useIambarnSession, iambarnLogout } from '../api/iambarnWidget'
 import { IambarnProfileModal } from './IambarnProfileModal'
 import { MobileTabBar } from './MobileTabBar'
 import { PWAInstallBanner } from './PWAInstallBanner'
+
+// Theme the hosted <iambarn-user-badge> to match SpanBarn's tokens.
+const badgeStyle: CSSProperties = {
+  ...({
+    '--iambarn-bg': 'transparent',
+    '--iambarn-text': 'var(--text)',
+    '--iambarn-muted': 'var(--text-muted)',
+    '--iambarn-accent': 'var(--accent)',
+  } as CSSProperties),
+  width: '100%',
+}
 
 const navItems = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -25,8 +35,7 @@ const navItems = [
 export function DashboardLayout(): ReactElement {
   const navigate = useNavigate()
   const location = useLocation()
-  const [iambarnIssuer, setIambarnIssuer] = useState<string | null>(null)
-  const [iambarnUser, setIambarnUser] = useState<IambarnUser | null>(null)
+  const session = useIambarnSession()
   const [profileOpen, setProfileOpen] = useState(false)
   const chipRef = useRef<HTMLButtonElement>(null)
 
@@ -39,31 +48,9 @@ export function DashboardLayout(): ReactElement {
     }
   }, [location.pathname])
 
-  useEffect(() => {
-    // Only sessions opened via the iambarn OIDC callback have a remote
-    // profile to manage — local password sessions do not.
-    if (!isOIDCSession()) return
-    let cancelled = false
-    void fetchClientConfig().then(async (cfg) => {
-      const issuer = cfg.iambarn?.issuer
-      if (cancelled || !issuer) return
-      setIambarnIssuer(issuer)
-      const user = await fetchIambarnMe(issuer)
-      if (!cancelled) setIambarnUser(user)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
   const handleLogout = async () => {
     setProfileOpen(false)
-    try {
-      await api.logout()
-    } catch {
-      // ignore
-    }
-    navigate('/login', { replace: true })
+    await iambarnLogout(session, () => navigate('/login', { replace: true }))
   }
 
   return (
@@ -126,7 +113,7 @@ export function DashboardLayout(): ReactElement {
 
         {/* User actions */}
         <div style={{ padding: '0.75rem 0.5rem', borderTop: '1px solid var(--border)' }}>
-          {iambarnIssuer ? (
+          {session ? (
             <button
               ref={chipRef}
               onClick={() => setProfileOpen(true)}
@@ -137,53 +124,11 @@ export function DashboardLayout(): ReactElement {
                 background: 'transparent',
                 border: 'none',
                 color: 'var(--text-muted)',
-                gap: '0.625rem',
+                padding: '0.25rem',
               }}
             >
-              {iambarnUser?.picture ? (
-                <img
-                  src={iambarnUser.picture}
-                  alt=""
-                  style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: '50%',
-                    objectFit: 'cover',
-                    flexShrink: 0,
-                  }}
-                  onError={(e) => {
-                    ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-                  }}
-                />
-              ) : (
-                <div
-                  style={{
-                    width: 28,
-                    height: 28,
-                    borderRadius: '50%',
-                    background: 'var(--accent)',
-                    color: '#fff',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 12,
-                    fontWeight: 600,
-                    flexShrink: 0,
-                  }}
-                >
-                  {(iambarnUser?.display_name || iambarnUser?.email || '?')[0].toUpperCase()}
-                </div>
-              )}
-              <span
-                style={{
-                  fontSize: '0.875rem',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {iambarnUser?.display_name || iambarnUser?.email || 'Profile'}
-              </span>
+              {/* Hosted IAMBarn avatar + name (+email), fed same-origin via the proxy. */}
+              <iambarn-user-badge server-url={session.proxyUrl} show-email="" style={badgeStyle} />
             </button>
           ) : (
             <button
@@ -202,10 +147,10 @@ export function DashboardLayout(): ReactElement {
             </button>
           )}
         </div>
-        {profileOpen && iambarnIssuer && (
+        {profileOpen && session && (
           <IambarnProfileModal
-            issuer={iambarnIssuer}
-            proxyUrl={window.location.origin + '/api/iam-proxy'}
+            issuer={session.issuer}
+            proxyUrl={session.proxyUrl}
             triggerRef={chipRef}
             onClose={() => setProfileOpen(false)}
             onLogout={handleLogout}

--- a/web/src/components/IambarnProfileModal.tsx
+++ b/web/src/components/IambarnProfileModal.tsx
@@ -73,7 +73,7 @@ export function IambarnProfileModal({ issuer: _issuer, proxyUrl: _proxyUrl, trig
     >
       <button
         style={{ ...menuItem, color: 'var(--text)' }}
-        onClick={() => { onClose(); navigate('/profile') }}
+        onClick={() => { onClose(); navigate('/account') }}
       >
         <UserCog size={16} />
         Account settings

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -1,9 +1,18 @@
-import { useEffect, useRef, useState, type ReactElement } from 'react'
+import { useRef, useState, type CSSProperties, type ReactElement } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { Activity, BarChart2, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut, ScrollText } from 'lucide-react'
-import { api } from '../api/client'
-import { fetchClientConfig, isOIDCSession, fetchIambarnMe, type IambarnUser } from '../api/clientConfig'
+import { useIambarnSession, iambarnLogout } from '../api/iambarnWidget'
 import { IambarnProfileModal } from './IambarnProfileModal'
+
+const badgeStyle: CSSProperties = {
+  ...({
+    '--iambarn-bg': 'transparent',
+    '--iambarn-text': 'var(--text-muted)',
+    '--iambarn-muted': 'var(--text-muted)',
+    '--iambarn-accent': 'var(--accent)',
+  } as CSSProperties),
+  width: '100%',
+}
 
 const tabs = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -14,38 +23,15 @@ const tabs = [
 
 export function MobileTabBar(): ReactElement {
   const [moreOpen, setMoreOpen] = useState(false)
-  const [iambarnIssuer, setIambarnIssuer] = useState<string | null>(null)
-  const [iambarnUser, setIambarnUser] = useState<IambarnUser | null>(null)
+  const session = useIambarnSession()
   const [profileOpen, setProfileOpen] = useState(false)
   const profileBtnRef = useRef<HTMLButtonElement>(null)
   const navigate = useNavigate()
 
-  useEffect(() => {
-    // Only sessions opened via the iambarn OIDC callback have a remote
-    // profile to manage — local password sessions do not.
-    if (!isOIDCSession()) return
-    let cancelled = false
-    void fetchClientConfig().then(async (cfg) => {
-      const issuer = cfg.iambarn?.issuer
-      if (cancelled || !issuer) return
-      setIambarnIssuer(issuer)
-      const user = await fetchIambarnMe(issuer)
-      if (!cancelled) setIambarnUser(user)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
   const handleLogout = async () => {
     setProfileOpen(false)
     setMoreOpen(false)
-    try {
-      await api.logout()
-    } catch {
-      // ignore
-    }
-    navigate('/login', { replace: true })
+    await iambarnLogout(session, () => navigate('/login', { replace: true }))
   }
 
   return (
@@ -232,7 +218,7 @@ export function MobileTabBar(): ReactElement {
             <Settings size={18} />
             Settings
           </NavLink>
-          {iambarnIssuer && (
+          {session && (
             <button
               ref={profileBtnRef}
               onClick={() => {
@@ -246,44 +232,14 @@ export function MobileTabBar(): ReactElement {
                 width: '100%',
                 padding: '0.625rem 0.75rem',
                 borderRadius: '0.5rem',
-                fontSize: '0.875rem',
-                fontWeight: 500,
-                color: 'var(--text-muted)',
                 background: 'transparent',
                 border: 'none',
                 cursor: 'pointer',
                 textAlign: 'left',
               }}
             >
-              {iambarnUser?.picture ? (
-                <img
-                  src={iambarnUser.picture}
-                  alt=""
-                  style={{ width: 24, height: 24, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
-                  onError={(e) => {
-                    ;(e.currentTarget as HTMLImageElement).style.display = 'none'
-                  }}
-                />
-              ) : (
-                <div
-                  style={{
-                    width: 24,
-                    height: 24,
-                    borderRadius: '50%',
-                    background: 'var(--accent)',
-                    color: '#fff',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    fontSize: 11,
-                    fontWeight: 600,
-                    flexShrink: 0,
-                  }}
-                >
-                  {(iambarnUser?.display_name || iambarnUser?.email || '?')[0].toUpperCase()}
-                </div>
-              )}
-              {iambarnUser?.display_name || iambarnUser?.email || 'Profile'}
+              {/* Hosted IAMBarn avatar + name (+email), fed same-origin via the proxy. */}
+              <iambarn-user-badge server-url={session.proxyUrl} show-email="" style={badgeStyle} />
             </button>
           )}
           <button
@@ -380,10 +336,10 @@ export function MobileTabBar(): ReactElement {
           More
         </button>
       </nav>
-      {profileOpen && iambarnIssuer && (
+      {profileOpen && session && (
         <IambarnProfileModal
-          issuer={iambarnIssuer}
-          proxyUrl={window.location.origin + '/api/iam-proxy'}
+          issuer={session.issuer}
+          proxyUrl={session.proxyUrl}
           triggerRef={profileBtnRef}
           onClose={() => setProfileOpen(false)}
           onLogout={handleLogout}

--- a/web/src/pages/ProfilePage.tsx
+++ b/web/src/pages/ProfilePage.tsx
@@ -2,23 +2,7 @@ import { useEffect, useState, type CSSProperties, type ReactElement } from 'reac
 import { useNavigate } from 'react-router-dom'
 import { ArrowLeft, RefreshCw } from 'lucide-react'
 import { fetchClientConfig, isOIDCSession } from '../api/clientConfig'
-
-let scriptPromise: Promise<void> | null = null
-
-function loadWidgetScript(src: string): Promise<void> {
-  if (!scriptPromise) {
-    scriptPromise = new Promise<void>((resolve, reject) => {
-      if (document.querySelector('script[data-iambarn-widget]')) { resolve(); return }
-      const el = document.createElement('script')
-      el.src = src
-      el.dataset['iambarnWidget'] = ''
-      el.onload = () => resolve()
-      el.onerror = () => { scriptPromise = null; reject(new Error('Failed to load widget')) }
-      document.head.appendChild(el)
-    })
-  }
-  return scriptPromise
-}
+import { loadWidgetScript } from '../api/iambarnWidget'
 
 const widgetStyle: CSSProperties = {
   ...({
@@ -57,7 +41,7 @@ export function ProfilePage(): ReactElement {
 
       void fetchClientConfig().then((cfg) => {
         const issuer = cfg.iambarn?.issuer
-        if (issuer) void loadWidgetScript(`${issuer}/widget/iambarn-widget.iife.js`)
+        if (issuer) void loadWidgetScript(issuer)
       })
       setStatus('ready')
     })()
@@ -100,7 +84,7 @@ export function ProfilePage(): ReactElement {
             Your session has expired. Sign in again to manage your account.
           </p>
           <a
-            href={'/api/v1/oidc/login?next=/profile'}
+            href={'/api/v1/oidc/login?next=/account'}
             className="btn"
             style={{ textDecoration: 'none', display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}
           >

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -12,6 +12,21 @@ declare module 'react' {
         },
         HTMLElement
       >
+      'iambarn-user-badge': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          'server-url'?: string
+          // Empty string = attribute present (widget uses hasAttribute).
+          'show-email'?: string
+        },
+        HTMLElement
+      >
+      'iambarn-avatar': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          'server-url'?: string
+          size?: number | string
+        },
+        HTMLElement
+      >
     }
   }
 }


### PR DESCRIPTION
## What

Replaces the hand-rolled sidebar/mobile avatar with IAMBarn's hosted `<iambarn-user-badge>` (live avatar/name/email), and adds a real RP-initiated logout.

- **Header/mobile**: hosted `<iambarn-user-badge>` fed same-origin via the existing `/api/iam-proxy` — no cross-origin credentialed `/api/v1/me` (avoids the third-party-cookie block the proxy was built for).
- **Logout**: navigates to `{issuer}/oauth2/end-session` and returns to a new public `GET /api/v1/oidc/logout-complete` landing that clears `session`, `spanbarn_auth_method`, `spanbarn_iam_token`. Local-password sessions keep the plain local logout.
- **Config**: `SPANBARN_OIDC_POST_LOGOUT_REDIRECT_URI` (defaults to the OIDC-callback origin + `/api/v1/oidc/logout-complete`); `client-config` now exposes `iambarn.client_id` + `post_logout_redirect_uri`.
- **Routing**: account page moves to `/account` (`/profile` redirects); shared `iambarnWidget.ts` de-duplicates the widget/logout logic.

## Not using `<iambarn-user-menu>`

Its single `server-url` couples the `/api/v1/me` fetch to the end-session nav, which is incompatible with the same-origin proxy. `<iambarn-user-badge>` + the existing dropdown + real-issuer end-session deliver the same UX with no IAMBarn CORS change.

## Deploy prerequisite

`{origin}/api/v1/oidc/logout-complete` must be registered on the SpanBarn IAMBarn client's post-logout allowlist (done for production).

## Tests

- Go: config default/override, client-config widget fields, logout-complete cookie-clear + redirect. Full suite + quality gate pass.
- Web: tsc, eslint, 59 Vitest tests, production build pass.