### PR TITLE
fix(auth): make the signed-out "Sign in" button text legible

### DIFF
--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -124,6 +124,9 @@ export function LoginPage(): ReactElement {
               padding: '0.75rem',
               fontSize: '0.9375rem',
               fontWeight: 700,
+              // Explicit: as an <a>, the link color would otherwise override the
+              // button's white text, rendering it blue-on-blue (illegible).
+              color: '#fff',
               textDecoration: 'none',
             }}
           >


### PR DESCRIPTION
The signed-out screen's Sign in button is an `<a>`, so the link color overrode the button's white text (blue-on-blue, illegible). Set explicit `color:#fff`. tsc + eslint + build pass.