### PR TITLE
fix(auth): show a signed-out state after logout instead of bouncing back to the IdP

### DIFF
--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -185,8 +185,8 @@ func TestOIDCLogoutComplete(t *testing.T) {
 	if resp.StatusCode != http.StatusFound {
 		t.Fatalf("expected 302, got %d", resp.StatusCode)
 	}
-	if loc := resp.Header.Get("Location"); loc != "/login" {
-		t.Fatalf("expected redirect to /login, got %q", loc)
+	if loc := resp.Header.Get("Location"); loc != "/login?logged_out=1" {
+		t.Fatalf("expected redirect to /login?logged_out=1, got %q", loc)
 	}
 	cleared := map[string]bool{"session": false, "spanbarn_auth_method": false, "spanbarn_iam_token": false}
 	for _, c := range resp.Cookies() {

--- a/internal/api/oidc.go
+++ b/internal/api/oidc.go
@@ -257,7 +257,10 @@ func (s *Server) handleOIDCLogoutComplete(w http.ResponseWriter, r *http.Request
 	}
 	// Never cache the teardown; a replayed 302 must not resurrect a cleared UI.
 	w.Header().Set("Cache-Control", "no-store")
-	http.Redirect(w, r, "/login", http.StatusFound)
+	// Land with ?logged_out=1 so the login page shows a signed-out state instead
+	// of auto-restarting OIDC — otherwise logout bounces straight back into the
+	// IdP's authorize/login and the user never sees they were signed out.
+	http.Redirect(w, r, "/login?logged_out=1", http.StatusFound)
 }
 
 // handleSessionRefresh (POST /api/v1/session/refresh) forces the refresh

--- a/web/src/components/DashboardLayout.tsx
+++ b/web/src/components/DashboardLayout.tsx
@@ -42,7 +42,7 @@ export function DashboardLayout(): ReactElement {
 
   const handleLogout = async () => {
     setProfileOpen(false)
-    await iambarnLogout(session, () => navigate('/login', { replace: true }))
+    await iambarnLogout(session, () => navigate('/login?logged_out=1', { replace: true }))
   }
 
   return (

--- a/web/src/components/MobileTabBar.tsx
+++ b/web/src/components/MobileTabBar.tsx
@@ -24,7 +24,7 @@ export function MobileTabBar(): ReactElement {
   const handleLogout = async () => {
     setProfileOpen(false)
     setMoreOpen(false)
-    await iambarnLogout(session, () => navigate('/login', { replace: true }))
+    await iambarnLogout(session, () => navigate('/login?logged_out=1', { replace: true }))
   }
 
   return (

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -32,9 +32,14 @@ export function LoginPage(): ReactElement {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
-  const [redirecting, setRedirecting] = useState(true)
+  // Set by the post-logout landing (/login?logged_out=1): show a signed-out
+  // state instead of auto-restarting OIDC, which would bounce the just-signed-out
+  // user straight back to the IdP login.
+  const loggedOut = new URLSearchParams(window.location.search).has('logged_out')
+  const [redirecting, setRedirecting] = useState(!loggedOut)
 
   useEffect(() => {
+    if (loggedOut) return // signed-out landing — do not auto-restart OIDC
     let cancelled = false
     void maybeRedirectToOIDC().then((redirected) => {
       if (!cancelled && !redirected) setRedirecting(false)
@@ -42,7 +47,7 @@ export function LoginPage(): ReactElement {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loggedOut])
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -75,6 +80,56 @@ export function LoginPage(): ReactElement {
         }}
       >
         Loading…
+      </div>
+    )
+  }
+
+  if (loggedOut) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '1rem',
+        }}
+      >
+        <div
+          style={{
+            width: '100%',
+            maxWidth: 400,
+            background: 'var(--surface)',
+            border: '1px solid var(--border)',
+            borderRadius: 16,
+            padding: '2.5rem',
+            textAlign: 'center',
+            boxShadow: '0 25px 60px rgba(0,0,0,0.5)',
+          }}
+        >
+          <Activity size={40} color="var(--accent)" style={{ marginBottom: 8 }} />
+          <div style={{ fontSize: 26, fontWeight: 800, letterSpacing: '-0.5px' }}>
+            Span<span style={{ color: 'var(--accent)' }}>Barn</span>
+          </div>
+          <div style={{ fontSize: 15, color: 'var(--text-muted)', margin: '1.25rem 0 1.75rem' }}>
+            You've been signed out.
+          </div>
+          <a
+            href="/api/v1/oidc/login"
+            className="btn btn-primary"
+            style={{
+              display: 'inline-flex',
+              width: '100%',
+              justifyContent: 'center',
+              padding: '0.75rem',
+              fontSize: '0.9375rem',
+              fontWeight: 700,
+              textDecoration: 'none',
+            }}
+          >
+            Sign in
+          </a>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Symptom
Logout lands the user on `iam.wiebe.xyz/auth/login?redirect_uri=/oauth2/authorize?...` — i.e. straight back into a fresh IdP login, instead of a "you're signed out" state.

## Cause
RP-initiated logout ends the IamBarn session and returns to the post-logout landing (`/api/v1/oidc/logout-complete`), which redirected to `/login`. `LoginPage` auto-restarts OIDC on mount (`maybeRedirectToOIDC`) → `/api/v1/oidc/login` → `/oauth2/authorize` → (no session) → IdP login. The user never sees they logged out.

## Fix
- `handleOIDCLogoutComplete` now redirects to `/login?logged_out=1`.
- `LoginPage` detects the flag: skips the auto-redirect and renders a "You've been signed out" card with a manual **Sign in** button (→ `/api/v1/oidc/login`).
- Session-expiry 401s still hit `/login` (no flag) and auto-log-in as before, so silent re-auth on expiry is unchanged.
- The client-side logout fallback also lands with `?logged_out=1`.

Updated `TestOIDCLogoutComplete`. Go api suite + web tsc/eslint/59 vitest pass.