### PR TITLE
fix(auth): request offline_access and silently refresh the iambarn session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.43.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
@@ -71,7 +72,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/internal/api/iam_proxy.go
+++ b/internal/api/iam_proxy.go
@@ -1,15 +1,24 @@
 package api
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
 )
 
 // handleIAMProxy forwards iambarn-profile widget API requests to IamBarn
 // using the OIDC access token stored in the spanbarn_iam_token cookie.
 // The widget's server-url points at /iam-proxy so all requests are
 // same-origin to SpanBarn — no cross-origin cookie issues.
+//
+// If IamBarn rejects the access token with 401, this transparently refreshes
+// it via the spanbarn_iam_refresh cookie (when present) and retries once —
+// the caller never sees the 401. Only a failed refresh (dead refresh token)
+// surfaces as 401, which is what sends the SPA to the "sign in again" screen.
 func (s *Server) handleIAMProxy(w http.ResponseWriter, r *http.Request) {
 	if s.oidc == nil {
 		writeError(w, http.StatusNotFound, "oidc not configured", "")
@@ -37,20 +46,32 @@ func (s *Server) handleIAMProxy(w http.ResponseWriter, r *http.Request) {
 		targetURL += "?" + r.URL.RawQuery
 	}
 
-	req, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
-	if err != nil {
-		writeError(w, http.StatusBadGateway, "proxy error", "")
-		return
+	// Buffer the body so it can be replayed if a refresh+retry is needed —
+	// the original r.Body can only be read once.
+	var body []byte
+	if r.Body != nil {
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "read request body", "")
+			return
+		}
 	}
-	if ct := r.Header.Get("Content-Type"); ct != "" {
-		req.Header.Set("Content-Type", ct)
-	}
-	req.Header.Set("Authorization", "Bearer "+tokenCookie.Value)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.proxyToIAM(r, targetURL, tokenCookie.Value, body)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "iambarn unreachable", "")
 		return
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+		if refreshed, ok := s.tryRefreshIAMToken(w, r); ok {
+			resp, err = s.proxyToIAM(r, targetURL, refreshed, body)
+			if err != nil {
+				writeError(w, http.StatusBadGateway, "iambarn unreachable", "")
+				return
+			}
+		}
 	}
 	defer resp.Body.Close()
 
@@ -64,6 +85,55 @@ func (s *Server) handleIAMProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(resp.StatusCode)
 	_, _ = io.Copy(w, resp.Body)
+}
+
+// proxyToIAM issues one proxied request to IamBarn with the given bearer
+// token, replaying body on each call (retries reuse the same buffered bytes).
+func (s *Server) proxyToIAM(r *http.Request, targetURL, bearer string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	return http.DefaultClient.Do(req)
+}
+
+// tryRefreshIAMToken attempts a silent token refresh using the
+// spanbarn_iam_refresh cookie. On success it rewrites both iambarn cookies
+// with the rotated pair and returns the new access token. On a definitive
+// invalid_grant failure (dead refresh token) it clears both cookies so the
+// next request cleanly surfaces the "sign in again" screen instead of
+// retrying a token that's gone. On a transient error (e.g. network timeout)
+// it leaves the stored refresh token untouched — retrying an ambiguous
+// refresh call with the same token risks a replay, so callers get one 401
+// today and try again on the next request instead.
+func (s *Server) tryRefreshIAMToken(w http.ResponseWriter, r *http.Request) (string, bool) {
+	refreshCookie, err := r.Cookie("spanbarn_iam_refresh")
+	if err != nil || refreshCookie.Value == "" {
+		return "", false
+	}
+
+	// singleflight collapses concurrent requests that hit 401 with the same
+	// refresh_token into one token-endpoint call — see Server.iamRefresh.
+	v, err, _ := s.iamRefresh.Do(refreshCookie.Value, func() (any, error) {
+		return s.oidc.Refresh(r.Context(), refreshCookie.Value)
+	})
+	if err != nil {
+		if errors.Is(err, auth.ErrRefreshInvalid) {
+			s.logger.Info("oidc: refresh token invalid, clearing iambarn session")
+			clearIAMTokenCookies(w, isSecureRequest(r))
+		} else {
+			s.logger.Warn("oidc: refresh failed", "error", err)
+		}
+		return "", false
+	}
+
+	refreshed := v.(auth.RefreshedTokens)
+	setIAMTokenCookies(w, refreshed.AccessToken, refreshed.RefreshToken, refreshed.ExpiresAt, isSecureRequest(r))
+	return refreshed.AccessToken, true
 }
 
 // proxyResponseHeaders is the set of upstream response headers the IAM proxy

--- a/internal/api/iam_proxy_test.go
+++ b/internal/api/iam_proxy_test.go
@@ -1,0 +1,243 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
+)
+
+// newIAMProxyTestIssuer spins up a fake iambarn that serves discovery, a
+// refresh_token token endpoint, and /api/v1/me — enough to drive
+// handleIAMProxy's silent-refresh path end to end. currentAccess tracks the
+// access token /api/v1/me currently accepts; refreshTo/refreshCount let tests
+// script and observe the token endpoint.
+type iamProxyTestIssuer struct {
+	srv *httptest.Server
+
+	mu              sync.Mutex
+	currentAccess   string
+	nextAccess      string
+	nextRefresh     string
+	refreshCalls    int32
+	refreshRejected bool
+	// refreshDelay, when set, holds the token endpoint open briefly so tests
+	// can force many concurrent callers to overlap in time before the first
+	// one completes — singleflight only collapses calls that are genuinely
+	// in flight together, so without this an in-process mock responds fast
+	// enough that goroutines can serialize through as separate (still
+	// individually valid, non-overlapping) calls.
+	refreshDelay time.Duration
+}
+
+func newIAMProxyTestIssuer(t *testing.T) *iamProxyTestIssuer {
+	t.Helper()
+	it := &iamProxyTestIssuer{}
+	mux := http.NewServeMux()
+	it.srv = httptest.NewServer(mux)
+	t.Cleanup(it.srv.Close)
+	issuer := it.srv.URL
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                issuer,
+			"authorization_endpoint":                issuer + "/oauth2/authorize",
+			"token_endpoint":                        issuer + "/oauth2/token",
+			"jwks_uri":                              issuer + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"EdDSA"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{}})
+	})
+	mux.HandleFunc("/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&it.refreshCalls, 1)
+		if it.refreshDelay > 0 {
+			time.Sleep(it.refreshDelay)
+		}
+		it.mu.Lock()
+		defer it.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		if it.refreshRejected {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid_grant"})
+			return
+		}
+		it.currentAccess = it.nextAccess
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  it.nextAccess,
+			"refresh_token": it.nextRefresh,
+			"token_type":    "Bearer",
+			"expires_in":    900,
+		})
+	})
+	mux.HandleFunc("/api/v1/me", func(w http.ResponseWriter, r *http.Request) {
+		it.mu.Lock()
+		want := it.currentAccess
+		it.mu.Unlock()
+		got := r.Header.Get("Authorization")
+		if got != "Bearer "+want {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"username": "wiebe"})
+	})
+	return it
+}
+
+func newIAMProxyTestServer(oc *auth.OIDCClient) *Server {
+	return &Server{logger: slog.Default(), oidc: oc}
+}
+
+func iamProxyRequest(accessCookie, refreshCookie string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/api/iam-proxy/api/v1/me", nil)
+	if accessCookie != "" {
+		req.AddCookie(&http.Cookie{Name: "spanbarn_iam_token", Value: accessCookie})
+	}
+	if refreshCookie != "" {
+		req.AddCookie(&http.Cookie{Name: "spanbarn_iam_refresh", Value: refreshCookie})
+	}
+	return req
+}
+
+func TestHandleIAMProxySilentlyRefreshesExpiredToken(t *testing.T) {
+	it := newIAMProxyTestIssuer(t)
+	it.currentAccess = "server-side-current-token"
+	it.nextAccess = "fresh-access"
+	it.nextRefresh = "fresh-refresh"
+
+	oc := auth.NewOIDCClient(auth.OIDCConfig{Issuer: it.srv.URL, ClientID: "spanbarn-web", ClientSecret: "sek", RedirectURL: "https://spanbarn.example.com/cb"})
+	s := newIAMProxyTestServer(oc)
+
+	req := iamProxyRequest("expired-access", "old-refresh")
+	rec := httptest.NewRecorder()
+	s.handleIAMProxy(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected the caller to never see the 401 (silent refresh), got %d: %s", rec.Code, rec.Body.String())
+	}
+	if atomic.LoadInt32(&it.refreshCalls) != 1 {
+		t.Errorf("expected exactly 1 refresh call, got %d", it.refreshCalls)
+	}
+
+	cookies := rec.Result().Cookies()
+	var gotAccess, gotRefresh string
+	for _, c := range cookies {
+		switch c.Name {
+		case "spanbarn_iam_token":
+			gotAccess = c.Value
+		case "spanbarn_iam_refresh":
+			gotRefresh = c.Value
+		}
+	}
+	if gotAccess != "fresh-access" {
+		t.Errorf("access cookie not updated: got %q, want fresh-access", gotAccess)
+	}
+	if gotRefresh != "fresh-refresh" {
+		t.Errorf("refresh cookie not rotated: got %q, want fresh-refresh", gotRefresh)
+	}
+}
+
+func TestHandleIAMProxyClearsCookiesOnInvalidGrant(t *testing.T) {
+	it := newIAMProxyTestIssuer(t)
+	it.currentAccess = "server-side-current-token"
+	it.refreshRejected = true
+
+	oc := auth.NewOIDCClient(auth.OIDCConfig{Issuer: it.srv.URL, ClientID: "spanbarn-web", ClientSecret: "sek", RedirectURL: "https://spanbarn.example.com/cb"})
+	s := newIAMProxyTestServer(oc)
+
+	req := iamProxyRequest("expired-access", "dead-refresh")
+	rec := httptest.NewRecorder()
+	s.handleIAMProxy(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected a clean 401 (dead refresh token), got %d", rec.Code)
+	}
+	for _, c := range rec.Result().Cookies() {
+		if (c.Name == "spanbarn_iam_token" || c.Name == "spanbarn_iam_refresh") && c.MaxAge >= 0 {
+			t.Errorf("cookie %q should be cleared (MaxAge<0), got MaxAge=%d value=%q", c.Name, c.MaxAge, c.Value)
+		}
+	}
+}
+
+func TestHandleIAMProxyNoRefreshCookieReturns401(t *testing.T) {
+	it := newIAMProxyTestIssuer(t)
+	it.currentAccess = "server-side-current-token"
+
+	oc := auth.NewOIDCClient(auth.OIDCConfig{Issuer: it.srv.URL, ClientID: "spanbarn-web", ClientSecret: "sek", RedirectURL: "https://spanbarn.example.com/cb"})
+	s := newIAMProxyTestServer(oc)
+
+	// No refresh cookie at all (e.g. a session predating offline_access) —
+	// must fall straight through to 401, no refresh attempt.
+	req := iamProxyRequest("expired-access", "")
+	rec := httptest.NewRecorder()
+	s.handleIAMProxy(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if atomic.LoadInt32(&it.refreshCalls) != 0 {
+		t.Errorf("should not have attempted a refresh with no refresh cookie, got %d calls", it.refreshCalls)
+	}
+}
+
+// TestHandleIAMProxyConcurrentRequestsShareOneRefresh reproduces two widget
+// API calls firing back-to-back right after the access token expires. Both
+// present the same (single-use) refresh_token; only one token-endpoint call
+// must happen — a second concurrent call with the same refresh_token would
+// be replay-rejected by iambarn and revoke the whole token family.
+func TestHandleIAMProxyConcurrentRequestsShareOneRefresh(t *testing.T) {
+	it := newIAMProxyTestIssuer(t)
+	it.currentAccess = "server-side-current-token"
+	it.nextAccess = "fresh-access"
+	it.nextRefresh = "fresh-refresh"
+	// Force every goroutine's refresh attempt to overlap: without this, an
+	// in-process mock can respond fast enough that 8 goroutines serialize
+	// through as separate (individually valid) calls instead of racing.
+	it.refreshDelay = 50 * time.Millisecond
+
+	oc := auth.NewOIDCClient(auth.OIDCConfig{Issuer: it.srv.URL, ClientID: "spanbarn-web", ClientSecret: "sek", RedirectURL: "https://spanbarn.example.com/cb"})
+	s := newIAMProxyTestServer(oc)
+
+	const n = 8
+	var wg sync.WaitGroup
+	var ready sync.WaitGroup
+	start := make(chan struct{})
+	codes := make([]int, n)
+	ready.Add(n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := iamProxyRequest("expired-access", "old-refresh")
+			rec := httptest.NewRecorder()
+			ready.Done()
+			<-start // all goroutines fire together, maximizing overlap
+			s.handleIAMProxy(rec, req)
+			codes[i] = rec.Code
+		}(i)
+	}
+	ready.Wait()
+	close(start)
+	wg.Wait()
+
+	for i, code := range codes {
+		if code != http.StatusOK {
+			t.Errorf("request %d: expected 200, got %d", i, code)
+		}
+	}
+	if got := atomic.LoadInt32(&it.refreshCalls); got != 1 {
+		t.Errorf("expected exactly 1 refresh call across %d concurrent requests, got %d", n, got)
+	}
+}

--- a/internal/api/login.go
+++ b/internal/api/login.go
@@ -106,17 +106,10 @@ func HandleLogout() http.HandlerFunc {
 			MaxAge:   -1,
 			SameSite: http.SameSiteLaxMode,
 		})
-		// Clear the OIDC access token used for iambarn-proxy requests, so a
-		// local logout fully tears down the browser's IamBarn linkage too.
-		http.SetCookie(w, &http.Cookie{
-			Name:     "spanbarn_iam_token",
-			Value:    "",
-			Path:     "/",
-			MaxAge:   -1,
-			HttpOnly: true,
-			Secure:   isSecureRequest(r),
-			SameSite: http.SameSiteLaxMode,
-		})
+		// Clear the iambarn access/refresh tokens used for iambarn-proxy
+		// requests, so a local logout fully tears down the browser's IamBarn
+		// linkage too.
+		clearIAMTokenCookies(w, isSecureRequest(r))
 		// Clear the JS-readable profile snapshot used by the header chip.
 		http.SetCookie(w, &http.Cookie{
 			Name:     "spanbarn_iam_profile",

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -26,7 +26,87 @@ const (
 	oidcNonceCookie = "spanbarn_oidc_nonce"
 	oidcNextCookie  = "spanbarn_oidc_next"
 	oidcCookieTTL   = 10 * time.Minute
+
+	// iamAccessCookie holds the raw iambarn access_token used to authenticate
+	// outbound /api/iam-proxy requests. HttpOnly: JS on the page never sees it.
+	iamAccessCookie = "spanbarn_iam_token"
+	// iamRefreshCookie holds the iambarn refresh_token. Same protections as
+	// the access token, but longer-lived — treated like a password, never
+	// exposed to page JS. It rotates on every use (handleIAMProxy overwrites
+	// it after each silent refresh).
+	iamRefreshCookie = "spanbarn_iam_refresh"
+	// iamRefreshTokenTTL mirrors iambarn's refresh_token lifetime: 30 days
+	// from issuance, extended another 30 days on every use. There's no
+	// absolute cap, so each refresh resets this cookie's Max-Age too.
+	iamRefreshTokenTTL = 30 * 24 * time.Hour
+	// iamAccessFallbackTTL is used only if a token response omits
+	// expires_in (shouldn't happen against iambarn, but a zero Expiry can't
+	// be turned into a sane cookie Expires).
+	iamAccessFallbackTTL = 15 * time.Minute
 )
+
+// setIAMTokenCookies stores the iambarn access/refresh token pair as
+// HttpOnly, Secure cookies. Used both on initial OIDC login and after a
+// silent refresh (handleIAMProxy), where it also carries the rotated
+// refresh_token that must overwrite the one just spent.
+//
+// When a refresh_token is present, the access-token cookie is given the same
+// long Max-Age as the refresh cookie rather than the access token's real
+// ~15m lifetime: staleness is now detected server-side via a 401 from
+// IamBarn and repaired with a silent refresh (see handleIAMProxy), so the
+// browser must keep sending the cookie well past 15 minutes for that path to
+// ever run. Expiring it on the access token's real lifetime would have the
+// browser discard it before a refresh could happen, reproducing the exact
+// forced-relogin bug this is fixing. Without a refresh_token there's nothing
+// to renew with, so it keeps the short, real expiry as before.
+func setIAMTokenCookies(w http.ResponseWriter, accessToken, refreshToken string, accessExpiresAt time.Time, secure bool) {
+	accessExp := accessExpiresAt
+	if accessExp.IsZero() {
+		accessExp = time.Now().Add(iamAccessFallbackTTL)
+	}
+	if refreshToken != "" {
+		accessExp = time.Now().Add(iamRefreshTokenTTL)
+	}
+	if accessToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     iamAccessCookie,
+			Value:    accessToken,
+			Path:     "/",
+			Expires:  accessExp,
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+	if refreshToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     iamRefreshCookie,
+			Value:    refreshToken,
+			Path:     "/",
+			Expires:  time.Now().Add(iamRefreshTokenTTL),
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+}
+
+// clearIAMTokenCookies removes both iambarn token cookies, e.g. on logout or
+// once a refresh has failed with an invalid_grant (the refresh token is dead
+// and retrying it would only replay-revoke the token family further).
+func clearIAMTokenCookies(w http.ResponseWriter, secure bool) {
+	for _, name := range []string{iamAccessCookie, iamRefreshCookie} {
+		http.SetCookie(w, &http.Cookie{
+			Name:     name,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   secure,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+}
 
 // handleOIDCLogin starts the OIDC authorization-code flow by redirecting the
 // browser to the iambarn authorize endpoint. State + nonce are stored in
@@ -121,20 +201,13 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
-	// Store the OIDC access token so SpanBarn can proxy iambarn-profile widget
-	// API calls server-to-server. HttpOnly prevents JS access; the proxy
-	// handler reads it for outbound Bearer requests to IamBarn.
-	if exchanged.AccessToken != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name:     "spanbarn_iam_token",
-			Value:    exchanged.AccessToken,
-			Path:     "/",
-			Expires:  expires,
-			HttpOnly: true,
-			Secure:   secure,
-			SameSite: http.SameSiteLaxMode,
-		})
-	}
+	// Store the iambarn access/refresh token pair so SpanBarn can proxy
+	// iambarn-profile widget API calls server-to-server. HttpOnly prevents JS
+	// access; handleIAMProxy reads them for outbound Bearer requests to
+	// IamBarn and silently refreshes the access token via the refresh token
+	// once it expires, instead of forcing the user through a full re-login.
+	// RefreshToken is empty if the client wasn't granted offline_access.
+	setIAMTokenCookies(w, exchanged.AccessToken, exchanged.RefreshToken, exchanged.ExpiresAt, secure)
 	// Non-HttpOnly hint so the SPA can show OIDC-specific UI only for
 	// sessions that actually came from iambarn. Same expiry as the session.
 	http.SetCookie(w, &http.Cookie{
@@ -186,8 +259,9 @@ func (s *Server) handleOIDCCallback(w http.ResponseWriter, r *http.Request) {
 // point is to run while tearing a session down.
 func (s *Server) handleOIDCLogoutComplete(w http.ResponseWriter, r *http.Request) {
 	secure := isSecureRequest(r)
+	clearIAMTokenCookies(w, secure)
 	jsReadable := map[string]bool{"spanbarn_auth_method": true, "spanbarn_iam_profile": true}
-	for _, name := range []string{"session", "spanbarn_auth_method", "spanbarn_iam_token", "spanbarn_iam_profile"} {
+	for _, name := range []string{"session", "spanbarn_auth_method", "spanbarn_iam_profile"} {
 		http.SetCookie(w, &http.Cookie{
 			Name:     name,
 			Value:    "",

--- a/internal/api/oidc_cookies_test.go
+++ b/internal/api/oidc_cookies_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func iamCookie(rec *httptest.ResponseRecorder, name string) *http.Cookie {
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestSetIAMTokenCookiesExtendsAccessLifetimeWithRefresh guards against the
+// exact bug this refresh flow exists to fix: if the access-token cookie were
+// given the access token's real ~15m Expires, the browser would delete it
+// before any request could trigger handleIAMProxy's reactive refresh, and
+// the user would be forced back through a full login every 15 minutes
+// anyway. When a refresh_token is issued, the access cookie must outlive
+// that 15-minute window so the silent-refresh path actually gets a chance to
+// run.
+func TestSetIAMTokenCookiesExtendsAccessLifetimeWithRefresh(t *testing.T) {
+	rec := httptest.NewRecorder()
+	shortExpiry := time.Now().Add(15 * time.Minute)
+	setIAMTokenCookies(rec, "access-1", "refresh-1", shortExpiry, true)
+
+	access := iamCookie(rec, iamAccessCookie)
+	if access == nil {
+		t.Fatal("access cookie not set")
+	}
+	if !access.Expires.After(time.Now().Add(24 * time.Hour)) {
+		t.Errorf("access cookie Expires = %v, want far beyond the 15m access-token lifetime (%v) since a refresh_token was issued", access.Expires, shortExpiry)
+	}
+
+	refresh := iamCookie(rec, iamRefreshCookie)
+	if refresh == nil {
+		t.Fatal("refresh cookie not set")
+	}
+	if refresh.Value != "refresh-1" {
+		t.Errorf("refresh cookie value = %q, want refresh-1", refresh.Value)
+	}
+}
+
+// TestSetIAMTokenCookiesKeepsShortExpiryWithoutRefresh covers the degraded
+// case (offline_access not granted): there's no refresh token to renew with,
+// so the access cookie keeps its real, short expiry — same as before this
+// change.
+func TestSetIAMTokenCookiesKeepsShortExpiryWithoutRefresh(t *testing.T) {
+	rec := httptest.NewRecorder()
+	shortExpiry := time.Now().Add(15 * time.Minute)
+	setIAMTokenCookies(rec, "access-1", "", shortExpiry, true)
+
+	access := iamCookie(rec, iamAccessCookie)
+	if access == nil {
+		t.Fatal("access cookie not set")
+	}
+	if access.Expires.After(time.Now().Add(time.Hour)) {
+		t.Errorf("access cookie Expires = %v, want close to the real access-token expiry %v (no refresh_token to extend it)", access.Expires, shortExpiry)
+	}
+	if iamCookie(rec, iamRefreshCookie) != nil {
+		t.Error("refresh cookie should not be set when refreshToken is empty")
+	}
+}
+
+func TestClearIAMTokenCookies(t *testing.T) {
+	rec := httptest.NewRecorder()
+	clearIAMTokenCookies(rec, true)
+
+	for _, name := range []string{iamAccessCookie, iamRefreshCookie} {
+		c := iamCookie(rec, name)
+		if c == nil {
+			t.Fatalf("expected %s to be cleared, got no cookie", name)
+		}
+		if c.MaxAge >= 0 {
+			t.Errorf("%s MaxAge = %d, want negative (deleted)", name, c.MaxAge)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/wiebe-xyz/spanbarn/internal/auth"
 	"github.com/wiebe-xyz/spanbarn/internal/cache"
 	"github.com/wiebe-xyz/spanbarn/internal/ingest"
@@ -62,6 +64,13 @@ type Server struct {
 	logger         *slog.Logger
 	oidc           *auth.OIDCClient
 	selfMetrics    *selfmetrics.Recorder
+
+	// iamRefresh collapses concurrent iam-proxy requests that discover the
+	// same expired refresh_token into a single token-endpoint call. Refresh
+	// tokens are single-use and rotate on every call, so firing two
+	// refreshes with the same token would have iambarn reject the second as
+	// a replay and revoke the whole token family. Zero value is ready to use.
+	iamRefresh singleflight.Group
 }
 
 // SetSelfMetricsRecorder wires the self-metrics recorder so the request

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -82,10 +82,12 @@ func (c *OIDCClient) AuthorizeURL(state, nonce string) (string, error) {
 	return c.oauth.AuthCodeURL(state, oidcv3.Nonce(nonce)), nil
 }
 
-// ExchangeResult holds the parsed claims and the raw OIDC access token.
+// ExchangeResult holds the parsed claims and the raw OIDC tokens.
 type ExchangeResult struct {
-	Claims      OIDCClaims
-	AccessToken string
+	Claims       OIDCClaims
+	AccessToken  string
+	RefreshToken string    // empty if the client/grant did not include offline_access
+	ExpiresAt    time.Time // zero if the token response omitted expires_in
 }
 
 // ExchangeFull swaps an authorization code for tokens, verifies the ID token,
@@ -116,7 +118,65 @@ func (c *OIDCClient) ExchangeFull(ctx context.Context, code, nonce string) (Exch
 	if err := idToken.Claims(&claims); err != nil {
 		return ExchangeResult{}, fmt.Errorf("oidc: decode claims: %w", err)
 	}
-	return ExchangeResult{Claims: claims, AccessToken: tok.AccessToken}, nil
+	return ExchangeResult{
+		Claims:       claims,
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    tok.Expiry,
+	}, nil
+}
+
+// ErrRefreshInvalid indicates iambarn rejected the refresh_token outright
+// (invalid_grant: revoked, expired, already-rotated/replayed, or the user was
+// suspended). The caller must not retry the same token — it is dead — and
+// should fall back to a full interactive login.
+var ErrRefreshInvalid = errors.New("oidc: refresh token invalid")
+
+// RefreshedTokens holds the renewed access/refresh token pair from a
+// refresh_token grant. Iambarn rotates the refresh token on every use, so
+// RefreshToken here always replaces whatever was previously stored.
+type RefreshedTokens struct {
+	AccessToken  string
+	RefreshToken string
+	ExpiresAt    time.Time
+}
+
+// Refresh exchanges a refresh_token for a new access/refresh token pair.
+// It authenticates as the client using the same style already established
+// for the authorization_code exchange (c.oauth carries ClientID/ClientSecret
+// and golang.org/x/oauth2 picks and caches the auth style per token
+// endpoint), so no separate client-auth logic is needed here.
+//
+// Refresh tokens are single-use: iambarn invalidates the one sent here the
+// moment it issues the replacement. Callers MUST NOT invoke Refresh
+// concurrently with the same refreshToken — a second call with an
+// already-rotated token is treated as a replay and revokes the whole token
+// family. Callers are responsible for serializing refreshes per session
+// (e.g. via singleflight).
+func (c *OIDCClient) Refresh(ctx context.Context, refreshToken string) (RefreshedTokens, error) {
+	if err := c.ensureReady(ctx); err != nil {
+		return RefreshedTokens{}, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	tok, err := c.oauth.TokenSource(ctx, &oauth2.Token{RefreshToken: refreshToken}).Token()
+	if err != nil {
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant" {
+			return RefreshedTokens{}, ErrRefreshInvalid
+		}
+		return RefreshedTokens{}, fmt.Errorf("oidc: refresh token: %w", err)
+	}
+	// golang.org/x/oauth2 falls back to the refresh_token we sent if the
+	// response omits one (its accommodation for non-rotating providers), so
+	// tok.RefreshToken is never empty here on a successful response —
+	// iambarn always rotates, so in practice this is always the new token.
+	return RefreshedTokens{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		ExpiresAt:    tok.Expiry,
+	}, nil
 }
 
 // Exchange swaps an authorization code for tokens and verifies the ID token's
@@ -217,7 +277,13 @@ func (c *OIDCClient) ensureReady(ctx context.Context) error {
 		ClientSecret: c.cfg.ClientSecret,
 		Endpoint:     prov.Endpoint(),
 		RedirectURL:  c.cfg.RedirectURL,
-		Scopes:       []string{oidcv3.ScopeOpenID, "profile", "email"},
+		// offline_access asks iambarn for a refresh_token alongside the
+		// short-lived (15m) access_token, so the session can be renewed
+		// silently instead of forcing a full re-login every 15 minutes.
+		// Requesting it here is required even though it's allowed on the
+		// client record — iambarn only grants what's both allowed AND
+		// explicitly requested.
+		Scopes: []string{oidcv3.ScopeOpenID, "profile", "email", "offline_access"},
 	}
 	return nil
 }

--- a/internal/auth/oidc_refresh_test.go
+++ b/internal/auth/oidc_refresh_test.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newRefreshTestIssuer spins up a minimal OIDC issuer (discovery + token
+// endpoint) so AuthorizeURL and Refresh can be exercised without a live
+// iambarn. tokenHandler serves POST /oauth2/token; pass nil if the test never
+// reaches the token endpoint.
+func newRefreshTestIssuer(t *testing.T, tokenHandler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/oauth2/authorize",
+			"token_endpoint":                        srv.URL + "/oauth2/token",
+			"jwks_uri":                              srv.URL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"EdDSA"},
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"keys": []any{}})
+	})
+	if tokenHandler != nil {
+		mux.HandleFunc("/oauth2/token", tokenHandler)
+	}
+	return srv
+}
+
+func testOIDCClient(issuer string) *OIDCClient {
+	return NewOIDCClient(OIDCConfig{
+		Issuer:       issuer,
+		ClientID:     "spanbarn-web",
+		ClientSecret: "sek",
+		RedirectURL:  "https://spanbarn.example.com/api/v1/oidc/callback",
+	})
+}
+
+func TestAuthorizeURLRequestsOfflineAccessScope(t *testing.T) {
+	srv := newRefreshTestIssuer(t, nil)
+	oc := testOIDCClient(srv.URL)
+
+	raw, err := oc.AuthorizeURL("state1", "nonce1")
+	if err != nil {
+		t.Fatalf("AuthorizeURL: %v", err)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse authorize url: %v", err)
+	}
+	scopes := strings.Fields(u.Query().Get("scope"))
+	want := map[string]bool{"openid": false, "profile": false, "email": false, "offline_access": false}
+	for _, s := range scopes {
+		if _, ok := want[s]; ok {
+			want[s] = true
+		}
+	}
+	for scope, got := range want {
+		if !got {
+			t.Errorf("authorize URL scope %q missing from %q", scope, u.Query().Get("scope"))
+		}
+	}
+}
+
+func TestOIDCClientRefreshSuccess(t *testing.T) {
+	var gotForm url.Values
+	srv := newRefreshTestIssuer(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		gotForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+			"token_type":    "Bearer",
+			"expires_in":    900,
+		})
+	})
+	oc := testOIDCClient(srv.URL)
+
+	result, err := oc.Refresh(context.Background(), "old-refresh")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.AccessToken != "new-access" {
+		t.Errorf("AccessToken = %q, want new-access", result.AccessToken)
+	}
+	if result.RefreshToken != "new-refresh" {
+		t.Errorf("RefreshToken = %q, want new-refresh (rotation)", result.RefreshToken)
+	}
+	if result.ExpiresAt.Before(time.Now().Add(14 * time.Minute)) {
+		t.Errorf("ExpiresAt = %v, want ~15 minutes out", result.ExpiresAt)
+	}
+	if gotForm.Get("grant_type") != "refresh_token" {
+		t.Errorf("grant_type = %q, want refresh_token", gotForm.Get("grant_type"))
+	}
+	if gotForm.Get("refresh_token") != "old-refresh" {
+		t.Errorf("refresh_token sent = %q, want old-refresh", gotForm.Get("refresh_token"))
+	}
+}
+
+func TestOIDCClientRefreshInvalidGrant(t *testing.T) {
+	srv := newRefreshTestIssuer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":             "invalid_grant",
+			"error_description": "refresh token revoked or already used",
+		})
+	})
+	oc := testOIDCClient(srv.URL)
+
+	_, err := oc.Refresh(context.Background(), "dead-refresh")
+	if !errors.Is(err, ErrRefreshInvalid) {
+		t.Fatalf("Refresh error = %v, want ErrRefreshInvalid", err)
+	}
+}
+
+// TestOIDCClientRefreshMissingRotatedToken documents a golang.org/x/oauth2
+// behavior we rely on: if a token response omits refresh_token, the library
+// falls back to the refresh_token that was sent in the request instead of
+// leaving it empty (its accommodation for non-rotating providers). IamBarn
+// always rotates in practice, so this path is defensive, not expected.
+func TestOIDCClientRefreshMissingRotatedToken(t *testing.T) {
+	srv := newRefreshTestIssuer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"token_type":   "Bearer",
+			"expires_in":   900,
+		})
+	})
+	oc := testOIDCClient(srv.URL)
+
+	result, err := oc.Refresh(context.Background(), "old-refresh")
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.RefreshToken != "old-refresh" {
+		t.Errorf("RefreshToken = %q, want the fallback to the sent old-refresh", result.RefreshToken)
+	}
+}
+
+func TestOIDCClientRefreshServerError(t *testing.T) {
+	srv := newRefreshTestIssuer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server_error"}`))
+	})
+	oc := testOIDCClient(srv.URL)
+
+	_, err := oc.Refresh(context.Background(), "old-refresh")
+	if err == nil {
+		t.Fatal("expected error on 500 response")
+	}
+	if errors.Is(err, ErrRefreshInvalid) {
+		t.Error("a transient server_error must not be classified as ErrRefreshInvalid — the caller must not treat it as a dead token")
+	}
+}


### PR DESCRIPTION
## Summary
- Request `offline_access` on the OIDC authorize redirect and store the resulting `refresh_token` (HttpOnly cookie, same protection as the existing access-token cookie) so the browser session doesn't die every 15 minutes.
- `handleIAMProxy` now silently refreshes on a 401 from IamBarn and retries once, instead of surfacing the 401 to the SPA — the "session expired, sign in again" screen only appears once the refresh itself has actually failed.
- Refreshes are serialized per refresh-token via `singleflight` so two concurrent requests never double-spend the same (single-use, rotating) refresh token; a definitive `invalid_grant` clears the session for a clean re-login instead of looping.

## Test plan
- [x] `go test ./...` and `go test -race ./internal/api/... ./internal/auth/...` pass, including new tests for scope request, refresh success/rotation, `invalid_grant` handling, silent-refresh-on-401, cookie clearing, and a forced-concurrency singleflight test.
- [x] `scripts/quality-gate.sh` passes (no regression in coverage/complexity/duplication).
- [ ] CI (spec/lint/test/build + quality gate) green on this PR.
- [ ] Automated E2E against staging (OIDC login) passes after merge.
- [ ] Manual: log in via OIDC, force-expire the access token, confirm `/api/v1/me` silently recovers with no visible interruption; confirm the stored refresh_token rotates; confirm an invalid refresh_token produces a single clean re-login prompt, not a loop.