### PR TITLE
fix(auth): render header identity from a profile cookie, not the hosted badge

### DIFF
--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -117,6 +117,14 @@ func HandleLogout() http.HandlerFunc {
 			Secure:   isSecureRequest(r),
 			SameSite: http.SameSiteLaxMode,
 		})
+		// Clear the JS-readable profile snapshot used by the header chip.
+		http.SetCookie(w, &http.Cookie{
+			Name:     "spanbarn_iam_profile",
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			SameSite: http.SameSiteLaxMode,
+		})
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -144,6 +145,23 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+	// Non-HttpOnly profile snapshot (name/email/picture) taken from the ID token
+	// so the header chip can render the live avatar + name with no runtime
+	// dependency on IamBarn (the access token is short-lived; this is stable for
+	// the session). Values are non-secret identity attributes the user owns.
+	profile, _ := json.Marshal(map[string]string{
+		"name":    username,
+		"email":   claims.Email,
+		"picture": claims.Picture,
+	})
+	http.SetCookie(w, &http.Cookie{
+		Name:     "spanbarn_iam_profile",
+		Value:    base64.RawURLEncoding.EncodeToString(profile),
+		Path:     "/",
+		Expires:  expires,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
 	// Clear the short-lived state/nonce/next cookies.
 	http.SetCookie(w, oidcShortLivedCookie(oidcStateCookie, "", secure))
 	http.SetCookie(w, oidcShortLivedCookie(oidcNonceCookie, "", secure))
@@ -168,13 +186,14 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 // point is to run while tearing a session down.
 func (s *Server) handleOIDCLogoutComplete(w http.ResponseWriter, r *http.Request) {
 	secure := isSecureRequest(r)
-	for _, name := range []string{"session", "spanbarn_auth_method", "spanbarn_iam_token"} {
+	jsReadable := map[string]bool{"spanbarn_auth_method": true, "spanbarn_iam_profile": true}
+	for _, name := range []string{"session", "spanbarn_auth_method", "spanbarn_iam_token", "spanbarn_iam_profile"} {
 		http.SetCookie(w, &http.Cookie{
 			Name:     name,
 			Value:    "",
 			Path:     "/",
 			MaxAge:   -1,
-			HttpOnly: name != "spanbarn_auth_method", // the auth-method hint is JS-readable
+			HttpOnly: !jsReadable[name],
 			Secure:   secure,
 			SameSite: http.SameSiteLaxMode,
 		})

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -229,6 +229,7 @@ type OIDCClaims struct {
 	Email             string   `json:"email"`
 	PreferredUsername string   `json:"preferred_username"`
 	Name              string   `json:"name"`
+	Picture           string   `json:"picture"`
 	Groups            []string `json:"groups"`
 	Roles             []string `json:"roles"`
 	TokenUse          string   `json:"token_use"` // "access_token" for resource-server validation

--- a/web/src/api/iambarnWidget.ts
+++ b/web/src/api/iambarnWidget.ts
@@ -18,6 +18,32 @@ export interface IambarnSession {
   postLogoutRedirectUri?: string
 }
 
+export interface IambarnProfile {
+  name: string
+  email: string
+  picture: string
+}
+
+// Read the profile snapshot (name/email/picture) the OIDC callback stored in the
+// non-HttpOnly `spanbarn_iam_profile` cookie. This lets the header render the
+// live avatar + name with zero runtime dependency on IamBarn — it never blanks
+// out when an access token expires. Returns null for non-OIDC sessions.
+export function getIambarnProfile(): IambarnProfile | null {
+  if (typeof document === 'undefined') return null
+  const raw = document.cookie
+    .split('; ')
+    .find((c) => c.startsWith('spanbarn_iam_profile='))
+    ?.slice('spanbarn_iam_profile='.length)
+  if (!raw) return null
+  try {
+    const json = atob(raw.replace(/-/g, '+').replace(/_/g, '/'))
+    const p = JSON.parse(json) as Partial<IambarnProfile>
+    return { name: p.name ?? '', email: p.email ?? '', picture: p.picture ?? '' }
+  } catch {
+    return null
+  }
+}
+
 let scriptPromise: Promise<void> | null = null
 
 // Inject the hosted widget bundle once; every custom element is registered by

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -1,21 +1,11 @@
-import { type CSSProperties, type ReactElement, useEffect, useRef, useState } from 'react'
+import { type ReactElement, useEffect, useRef, useState } from 'react'
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { Activity, BarChart2, Bell, GitBranch, Network, Search, Database, BrainCircuit, Radio, Settings, LogOut, Globe, ScrollText } from 'lucide-react'
-import { useIambarnSession, iambarnLogout } from '../api/iambarnWidget'
+import { useIambarnSession, iambarnLogout, getIambarnProfile } from '../api/iambarnWidget'
+import { isOIDCSession } from '../api/clientConfig'
 import { IambarnProfileModal } from './IambarnProfileModal'
 import { MobileTabBar } from './MobileTabBar'
 import { PWAInstallBanner } from './PWAInstallBanner'
-
-// Theme the hosted <iambarn-user-badge> to match SpanBarn's tokens.
-const badgeStyle: CSSProperties = {
-  ...({
-    '--iambarn-bg': 'transparent',
-    '--iambarn-text': 'var(--text)',
-    '--iambarn-muted': 'var(--text-muted)',
-    '--iambarn-accent': 'var(--accent)',
-  } as CSSProperties),
-  width: '100%',
-}
 
 const navItems = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -36,6 +26,8 @@ export function DashboardLayout(): ReactElement {
   const navigate = useNavigate()
   const location = useLocation()
   const session = useIambarnSession()
+  const oidc = isOIDCSession()
+  const profile = getIambarnProfile()
   const [profileOpen, setProfileOpen] = useState(false)
   const chipRef = useRef<HTMLButtonElement>(null)
 
@@ -113,7 +105,7 @@ export function DashboardLayout(): ReactElement {
 
         {/* User actions */}
         <div style={{ padding: '0.75rem 0.5rem', borderTop: '1px solid var(--border)' }}>
-          {session ? (
+          {oidc ? (
             <button
               ref={chipRef}
               onClick={() => setProfileOpen(true)}
@@ -124,11 +116,30 @@ export function DashboardLayout(): ReactElement {
                 background: 'transparent',
                 border: 'none',
                 color: 'var(--text-muted)',
-                padding: '0.25rem',
+                gap: '0.625rem',
               }}
             >
-              {/* Hosted IAMBarn avatar + name (+email), fed same-origin via the proxy. */}
-              <iambarn-user-badge server-url={session.proxyUrl} show-email="" style={badgeStyle} />
+              {/* SpanBarn-owned chip fed by the profile cookie — never blanks out. */}
+              {profile?.picture ? (
+                <img
+                  src={profile.picture}
+                  alt=""
+                  style={{ width: 28, height: 28, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
+                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: 28, height: 28, borderRadius: '50%', background: 'var(--accent)', color: '#fff',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12, fontWeight: 600, flexShrink: 0,
+                  }}
+                >
+                  {(profile?.name || profile?.email || '?')[0].toUpperCase()}
+                </div>
+              )}
+              <span style={{ fontSize: '0.875rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {profile?.name || profile?.email || 'Account'}
+              </span>
             </button>
           ) : (
             <button
@@ -147,10 +158,10 @@ export function DashboardLayout(): ReactElement {
             </button>
           )}
         </div>
-        {profileOpen && session && (
+        {profileOpen && oidc && (
           <IambarnProfileModal
-            issuer={session.issuer}
-            proxyUrl={session.proxyUrl}
+            issuer={session?.issuer ?? ''}
+            proxyUrl={session?.proxyUrl ?? ''}
             triggerRef={chipRef}
             onClose={() => setProfileOpen(false)}
             onLogout={handleLogout}

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -1,18 +1,9 @@
-import { useRef, useState, type CSSProperties, type ReactElement } from 'react'
+import { useRef, useState, type ReactElement } from 'react'
 import { NavLink, useNavigate } from 'react-router-dom'
 import { Activity, BarChart2, Bell, Search, GitBranch, BrainCircuit, MoreHorizontal, Settings, Database, Radio, Network, Globe, LogOut, ScrollText } from 'lucide-react'
-import { useIambarnSession, iambarnLogout } from '../api/iambarnWidget'
+import { useIambarnSession, iambarnLogout, getIambarnProfile } from '../api/iambarnWidget'
+import { isOIDCSession } from '../api/clientConfig'
 import { IambarnProfileModal } from './IambarnProfileModal'
-
-const badgeStyle: CSSProperties = {
-  ...({
-    '--iambarn-bg': 'transparent',
-    '--iambarn-text': 'var(--text-muted)',
-    '--iambarn-muted': 'var(--text-muted)',
-    '--iambarn-accent': 'var(--accent)',
-  } as CSSProperties),
-  width: '100%',
-}
 
 const tabs = [
   { to: '/', icon: Activity, label: 'Services' },
@@ -24,6 +15,8 @@ const tabs = [
 export function MobileTabBar(): ReactElement {
   const [moreOpen, setMoreOpen] = useState(false)
   const session = useIambarnSession()
+  const oidc = isOIDCSession()
+  const profile = getIambarnProfile()
   const [profileOpen, setProfileOpen] = useState(false)
   const profileBtnRef = useRef<HTMLButtonElement>(null)
   const navigate = useNavigate()
@@ -218,7 +211,7 @@ export function MobileTabBar(): ReactElement {
             <Settings size={18} />
             Settings
           </NavLink>
-          {session && (
+          {oidc && (
             <button
               ref={profileBtnRef}
               onClick={() => {
@@ -232,14 +225,33 @@ export function MobileTabBar(): ReactElement {
                 width: '100%',
                 padding: '0.625rem 0.75rem',
                 borderRadius: '0.5rem',
+                fontSize: '0.875rem',
+                fontWeight: 500,
+                color: 'var(--text-muted)',
                 background: 'transparent',
                 border: 'none',
                 cursor: 'pointer',
                 textAlign: 'left',
               }}
             >
-              {/* Hosted IAMBarn avatar + name (+email), fed same-origin via the proxy. */}
-              <iambarn-user-badge server-url={session.proxyUrl} show-email="" style={badgeStyle} />
+              {profile?.picture ? (
+                <img
+                  src={profile.picture}
+                  alt=""
+                  style={{ width: 24, height: 24, borderRadius: '50%', objectFit: 'cover', flexShrink: 0 }}
+                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                />
+              ) : (
+                <div
+                  style={{
+                    width: 24, height: 24, borderRadius: '50%', background: 'var(--accent)', color: '#fff',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 600, flexShrink: 0,
+                  }}
+                >
+                  {(profile?.name || profile?.email || '?')[0].toUpperCase()}
+                </div>
+              )}
+              {profile?.name || profile?.email || 'Account'}
             </button>
           )}
           <button
@@ -336,10 +348,10 @@ export function MobileTabBar(): ReactElement {
           More
         </button>
       </nav>
-      {profileOpen && session && (
+      {profileOpen && oidc && (
         <IambarnProfileModal
-          issuer={session.issuer}
-          proxyUrl={session.proxyUrl}
+          issuer={session?.issuer ?? ''}
+          proxyUrl={session?.proxyUrl ?? ''}
           triggerRef={profileBtnRef}
           onClose={() => setProfileOpen(false)}
           onLogout={handleLogout}


### PR DESCRIPTION
## Why

The hosted `<iambarn-user-badge>` (added in #132) fetches `/api/v1/me` through the proxy on every render and renders **nothing** on failure — so an expired access token or any IamBarn hiccup blanked the entire user chip in the sidebar/mobile nav. That's a regression versus the resilient session-based chip, and it's what surfaced the prod incident.

## What

Snapshot `name`/`email`/`picture` from the OIDC **id token** at callback into a non-HttpOnly `spanbarn_iam_profile` cookie, and render a **SpanBarn-owned** avatar+name chip from it. The header now has **zero runtime dependency** on IamBarn — it can't blank out. The cookie is cleared on local logout and on the `/api/v1/oidc/logout-complete` landing.

The hosted `<iambarn-profile>` editor stays on `/account` (unblocked by the IamBarn signature-verify fix, iam PR #176).

- `OIDCClaims` gains `picture`; the OIDC callback sets the profile cookie
- `getIambarnProfile()` reads it; `DashboardLayout` + `MobileTabBar` render the chip (gated on `isOIDCSession()`); the hosted badge is removed
- profile cookie cleared in `HandleLogout` + `handleOIDCLogoutComplete`

## Tests
Go build + api/auth/config suites pass; web tsc + eslint + 59 Vitest pass.