### PR TITLE
fix(selfmetrics): route self-metrics to the spanbarn project, not project 0

### DIFF
--- a/deploy/k8s/production/secret.yaml
+++ b/deploy/k8s/production/secret.yaml
@@ -11,7 +11,7 @@ stringData:
     SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:RKkwYuNJ5Xfmfw==,iv:DRN2++C5aObz837QJi5Sc+DEBK6fOvTpZ5SXqquYWlA=,tag:uCfAnqqSpcJIL5rU7te5lA==,type:str]
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:9Y+7UlA=,iv:AXrWFZPuV89yA6Z4t5XpVdgj+CiUgK+wW7+Aeyo0K9I=,tag:6Iegup1uBxpq7SOUpM5/Zw==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:NGC4poO5dZE=,iv:BzBZXi6KdKKFGv6gcmgt6yGWBw0ZQHrxmWiPnZDekeI=,tag:K9wfmD6UrMlmZli3zUPFSA==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:MdMUiK5ts8wK/Psy8jCY+nC5UjW3fzWntmxvTKtUDaDA8wqcQibDyQ==,iv:/J3iMPMrbWg9pva9sGmbWbU4hK40oBc8BM8N0R2zBsI=,tag:5XQySI1jNkQ5yJsQ4KcSXw==,type:str]
+    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:YlsbyPZQaCEd+mw8HF0Q5AU37FSmGaRzzxFxyYo68RuMLQq2Uz4vD+hyt45rWm0gHC8zaMkS8zLLsCxWkHIqbA==,iv:mkF6jyUR8BbJIk6eRdUolgQSOdGvIfo7nEBUjCaRGxc=,tag:blLrmTjyXxwYbNCCpI5vFQ==,type:str]
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:HwNgHUUYQWDZbOkvf+dIu78u+r/n6QMlDBKoiQ==,iv:4aV+qBP9+080KDePZCcEKC5ibLkRCsEst9jWePASMMc=,tag:LaMg+njHse/LlKLlbFctjg==,type:str]
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:NzfEXAgvLmhu91duv7RNf3yCOWCrO7ZnCTaQHavttue7l6PwEUMA0Q==,iv:1J3oijSev45KGhiyKXUJQ3MFuSAQ8LmUkfI9WublE4M=,tag:OWPTf+RT3SqjzU8R7pyrAg==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:e94Ys2daiPQ=,iv:oeTSIaA2P4XN0ldC7V+6cX0tkYbbucBDqNr3DWLdbh4=,tag:3CvpuWycQ2lw7G6+eb++8w==,type:str]
@@ -34,7 +34,7 @@ sops:
             elo4cko3b01ZdTViOC9zNk5KZFY4RjgKlc1P892HWbmiCQ1iD+l0LXD4JDjmxJzN
             ppLLPXz3vwKSirpHk5wVQ2NAPKL28G+8Hcz2LaoXXO0akhxqRHxSiw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-12T09:07:01Z"
-    mac: ENC[AES256_GCM,data:0S/29jXcppwtpFnnRwaxo5kybE7ZBKruF97mTgcdY5utqI/JvHRsQvHMUCsu6GpbnmtF33hsG5688BFJw113zQHI3H9viyQDfpmIM5D1ddDpu20VPQjMPNbPdyflgyF6vCm2mtclaoBFHkOz/KERkQLWOOi7+MOWABzs7qc2M3Y=,iv:MWeNjPBHVMdqQKhLuAP0V4hZyv7F1Z8/T8Up9ELyDvs=,tag:fIHA6eki9fkN9+ByWmbNPw==,type:str]
+    lastmodified: "2026-07-13T09:19:32Z"
+    mac: ENC[AES256_GCM,data:aQk8GFFf74tY18Ev1qCXeMlWtB3Viaa4NOX3mngwbFDbraVyPsvkqqQByHxPSBS/huM/KhG9XjCJhh7aUpoJPgbtobt7vKAyEF24X/OPnOPZRl0jEH5SHrHiTfJ+umr58tnKrDfrf4pWF1ui37Z6DMNgBAZGQCT0xR2eHFEclU0=,iv:nAeQZi+MCWX++zcK6PcVMUrbrYB7num5TfC8rN3AkGQ=,tag:wJ2WpxJpLlj8oVYL7nSVCw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/staging/secret.yaml
+++ b/deploy/k8s/staging/secret.yaml
@@ -11,7 +11,7 @@ stringData:
     SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:+aX1cEUA4g==,iv:yrxwbZrD/gkKN2AalFApYV7IH9dwKAGZYkFtRHACSxY=,tag:/oLHc2EnxWH7F4w/2crbKQ==,type:str]
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:SVBfM9c=,iv:DW3O9ltZxf2XvKthwam7DeTjDHR5jwRZs/i6P2ZPonQ=,tag:T2/wHfGJTL3/MNcpEy9psA==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:Vacvyi6PUmk=,iv:EmdHo9MT+yecjJ9OKi+V+/7QQVjdLd5Wv7hAbjr/avc=,tag:056ciKnaBPhW2+DMPcj2RA==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:sVLkm4NlrCahz4ka/ObAWEp667Wb79FZ9TMZbPrCvsgvbZtAG4gmoA==,iv:KhHe0Qhlflq3ZFIhXFZrYUHbbH1n9ZX2SBGwH1HSVPs=,tag:+pHgjBBentmbt0fb9rmfBw==,type:str]
+    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:ZcQOVs/rSdpE6xp7E0gRXNS9WCS/oQ8gs2LrCVOn21fquhUkLBMk3d+atAr9A7ClgP7d0PhhQck5x9Ie1ApcyQ==,iv:FkFsdRFrmVAFCh9Wg0NGxaK7TLBjmrEVD1FXoOgssyI=,tag:CD0wOhsrIsmZurWmqSuNLw==,type:str]
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:4mLL9n9/QXp0A6mqpAhQoREjZMaGOv7u4E0g652nZX1emnwY,iv:Ffidh7MJzXNH4UlJxrGFQQnT4C4EO6AVbNTlBVGDCSA=,tag:1xN46uoebgFGUhORxIP3tg==,type:str]
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:0SobfTf6o8OE7Q1MGufNg1sHeO4aKXTWswTkp06RnKkFkxGKmtHr5A==,iv:mJxgYFc13tu8NBtwHF6dk7oY82fsei/VF0UaaUM4+4c=,tag:EEG4ODxHLWN20LiwavK3wQ==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:5yXWq8p0xYw=,iv:74PfHQBQ2ee7r/6u0HX4Uxxpc3mqPRq9AEXDcVPxxDE=,tag:53fWTWNFnGd2z3ZA9Tdyww==,type:str]
@@ -35,7 +35,7 @@ sops:
             L3I5VGhLNUxhdVhhKy8rY1FGalI4ckUKaGmCJcjgOENhn+cKdJYy+24jN02b4Bhi
             kG18L5aPlceEeKvI5PkIBPi26uATCe3LqiqUkXftawI3wxojYeahOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-11T14:58:29Z"
-    mac: ENC[AES256_GCM,data:Wao77eI4JVLoC+Md+lFUYBd8aSDDdKdAAnzPA1ql8PuHpq+dTHEC20kHxyGohPLrcGi0Ejufyo2KKUvjZGMfoGvpN6ishZH8HHYPMKiNLHMrdo99upF2n5P1ickaOJ0lT6LlgqBy9oWhNb+zIH19MlLHf0ZDf1+lkPDhVmT9Ej8=,iv:nBUneJZa3QlZZ7tgdwUuKhSPzRO1tYfHB36y1oqdj+w=,tag:up7i/sp010x5KkywWobeTw==,type:str]
+    lastmodified: "2026-07-13T09:19:32Z"
+    mac: ENC[AES256_GCM,data:CcgO/owM699X4jJUdTZEal0V4Dm0QiZhg9lEI+rrEsWqkhpzACwDgmQuHE2TV5vvcszYPyeQJRWRCTaW2ck5plpjySdutAJ5A/NoHDQu7BWKLt6yOq9eXX465xnLhzZL6ecGbDi13vX9JFYExdal582BouvE31lKbeCH/m2YpiM=,iv:09D009ZzTWODcEur9PLJd4p/ExeYZqRWt+b5J8JxOgk=,tag:h04P8NqYopQQy0X/R4ttRg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/deploy/k8s/testing/secret.yaml
+++ b/deploy/k8s/testing/secret.yaml
@@ -11,7 +11,7 @@ stringData:
     SPANBARN_ENVIRONMENT: ENC[AES256_GCM,data:Igaljcb7wQ==,iv:zfSJDfcb1WfJX1f8xIS7ZbZ8izhfrpFrCMGhgYidUCQ=,tag:LojB6lGvcSFRq8duFch7eQ==,type:str]
     SPANBARN_ADMIN_USERNAME: ENC[AES256_GCM,data:Cw7nl4Q=,iv:/0I/VhPUOLDWjDXiqR755iYVHjbKYmPCWseZxrbxWjo=,tag:1y28Eg6b8G7waGnqOFwkAw==,type:str]
     SPANBARN_ADMIN_PASSWORD: ENC[AES256_GCM,data:d0OmilQE928=,iv:g86zTfLw2h9vw+S1lr8egOvaZImZO4rrYF5OQcKvXMY=,tag:V3JDOx0BLdhyALs3sFh8Fw==,type:str]
-    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:sRjoT4aGYD7enn4xcLwK9KFTtC6adTJftvIPvJRc6TdplZ5VtODY2w==,iv:8MgnC7LOdFox6IzYZ9bx7RbSc1jIEx4z8e07FxsmaWc=,tag:DbSLLKT6dObqFNCgJFsAOw==,type:str]
+    SPANBARN_SELF_API_KEY: ENC[AES256_GCM,data:aiMsvIPFUrZ1sLv9D97ndmHY9jZwjrGHgd6WjFCGaj2H6tqwmmxRzogOAYbOUfBwDvPeWjKox+b2x3GPriASvw==,iv:1ZBwA8781cRwy78Z11vatwoy+P/WCblLyCIQCGPqvjA=,tag:1i+QdMYZrtbO01JYV6cRfQ==,type:str]
     SPANBARN_FUNNELBARN_ENDPOINT: ENC[AES256_GCM,data:4SRgXX/hZr9vsuB77rbMojkNmwSFq3ec5ogvTFmnqiY0,iv:5nQlgujI8uHyS03oxVUj9C46bhMsGfq7ffc8vYfuhvQ=,tag:/vCxEEtNuWcwSNZu+C1MEQ==,type:str]
     SPANBARN_FUNNELBARN_API_KEY: ENC[AES256_GCM,data:C0W0Ukf7sv8JZwQv45ior5saiVQkWnduhinNcgx2RF3Ffk4I8Orj4g==,iv:TYnG7XLwMZBBOO58ZeV4HHNHJ8jv7HAQO79htuimMoE=,tag:Dzy5y5z+ZVYjNNU/OTbOYw==,type:str]
     SPANBARN_FUNNELBARN_PROJECT: ENC[AES256_GCM,data:6vKWatS+5c8=,iv:OSZGVOt+AQdRYY0hrnMBnTjL9hSeQkGWX+5U9+fq4Tw=,tag:ZzbxrR8svo/R254Ks3tslA==,type:str]
@@ -34,7 +34,7 @@ sops:
             QmhZck9TZEdTLzNLa0JXR2kxSlBIVUEK7ulhIe1LbASOM3DYo8/N3m3M5+K22bFD
             W4ZfrOTU9W2TFMvtDAkFNLQw6kb6CmPmR6n638+ZT5E5R7WYb61AZQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-07-12T09:07:01Z"
-    mac: ENC[AES256_GCM,data:AcD9WC8rx357t0n0DNi6zwwRb4cNjJKAsL+k7qGRBmU6Da6Kdmo3zj0fR0PUxv6RLSXWUUTpsBouIertXY1/4L/mK8AjYtV3m08xEcBAuCKwQ3RGqnxa7LRq2yVO/e+QZk4ij11aH/gKVawz7zWGjyY3X1Z9PGNvYx5KFZJfTKo=,iv:SLgreuG2wrLNEYvxja/BKO1UFFy7FonGoNRsZuLzvYU=,tag:BgPQIR31Kh526BKg8AnSfA==,type:str]
+    lastmodified: "2026-07-13T09:19:32Z"
+    mac: ENC[AES256_GCM,data:DV2YmabaLfj4tI6cJTU9mbhsfiEudSx2v7sXt3PtvabFDLbdJGftOTcHjhDg9XLB6x7kvUGmEgUCWnxYT0XhJKymyLZKu1UNMca3mQ2h119WvHaCfikZTPi0SCl4Hcie40PEbE4CmolVLsP+nPAZgZQvzHfctbLCbnStknEMsOg=,iv:FpGuPmSBw6htEYLKH0rJ4uDLjqX6VF9hwSbCrV90ck8=,tag:TKWjipcAfF7nEARSiQtARQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2

--- a/internal/selfmetrics/reporter.go
+++ b/internal/selfmetrics/reporter.go
@@ -97,7 +97,10 @@ func (rp *Reporter) flush(ctx context.Context) {
 		rp.logger.Warn("self-metrics export failed", "error", err)
 		return
 	}
-	_ = resp.Body.Close()
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		rp.logger.Warn("self-metrics export rejected", "status", resp.StatusCode)
+	}
 }
 
 // buildRequest converts a snapshot into an OTLP ExportMetricsServiceRequest.

--- a/internal/selfmetrics/reporter_test.go
+++ b/internal/selfmetrics/reporter_test.go
@@ -1,0 +1,60 @@
+package selfmetrics
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReporterLogsRejectedExport guards against a regression where flush()
+// closed the response body without checking its status code, so a failing
+// self-metrics export (wrong API key, wrong project, server error) produced
+// no log output at all — the exact failure mode that let a misconfigured
+// SPANBARN_SELF_API_KEY (identical to the static admin key, routing every
+// self-metric to project_id=0 instead of the "spanbarn" project) go
+// unnoticed in production.
+func TestReporterLogsRejectedExport(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	rec := NewRecorder()
+	rp := NewReporter(rec, srv.URL, "test-key", time.Second, nil, uint64(time.Now().UnixNano()), logger)
+	rp.flush(context.Background())
+
+	if !strings.Contains(logBuf.String(), "self-metrics export rejected") {
+		t.Fatalf("expected a rejected-export log line, got: %s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "401") {
+		t.Fatalf("expected the log line to include the rejected status code, got: %s", logBuf.String())
+	}
+}
+
+// TestReporterSilentOnSuccess confirms a 2xx response produces no warning —
+// the check added for the rejected-export case must not fire on the happy path.
+func TestReporterSilentOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	rec := NewRecorder()
+	rp := NewReporter(rec, srv.URL, "test-key", time.Second, nil, uint64(time.Now().UnixNano()), logger)
+	rp.flush(context.Background())
+
+	if strings.Contains(logBuf.String(), "rejected") || strings.Contains(logBuf.String(), "failed") {
+		t.Fatalf("expected no warning on a successful export, got: %s", logBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Found while doing a post-deploy self-diagnostic: \`sb metrics names -project spanbarn\` always returned empty, even though self-metrics (spool bytes, queue depth, rollup counts) were confirmed to be flowing correctly through the pipeline.

Root cause: \`SPANBARN_SELF_API_KEY\` was set to the exact same value as the static admin key (\`SPANBARN_API_KEY\`) in all three environments (production, staging, testing). \`Authorizer.Authorize\` checks the static key first and returns \`project_id=0\` on a match — so every self-reported metric landed under the \`project_id=0\` sentinel instead of the "spanbarn" project.

Fix:
- Minted a dedicated ingest-scoped API key bound to the "spanbarn" project in each environment (staging/testing had no "spanbarn" project at all, so created it there too), and pointed \`SPANBARN_SELF_API_KEY\` at it.
- Fixed \`selfmetrics.Reporter.flush()\`, which closed the HTTP response without checking its status code — a rejected export would have failed completely silently. This is part of why the misconfiguration went unnoticed: the static key is valid (just for the wrong project), so the reporter got real 200s and there was nothing to see. Added regression tests confirming a non-2xx response now logs a warning with the status code, and a 2xx response stays silent.

## Test plan

- [x] \`go build\`, \`go vet\`, \`gofmt -l\` clean
- [x] \`go test -race ./...\` — all packages pass, including new \`TestReporterLogsRejectedExport\`/\`TestReporterSilentOnSuccess\`
- [x] \`make quality-gate\` passes
- [ ] After merge + production deploy: confirm \`sb metrics names -project spanbarn\` shows real self-metric names in production