### PR TITLE
feat: link kind filter to Services toggle + dedup parameterized-SQL spans

### DIFF
--- a/internal/api/ingest.go
+++ b/internal/api/ingest.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
+	"github.com/wiebe-xyz/spanbarn/internal/service"
 )
 
 func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
@@ -66,6 +67,8 @@ func (s *Server) handleIngest(w http.ResponseWriter, r *http.Request) {
 		if rec.Resource == "" && len(sp.Attributes) > 0 {
 			rec.Resource = extractResource(sp.Attributes)
 		}
+
+		collapseSpanParams(&rec)
 
 		records = append(records, rec)
 	}
@@ -124,6 +127,14 @@ func normalizeStatus(status string) string {
 		return "unset"
 	}
 	return status
+}
+
+// collapseSpanParams collapses variable-length bind-placeholder lists (e.g.
+// `IN (?,?,?)`) in a span's name and resource so parameterized SQL statements
+// group as a single operation instead of one per placeholder count.
+func collapseSpanParams(rec *model.SpanRecord) {
+	rec.Name = service.CollapseParamLists(rec.Name)
+	rec.Resource = service.CollapseParamLists(rec.Resource)
 }
 
 // extractResource tries to derive a resource name from span attributes.

--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -146,6 +146,8 @@ func otlpToSpanRecords(req *collectorpb.ExportTraceServiceRequest, projectID int
 					rec.Resource = extractResource(raw)
 				}
 
+				collapseSpanParams(&rec)
+
 				records = append(records, rec)
 			}
 		}

--- a/internal/service/normalize.go
+++ b/internal/service/normalize.go
@@ -38,7 +38,102 @@ func NormalizeSQL(sql string) string {
 		}
 	}
 
-	return strings.TrimSpace(b.String())
+	return CollapseParamLists(strings.TrimSpace(b.String()))
+}
+
+// CollapseParamLists collapses a run of two-or-more consecutive bind
+// placeholders ("?" or "$N") separated only by commas/whitespace into a single
+// canonical "?, …", so `IN (?,?,?)` and `IN (?,?,?,?,?)` group together. A lone
+// placeholder is left untouched. Non-placeholder text is preserved verbatim
+// (case and literals included), so it is safe to run on any span name/resource.
+func CollapseParamLists(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	i, n := 0, len(s)
+	var prevNonSpace byte
+
+	for i < n {
+		// Only collapse a placeholder run that sits directly inside parentheses
+		// (`IN (?,?,?)`, `VALUES (?,?,?)`) — the variable-length list shape. Bare
+		// projections like `SELECT ?, ?` keep their exact arity.
+		if prevNonSpace == '(' && isPlaceholderStart(s, i) {
+			i = scanPlaceholderRun(s, i, &b)
+			prevNonSpace = '?'
+			continue
+		}
+		ch := s[i]
+		b.WriteByte(ch)
+		if !isSpace(ch) {
+			prevNonSpace = ch
+		}
+		i++
+	}
+
+	return b.String()
+}
+
+// isPlaceholderStart reports whether a bind placeholder ("?" or "$N") begins at i.
+func isPlaceholderStart(s string, i int) bool {
+	if s[i] == '?' {
+		return true
+	}
+	return s[i] == '$' && i+1 < len(s) && s[i+1] >= '0' && s[i+1] <= '9'
+}
+
+// scanPlaceholderRun consumes a maximal run of placeholders separated only by
+// commas/whitespace starting at i. It writes "?, …" when the run holds two or
+// more placeholders, otherwise the lone placeholder verbatim, and returns the
+// index just past the run.
+func scanPlaceholderRun(s string, i int, b *strings.Builder) int {
+	n := len(s)
+	start := i
+	count := 0
+	j := i
+	for {
+		j = skipPlaceholder(s, j)
+		count++
+		// Look past an optional "whitespace* , whitespace*" separator for the
+		// next placeholder; if absent, the run ends here.
+		k := j
+		for k < n && isSpace(s[k]) {
+			k++
+		}
+		if k < n && s[k] == ',' {
+			k++
+			for k < n && isSpace(s[k]) {
+				k++
+			}
+			if k < n && isPlaceholderStart(s, k) {
+				j = k
+				continue
+			}
+		}
+		break
+	}
+
+	if count >= 2 {
+		b.WriteString("?, …")
+	} else {
+		b.WriteString(s[start:j])
+	}
+	return j
+}
+
+// skipPlaceholder returns the index just past a single placeholder at i.
+func skipPlaceholder(s string, i int) int {
+	n := len(s)
+	if s[i] == '?' {
+		return i + 1
+	}
+	i++ // '$'
+	for i < n && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	return i
 }
 
 // Each scanXxx consumes one token starting at i, writes its canonical form to b,

--- a/internal/service/normalize_test.go
+++ b/internal/service/normalize_test.go
@@ -48,12 +48,79 @@ func TestNormalizeSQL(t *testing.T) {
 			"SELECT $1::VARCHAR, $2::INTEGER",
 			"select ?, ?",
 		},
+		{
+			// Variable-length IN lists collapse regardless of placeholder count.
+			"DELETE FROM t WHERE id IN (?,?,?)",
+			"delete from t where id in (?, …)",
+		},
+		{
+			"DELETE FROM t WHERE id IN (?,?,?,?,?,?,?)",
+			"delete from t where id in (?, …)",
+		},
+		{
+			"SELECT * FROM t WHERE id IN ($1, $2, $3)",
+			"select * from t where id in (?, …)",
+		},
 	}
 
 	for _, tt := range tests {
 		got := NormalizeSQL(tt.input)
 		if got != tt.want {
 			t.Errorf("NormalizeSQL(%q)\n  got  %q\n  want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCollapseParamLists(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{
+			// The reported case: parameterized IN lists of differing length must
+			// collapse to the same canonical form, with case preserved.
+			"DELETE FROM spans_staging WHERE trace_id IN (?,?,?)",
+			"DELETE FROM spans_staging WHERE trace_id IN (?, …)",
+		},
+		{
+			"DELETE FROM spans_staging WHERE trace_id IN (?,?,?,?,?,?,?,?,?)",
+			"DELETE FROM spans_staging WHERE trace_id IN (?, …)",
+		},
+		{
+			// Postgres-style numbered placeholders collapse too.
+			"SELECT * FROM t WHERE id IN ($1, $2, $3)",
+			"SELECT * FROM t WHERE id IN (?, …)",
+		},
+		{
+			// A lone placeholder is left untouched.
+			"SELECT * FROM t WHERE id = ?",
+			"SELECT * FROM t WHERE id = ?",
+		},
+		{
+			"SELECT * FROM t WHERE id IN (?)",
+			"SELECT * FROM t WHERE id IN (?)",
+		},
+		{
+			// Bare projection list (not inside parentheses) keeps its exact arity.
+			"SELECT ?, ? FROM t",
+			"SELECT ?, ? FROM t",
+		},
+		{
+			// Non-SQL text is preserved verbatim, case intact.
+			"GET /api/v1/users/:id",
+			"GET /api/v1/users/:id",
+		},
+		{
+			// Multiple lists each collapse independently.
+			"SELECT * FROM a WHERE x IN (?,?) AND y IN (?,?,?)",
+			"SELECT * FROM a WHERE x IN (?, …) AND y IN (?, …)",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := CollapseParamLists(tt.input); got != tt.want {
+			t.Errorf("CollapseParamLists(%q)\n  got  %q\n  want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/service/query_database_test.go
+++ b/internal/service/query_database_test.go
@@ -84,6 +84,46 @@ func TestListDatabaseQueries(t *testing.T) {
 	}
 }
 
+func TestListDatabaseQueriesCollapsesParamLists(t *testing.T) {
+	repo := setupTestRepo(t)
+	svc := NewQueryService(repo, nil, nil)
+	now := time.Now()
+
+	// Two executions of the same DELETE differing only in IN-list length must
+	// fold into a single normalized pattern rather than two rows.
+	spans := []repository.Span{
+		{
+			ProjectID: 1, TraceID: "t1", SpanID: "s1", Name: "db.query", Service: "web",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro(), DurationUs: 100,
+			Attributes: `{"db.system":"sqlite","db.statement":"DELETE FROM spans_staging WHERE trace_id IN (?,?,?)"}`,
+			Events:     "[]", IngestedAt: now,
+		},
+		{
+			ProjectID: 1, TraceID: "t2", SpanID: "s2", Name: "db.query", Service: "web",
+			Kind: "client", Status: "ok", StartTimeUs: now.UnixMicro() + 10, DurationUs: 120,
+			Attributes: `{"db.system":"sqlite","db.statement":"DELETE FROM spans_staging WHERE trace_id IN (?,?,?,?,?,?,?)"}`,
+			Events:     "[]", IngestedAt: now,
+		},
+	}
+	if err := repo.InsertSpans(spans); err != nil {
+		t.Fatalf("InsertSpans: %v", err)
+	}
+
+	out, err := svc.ListDatabaseQueries(context.Background(), 1, time.Time{}, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListDatabaseQueries: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("want 1 collapsed query pattern, got %d: %+v", len(out), out)
+	}
+	if out[0].CallCount != 2 {
+		t.Errorf("CallCount = %d, want 2 (both placeholder-count variants folded)", out[0].CallCount)
+	}
+	if want := "delete from spans_staging where trace_id in (?, …)"; out[0].Pattern != want {
+		t.Errorf("Pattern = %q, want %q", out[0].Pattern, want)
+	}
+}
+
 func TestGetDatabaseQuerySpans(t *testing.T) {
 	repo := setupTestRepo(t)
 	svc := NewQueryService(repo, nil, nil)

--- a/internal/service/query_services.go
+++ b/internal/service/query_services.go
@@ -254,7 +254,7 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 			for _, a := range s.accumulator.QueryRecent(repository.AggregateFilter{
 				ProjectID: projectID, Service: service, Kind: kind, From: fbFrom, To: to,
 			}) {
-				k := opKey{a.Operation, a.Resource, a.Kind}
+				k := opKey{CollapseParamLists(a.Operation), CollapseParamLists(a.Resource), a.Kind}
 				st := byOp[k]
 				if st == nil {
 					st = &aggStats{}
@@ -268,7 +268,7 @@ func (s *QueryService) ListOperations(ctx context.Context, projectID int64, serv
 				s.logger.Warn("failed to query operation stats from spans", "error", err)
 			}
 			for _, ss := range spanStats {
-				k := opKey{ss.Operation, ss.Resource, ss.Kind}
+				k := opKey{CollapseParamLists(ss.Operation), CollapseParamLists(ss.Resource), ss.Kind}
 				st := byOp[k]
 				if st == nil {
 					st = &aggStats{}

--- a/web/src/pages/OperationsPage.tsx
+++ b/web/src/pages/OperationsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef, type ReactElement } from 'react'
-import { useParams, useNavigate, Link } from 'react-router-dom'
+import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom'
 import { ChevronRight, Search } from 'lucide-react'
 import {
   AreaChart,
@@ -21,14 +21,21 @@ import { useTimeRange } from '../contexts/useTimeRange'
 export function OperationsPage(): ReactElement {
   const { service } = useParams<{ service: string }>()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { range, setRange } = useTimeRange()
   const [refreshInterval, setRefreshInterval] = useState(0)
   const [operations, setOperations] = useState<OperationSummary[]>([])
   const [_timeseries, setTimeseries] = useState<TimeseriesBucket[]>([])
   const [loading, setLoading] = useState(true)
   const [search, setSearch] = useState('')
-  // 'server' by default surfaces entry-point operations; '' means all kinds.
-  const [kindFilter, setKindFilter] = useState('server')
+  // Initialize from the `kind` URL param so navigation from the Services page
+  // carries its "Entry points / All spans" toggle. 'all' maps to '' (all kinds);
+  // absent means a direct/breadcrumb visit and keeps the 'server' default that
+  // surfaces entry-point operations.
+  const initialKind = searchParams.get('kind')
+  const [kindFilter, setKindFilter] = useState(
+    initialKind === null ? 'server' : initialKind === 'all' ? '' : initialKind,
+  )
   const [sortKey, setSortKey] = useState<string>('score')
   const [sortAsc, setSortAsc] = useState(false)
   const fetchIdRef = useRef(0)
@@ -154,7 +161,10 @@ export function OperationsPage(): ReactElement {
           </div>
           <select
             value={kindFilter}
-            onChange={(e) => setKindFilter(e.target.value)}
+            onChange={(e) => {
+              setKindFilter(e.target.value)
+              setSearchParams({ kind: e.target.value || 'all' }, { replace: true })
+            }}
             style={{
               background: 'var(--surface)',
               border: '1px solid var(--border)',

--- a/web/src/pages/ServicesPage.tsx
+++ b/web/src/pages/ServicesPage.tsx
@@ -267,7 +267,7 @@ export function ServicesPage(): ReactElement {
                     <tr
                       key={svc.service}
                       style={{ cursor: 'pointer' }}
-                      onClick={() => navigate(`/services/${encodeURIComponent(svc.service)}`)}
+                      onClick={() => navigate(`/services/${encodeURIComponent(svc.service)}?kind=${serverOnly ? 'server' : 'all'}`)}
                     >
                       <td>
                         <span style={{ fontWeight: 600, color: 'var(--accent)' }}>{svc.service}</span>


### PR DESCRIPTION
## Summary

Two independent UX fixes on the Services/Operations views.

### 1. Link the entry-points filter to the Services toggle
The Services page's **Entry points / All spans** toggle was local state, dropped when a service row was clicked; the Operations page always defaulted its kind filter to `server`. So a user viewing **All spans** who clicked into a service landed on **Entry points (server)** instead of **All**.

- `ServicesPage` now carries the toggle through the URL as `?kind=server|all` on row navigation.
- `OperationsPage` initializes its `kindFilter` from that param (absent → keeps the `server` default for direct/breadcrumb visits) and syncs the value back to the URL on change.

### 2. Deduplicate parameterized-SQL spans
Parameterized DB spans are named by their SQL statement, so an `IN (?,?,?)` list of differing length was treated as a distinct operation per placeholder count — flooding the Operations and Database Queries pages with near-identical rows and fragmenting the `aggregates` table.

- New `CollapseParamLists` folds a run of ≥2 bind placeholders (`?` or `$N`) **directly inside parentheses** into a canonical `?, …`. Gating on the preceding `(` keeps bare projections like `SELECT ?, ?` at their exact arity.
- `NormalizeSQL` applies it → fixes the Database Queries page.
- Ingest (JSON + OTLP) collapses span name/resource at the source → stops future aggregate fragmentation. Exact SQL is still preserved in `db.statement`.
- `ListOperations` collapses the group key → already-stored historical aggregate rows merge at read time, **no migration**.
- Collapsed lists render as `IN (?, …)`.

## Tests
- New `TestCollapseParamLists`, extended `TestNormalizeSQL`, and `TestListDatabaseQueriesCollapsesParamLists` (two placeholder-count variants fold into one summary row).

## Verification
- `go build ./...`, full `go test ./...`, `go test -race ./internal/service/...` — all green
- `make quality-gate` — passes (cyclo 23/24, coverage/dup/length within baselines)
- `make lint` — "All checks passed!"
- `web` tsc lint + 59 Vitest tests — green