### PR TITLE
chore(storage): prod SQLite on hard-capped SSD loopback; disable staging Litestream

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -204,7 +204,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
 	}
 	// Combined (spool) mode has no Redis write-queue backlog to gate on, so no busy skip.
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, nil, logger) })
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}
@@ -789,16 +789,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	if cpMode == repository.CheckpointPassive {
 		cpTruncateFrames = cfg.WALTruncateThresholdMB * 256
 	}
-	// While the span write-queue is backed up, skip checkpoints so the single
-	// writer connection isn't blocked (up to busy_timeout) draining the backlog.
-	cpBusy := func() bool {
-		if cfg.CheckpointSkipQueueDepth <= 0 {
-			return false
-		}
-		n, err := writeQueue.Len(workerCtx)
-		return err == nil && n > int64(cfg.CheckpointSkipQueueDepth)
-	}
-	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, cpBusy, logger) })
+	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, cpMode, cpTruncateFrames, logger) })
 	if litestreamActive() {
 		logger.Info("litestream active: writer runs PASSIVE WAL checkpoints; Litestream owns WAL truncation")
 	}

--- a/deploy/k8s/base/pv-spanbarn-data.yaml
+++ b/deploy/k8s/base/pv-spanbarn-data.yaml
@@ -1,17 +1,36 @@
+# One-time cluster-setup resource — apply manually, NOT part of the rolling deploy.
+#
+# Production SQLite lives on a HARD-CAPPED 5 GB ext4 loopback on the layer7-prod
+# ROOT SSD (vda), not the slow vdb network volume. The loopback both makes SQLite
+# fast (SSD random I/O) and hard-bounds spanbarn's disk use so a Litestream local
+# cache runaway (cf. the 117 GB staging incident) can only fill its own 5 GB, never
+# the node.
+#
+# Node-level setup on layer7-prod (host mount namespace; survives reboot via fstab):
+#   fallocate -l 5G /var/lib/rancher/k3s/storage/spanbarn-fast.img
+#   mkfs.ext4 -m 0 /var/lib/rancher/k3s/storage/spanbarn-fast.img
+#   mkdir -p /var/lib/rancher/k3s/storage/spanbarn-fast
+#   echo '/var/lib/rancher/k3s/storage/spanbarn-fast.img /var/lib/rancher/k3s/storage/spanbarn-fast ext4 loop,rw 0 0' >> /etc/fstab
+#   mount /var/lib/rancher/k3s/storage/spanbarn-fast
+#   chown 100:101 /var/lib/rancher/k3s/storage/spanbarn-fast   # spanbarn uid:gid
+#
+# The previous vdb PV (spanbarn-data-storage, /mnt/storage/spanbarn, 200Gi, Retain)
+# is kept as rollback — its data is retained on delete. To roll back, clear its
+# claimRef and point the PVC's volumeName back at it.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: spanbarn-data-storage
+  name: spanbarn-fast-storage
 spec:
   capacity:
-    storage: 200Gi
+    storage: 5Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   storageClassName: spanbarn-local
   local:
-    path: /mnt/storage/spanbarn
+    path: /var/lib/rancher/k3s/storage/spanbarn-fast
   nodeAffinity:
     required:
       nodeSelectorTerms:

--- a/deploy/k8s/base/pvc.yaml
+++ b/deploy/k8s/base/pvc.yaml
@@ -6,7 +6,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: spanbarn-local
-  volumeName: spanbarn-data-storage
+  volumeName: spanbarn-fast-storage
   resources:
     requests:
-      storage: 200Gi
+      storage: 5Gi

--- a/deploy/k8s/production/pvc-patch.yaml
+++ b/deploy/k8s/production/pvc-patch.yaml
@@ -1,9 +1,0 @@
-# Production PVC patch — overrides base spec to match the existing volume
-# that was provisioned with local-path before spanbarn-local was introduced.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: spanbarn-data
-spec:
-  storageClassName: local-path
-  volumeName: pvc-01a1a366-83ba-4b2b-a407-eaebfb0c6f71

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -12,7 +12,7 @@ stringData:
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:SVBfM9c=,iv:DW3O9ltZxf2XvKthwam7DeTjDHR5jwRZs/i6P2ZPonQ=,tag:T2/wHfGJTL3/MNcpEy9psA==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:Vacvyi6PUmk=,iv:EmdHo9MT+yecjJ9OKi+V+/7QQVjdLd5Wv7hAbjr/avc=,tag:056ciKnaBPhW2+DMPcj2RA==,type:str]
     SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:sVLkm4NlrCahz4ka/ObAWEp667Wb79FZ9TMZbPrCvsgvbZtAG4gmoA==,iv:KhHe0Qhlflq3ZFIhXFZrYUHbbH1n9ZX2SBGwH1HSVPs=,tag:+pHgjBBentmbt0fb9rmfBw==,type:str]
-    LITESTREAM_ACCESS_KEY_ID: ENC[AES256_GCM,data:QgWQyliKk7q9E3QtZZTLAw==,iv:4JE/Qbcb5VgGAV4En+LFB6zdyTZ9l2y3FaIlwaZ9Z60=,tag:zYbrY9EHVlRQ9Y+P5B7JYw==,type:str]
+    LITESTREAM_ACCESS_KEY_ID: ""
     LITESTREAM_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:Yv82Wvn+6zdazZNVy7yZ4mRvUh9K4+zI,iv:bKTfd3OIuAxt1+pd2cRbCwzUlHy4YWTRISPi3tm6nYc=,tag:En3M41p9UfT5xzGankUxMA==,type:str]
     LITESTREAM_REPLICA_PATH: ENC[AES256_GCM,data:SM2F0H7tfQ==,iv:VJxXCOq68za6jsG+t1ynpyqZHXE4rHvgd3YDB+R97XA=,tag:W5ii99UA36kSNcrwSEEvQg==,type:str]
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:4mLL9n9/QXp0A6mqpAhQoREjZMaGOv7u4E0g652nZX1emnwY,iv:Ffidh7MJzXNH4UlJxrGFQQnT4C4EO6AVbNTlBVGDCSA=,tag:1xN46uoebgFGUhORxIP3tg==,type:str]
@@ -38,7 +38,7 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-29T14:08:14Z"
-    mac: ENC[AES256_GCM,data:VTQurGBggTp9sOE57ubv1GflT0PV+636RG5lZNtRswdzLSeqtEHsG+UpfMW9vDFo2Drik88NxAVA86kUazOwPMgbXA1YiwahSCVuvIBoP/tixUrf0kGQ68TbhDqxxdBs79rTMiUUbnAmks4R6MyaKB4GueGsMpHcqBixEEapmMY=,iv:tG7qnoX7TAhOBDh/bQbm2zsXDjc4NBCzOnsNhPxoJEM=,tag:73U3FBAu1ikC2TxtSq8MrQ==,type:str]
+    lastmodified: "2026-07-11T09:50:57Z"
+    mac: ENC[AES256_GCM,data:E9QK/tqqCU3QCuiYgS5O8LXzFyicJs3h6PA7XL5RPY0hgDTEjnFTsKyi3qakBRcgK/2YGRUbo66SlPV51YLaRgURCzWN+oiQAbKiWHnCuvLyI2Rv3zlnl/r8cd/kW2vELkJQaEesiak0x5LER/pETOY0NL7gV4SoS+kxPyl7giI=,iv:ZGPv5HGHxhsasQbGRLR5qZq2IZgkz+9lsXNoBCPLJis=,tag:cYVyyMQiOb1Ls7D88YVObA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,7 +71,6 @@ type Config struct {
 	MaxSpoolBytes            int64
 	Retention                RetentionConfig
 	WALTruncateThresholdMB   int  // SPANBARN_WAL_TRUNCATE_THRESHOLD_MB — under Litestream the writer checkpoints PASSIVE (no forced re-snapshot) but escalates to one TRUNCATE when the WAL grows past this size, to bound it under sustained read load (default 256; 0 disables escalation)
-	CheckpointSkipQueueDepth int  // SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH — when the span write-queue holds more than this many pending batches, the writer skips WAL checkpoints so it can drain the backlog (default 100; 0 disables gating)
 	SpanStagingEnabled       bool // SPANBARN_SPAN_STAGING_ENABLED — when true, the redis worker appends consumed spans to spans_staging (cheap) and a background flusher does accumulation+classification+indexed storage per complete trace off the hot path (default false)
 	TraceBufferWindowSeconds int  // SPANBARN_TRACE_BUFFER_WINDOW_SECONDS — how long a trace's spans buffer in spans_staging before the flusher treats the trace as complete (default 90)
 	StagingMaxAgeSeconds     int  // SPANBARN_STAGING_MAX_AGE_SECONDS — hard backstop: spans_staging rows older than this are dropped unconditionally so the table can never grow without bound (default 900)
@@ -126,7 +125,6 @@ func Load() Config {
 			DeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),
 		},
 		WALTruncateThresholdMB:   getenvInt("SPANBARN_WAL_TRUNCATE_THRESHOLD_MB", 256),
-		CheckpointSkipQueueDepth: getenvInt("SPANBARN_CHECKPOINT_SKIP_QUEUE_DEPTH", 100),
 		SpanStagingEnabled:       getenvInt("SPANBARN_SPAN_STAGING_ENABLED", 0) != 0,
 		TraceBufferWindowSeconds: getenvInt("SPANBARN_TRACE_BUFFER_WINDOW_SECONDS", 90),
 		StagingMaxAgeSeconds:     getenvInt("SPANBARN_STAGING_MAX_AGE_SECONDS", 900),

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -154,54 +154,30 @@ const (
 // BugBarn and FunnelBarn do. Once Litestream is doing the periodic checkpoint
 // as part of its replication loop, this goroutine can go away entirely and
 // "snapshots are not the writer's problem" becomes literally true.
-// maxSkippedCheckpoints bounds how many consecutive ticks the busy gate may skip
-// before a checkpoint is forced anyway, so a long catch-up cannot grow the WAL
-// without limit. At a 30s interval this is ~10 minutes.
-const maxSkippedCheckpoints = 20
-
-// checkpointGate decides whether to skip this checkpoint tick. While the writer
-// is busy draining a backlog, a checkpoint is skipped so it doesn't block the
-// single connection — but only up to maxSkippedCheckpoints consecutive ticks, so
-// the WAL still gets bounded during a long catch-up. Returns whether to skip and
-// the updated consecutive-skip count.
-func checkpointGate(busy bool, skipped int) (skip bool, nextSkipped int) {
-	if busy && skipped < maxSkippedCheckpoints {
-		return true, skipped + 1
-	}
-	return false, 0
-}
-
 // truncateAboveFrames, when > 0 and mode is PASSIVE, escalates to a one-off
 // TRUNCATE on any tick where the WAL still holds more than that many frames
 // after the PASSIVE pass. This bounds the WAL under sustained read load (PASSIVE
 // cannot reset it past the oldest reader snapshot) at the cost of an occasional
 // Litestream re-snapshot — only when the WAL actually grows large, not every tick.
 //
-// busy, when non-nil and returning true, means the writer is behind on its
-// backlog. A checkpoint runs on the single writer connection and can block span
-// inserts for up to busy_timeout, so while busy we skip the tick and pour
-// throughput into draining — except every maxSkippedCheckpoints ticks, where one
-// checkpoint is forced to keep the WAL bounded during a long catch-up.
-func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, truncateAboveFrames int, busy func() bool, log *slog.Logger) {
+// The checkpoint runs unconditionally on every tick. An earlier version skipped
+// checkpoints while the Redis write-queue backlog was deep, on the theory that a
+// checkpoint competes with backlog-draining writes on the single connection. In
+// production the stale backlog kept that gate tripped permanently, so no
+// checkpoint ever ran and the WAL bloated to hundreds of MB — which made *every*
+// write slow (each op walks the WAL), the exact opposite of the intended effect,
+// and even stalled a schema migration on first open. PASSIVE checkpoints are
+// cheap; running them every tick keeps the WAL small and writes fast, so there is
+// no gate.
+func (d *DB) RunPeriodicCheckpoint(ctx context.Context, interval time.Duration, mode CheckpointMode, truncateAboveFrames int, log *slog.Logger) {
 	retryInterval := 5 * time.Second
 	t := time.NewTicker(interval)
 	defer t.Stop()
-	skipped := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			isBusy := busy != nil && busy()
-			if skip, next := checkpointGate(isBusy, skipped); skip {
-				skipped = next
-				log.Debug("writer catching up on backlog; skipping checkpoint", "consecutive_skips", skipped)
-				continue
-			}
-			if skipped >= maxSkippedCheckpoints {
-				log.Info("forcing checkpoint after prolonged catch-up to bound the WAL", "skipped", skipped)
-			}
-			skipped = 0
 			frames := d.checkpoint(ctx, mode, retryInterval, log)
 			if mode == CheckpointPassive && truncateAboveFrames > 0 && frames > truncateAboveFrames {
 				log.Info("wal exceeded truncate threshold; escalating to one TRUNCATE checkpoint",

--- a/internal/repository/db_checkpoint_test.go
+++ b/internal/repository/db_checkpoint_test.go
@@ -97,32 +97,3 @@ func TestCheckpointFrameCount(t *testing.T) {
 		t.Fatalf("TRUNCATE checkpoint should report 0 WAL frames after reset, got %d", n)
 	}
 }
-
-// TestCheckpointGate covers the busy-skip decision: skip while busy up to the
-// cap, then force a checkpoint; never skip when idle.
-func TestCheckpointGate(t *testing.T) {
-	// Not busy: always checkpoint, skip count resets.
-	if skip, next := checkpointGate(false, 0); skip || next != 0 {
-		t.Fatalf("idle should checkpoint: skip=%v next=%d", skip, next)
-	}
-	if skip, next := checkpointGate(false, 5); skip || next != 0 {
-		t.Fatalf("idle should checkpoint and reset skips: skip=%v next=%d", skip, next)
-	}
-
-	// Busy: skip and increment, until the cap is reached.
-	skipped := 0
-	for i := 0; i < maxSkippedCheckpoints; i++ {
-		skip, next := checkpointGate(true, skipped)
-		if !skip {
-			t.Fatalf("busy below cap (skipped=%d) should skip", skipped)
-		}
-		skipped = next
-	}
-	if skipped != maxSkippedCheckpoints {
-		t.Fatalf("expected %d consecutive skips, got %d", maxSkippedCheckpoints, skipped)
-	}
-	// At the cap while still busy: force a checkpoint (don't skip), reset count.
-	if skip, next := checkpointGate(true, skipped); skip || next != 0 {
-		t.Fatalf("busy at cap should force checkpoint and reset: skip=%v next=%d", skip, next)
-	}
-}


### PR DESCRIPTION
## What & why

Two related storage fixes discovered during a production writer-wedge investigation.

### Production — move SQLite to fast, hard-capped storage
The prod writer kept wedging because SQLite lived on **vdb**, an IOPS-starved network volume (~2.5 MB/s random I/O) → WAL bloat → every write wedged. The node's **vda root SSD** is 30–150× faster on random I/O.

- Repoint the (manually-applied) PV/PVC at a **hard-capped 5 GB ext4 loopback on vda** instead of vdb. The loopback makes SQLite fast **and** hard-bounds spanbarn's disk use so a Litestream local-cache runaway can only fill its own 5 GB, never the node.
- PV manifest now documents the node-level loopback + fstab setup.
- The live DB was rebuilt fresh during a short cutover: **config tables only** (projects/users/api_keys/settings/alerts/saved_queries/trace_exclusions), all telemetry history dropped. Verified schema parity + integrity + row counts. Old 6.8 GB vdb DB retained as rollback.
- Remove stale, unreferenced `production/pvc-patch.yaml`.

### Staging — disable Litestream
Staging's Litestream local WAL cache grew to **117 GB** (broken S3 creds → never prunes), filling the k3s1 control-plane/etcd node (DiskPressure, spanbarn-staging down 9 h). Blank `LITESTREAM_ACCESS_KEY_ID` so the entrypoint runs the binary directly — staging data is disposable, no backup needed.

## Notes
- PV/PVC are one-time manual cluster-setup resources (not in the rolling-deploy base); they were applied live and are documented here for record.
- Post-cutover prod is stable: writes fast, **zero wedges**, volume bounded ~1.1 GB well under the 5 GB cap, Litestream self-prunes.