### PR TITLE
perf(traces): serve trace list from a rolled-up trace_summaries table

### DIFF
--- a/internal/repository/migrations/032_trace_summaries.go
+++ b/internal/repository/migrations/032_trace_summaries.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(up032, down032)
+}
+
+// up032 adds trace_summaries: one row per (project_id, trace_id) holding
+// everything the trace-LIST needs (root name/service/duration, start time, span
+// count, has_error). The list query previously did a GROUP BY over every span in
+// the whole time window (spans ∪ error_samples) before applying LIMIT, which
+// timed out (30s+) on busy projects. Reading a pre-rolled summary turns that into
+// an indexed ORDER BY … LIMIT scan, independent of span volume.
+//
+// Maintained by the staging flush (and the inline insert when staging is off) via
+// an UPSERT, so a trace's summary lands atomically with its spans. Cleaned up by
+// retention in lockstep with the spans it describes: boring-sampled traces carry
+// an expires_at and are dropped early; interesting traces are dropped at the
+// interesting cutoff; error traces persist to the error cutoff (mirroring
+// error_samples), so the list keeps showing errors exactly as long as before.
+//
+// No backfill: a GROUP BY over the existing spans table at migration time would
+// hold the single write connection and wedge the writer mid-deploy (the failure
+// mode migration 030's notes call out). The table fills forward from flushes.
+func up032(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS trace_summaries (
+			project_id       INTEGER  NOT NULL,
+			trace_id         TEXT     NOT NULL,
+			root_name        TEXT     NOT NULL DEFAULT '',
+			root_service     TEXT     NOT NULL DEFAULT '',
+			root_duration_us INTEGER  NOT NULL DEFAULT 0,
+			start_time_us    INTEGER  NOT NULL DEFAULT 0,
+			span_count       INTEGER  NOT NULL DEFAULT 0,
+			has_error        INTEGER  NOT NULL DEFAULT 0,
+			ingested_at      DATETIME NOT NULL,
+			expires_at       DATETIME,
+			PRIMARY KEY (project_id, trace_id)
+		)`,
+		// Serves the list: filter by project + ingested_at window, order by
+		// ingested_at DESC. ingested_at is server-authoritative (robust against
+		// client clock skew) and matches the retention/cleanup key.
+		`CREATE INDEX IF NOT EXISTS idx_trace_summaries_list ON trace_summaries(project_id, ingested_at DESC)`,
+		// Early cleanup of boring-sampled summaries seeks this partial index, same
+		// pattern as idx_spans_expires.
+		`CREATE INDEX IF NOT EXISTS idx_trace_summaries_expires ON trace_summaries(expires_at) WHERE expires_at IS NOT NULL`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func down032(ctx context.Context, tx *sql.Tx) error {
+	for _, stmt := range []string{
+		`DROP INDEX IF EXISTS idx_trace_summaries_expires`,
+		`DROP INDEX IF EXISTS idx_trace_summaries_list`,
+		`DROP TABLE IF EXISTS trace_summaries`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -44,6 +44,14 @@ func (r *Repository) InsertSpansContext(ctx context.Context, spans []Span) error
 				return err
 			}
 		}
+
+		// Maintain trace_summaries in the same tx (staging-disabled path; the
+		// staging flush does the same for the normal path).
+		if sums := buildTraceSummaries(spans, time.Now().UTC()); len(sums) > 0 {
+			if err := upsertTraceSummariesTx(ctx, tx, sums); err != nil {
+				return err
+			}
+		}
 		return tx.Commit()
 	})
 }
@@ -255,29 +263,65 @@ type TraceSummaryRow struct {
 	PromptCount  int
 }
 
-// SearchTraceSummaries returns at most filter.Limit trace summaries matching
-// the filter, ordered by trace start time descending. The grouping happens
-// in SQL — old code fetched filter.Limit*5 raw spans and grouped in Go,
-// which was the dominant cost of the /traces page.
+// SearchTraceSummaries returns at most filter.Limit trace summaries matching the
+// filter, ordered by ingested_at descending (or errors-first). It reads the
+// pre-rolled trace_summaries table — one indexed row per trace — instead of
+// grouping every span in the window, which timed out on busy projects.
 //
-// minSpans (>0) filters out traces whose total span count falls below the
-// threshold; applied via HAVING so pagination respects it.
-//
-// Considers both `spans` and `error_samples` because old traces past span
-// retention may only have error_samples rows; without the UNION those
-// traces would disappear from search even though detail still works.
+// Filters map onto the summary's root/rollup columns: Service→root_service,
+// Operation/ExcludeOperations→root_name, Status(error/ok)→has_error,
+// MinDuration→root_duration_us (whole-trace duration), From/To→ingested_at,
+// minSpans→span_count. Error traces stay listed until the error cutoff because
+// their summaries are retained that long (see repo_trace_summaries.go), so
+// dropping the old spans∪error_samples UNION does not lose them.
 func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSummaryRow, error) {
 	var where []string
 	var args []any
-	where, args = f.appendCommonWhere(where, args)
+
+	if f.ProjectID != 0 {
+		where = append(where, "project_id = ?")
+		args = append(args, f.ProjectID)
+	}
+	if f.Service != "" {
+		where = append(where, "root_service = ?")
+		args = append(args, f.Service)
+	}
+	if f.Operation != "" {
+		where = append(where, "root_name = ?")
+		args = append(args, f.Operation)
+	}
+	if f.Status != "" {
+		if strings.EqualFold(f.Status, "error") {
+			where = append(where, "has_error = 1")
+		} else {
+			where = append(where, "has_error = 0")
+		}
+	}
+	if f.MinDuration > 0 {
+		where = append(where, "root_duration_us >= ?")
+		args = append(args, f.MinDuration)
+	}
+	if !f.From.IsZero() {
+		where = append(where, "ingested_at >= ?")
+		args = append(args, f.From)
+	}
+	if !f.To.IsZero() {
+		where = append(where, "ingested_at <= ?")
+		args = append(args, f.To)
+	}
 	if len(f.ExcludeOperations) > 0 {
 		placeholders := strings.Repeat("?,", len(f.ExcludeOperations))
 		placeholders = placeholders[:len(placeholders)-1]
-		where = append(where, "name NOT IN ("+placeholders+")")
+		where = append(where, "root_name NOT IN ("+placeholders+")")
 		for _, op := range f.ExcludeOperations {
 			args = append(args, op)
 		}
 	}
+	if minSpans > 0 {
+		where = append(where, "span_count >= ?")
+		args = append(args, minSpans)
+	}
+
 	whereSQL := ""
 	if len(where) > 0 {
 		whereSQL = " WHERE " + strings.Join(where, " AND ")
@@ -287,68 +331,36 @@ func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSu
 	if limit <= 0 {
 		limit = 50
 	}
-	having := ""
-	if minSpans > 0 {
-		having = fmt.Sprintf(" HAVING COUNT(DISTINCT span_id) >= %d", minSpans)
-	}
-	if f.RootOnly {
-		rootCheck := "MAX(CASE WHEN COALESCE(parent_span_id,'') = '' THEN 1 ELSE 0 END) = 1"
-		if having == "" {
-			having = " HAVING " + rootCheck
-		} else {
-			having += " AND " + rootCheck
-		}
-	}
-
-	// Args are reused for the two UNIONed selects (spans + error_samples).
-	doubled := make([]any, 0, len(args)*2)
-	doubled = append(doubled, args...)
-	doubled = append(doubled, args...)
-
-	orderBy := "start_us DESC"
+	orderBy := "ingested_at DESC"
 	if f.SortErrorsFirst {
-		orderBy = "has_error DESC, start_us DESC"
+		orderBy = "has_error DESC, ingested_at DESC"
 	}
 
-	q := fmt.Sprintf(`
-		SELECT trace_id,
-		       MIN(start_time_us)                                                  AS start_us,
-		       COUNT(DISTINCT span_id)                                             AS span_count,
-		       MAX(CASE WHEN status IN ('error','ERROR','Error') THEN 1 ELSE 0 END) AS has_error
-		FROM (
-			SELECT trace_id, span_id, status, start_time_us, COALESCE(parent_span_id,'') AS parent_span_id FROM spans%s
-			UNION ALL
-			SELECT trace_id, span_id, status, start_time_us, COALESCE(parent_span_id,'') AS parent_span_id FROM error_samples%s
-		)
-		GROUP BY trace_id%s
-		ORDER BY `+orderBy+`
-		LIMIT %d OFFSET %d`,
-		whereSQL, whereSQL, having, limit, f.Offset)
+	q := fmt.Sprintf(`SELECT trace_id, start_time_us, span_count, has_error, root_name, root_service, root_duration_us
+		FROM trace_summaries%s
+		ORDER BY %s
+		LIMIT %d OFFSET %d`, whereSQL, orderBy, limit, f.Offset)
 
 	ctx, cancel := r.queryContext()
 	defer cancel()
-	rows, err := r.db.QueryContext(ctx, q, doubled...)
+	rows, err := r.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
-	type acc struct {
-		startUs   int64
-		spanCount int
-		hasError  bool
-	}
 	order := make([]string, 0, limit)
-	accs := make(map[string]*acc, limit)
+	byTrace := make(map[string]*TraceSummaryRow, limit)
 	for rows.Next() {
-		var traceID string
-		var startUs int64
-		var spanCount int
+		var tr TraceSummaryRow
 		var hasErrorInt int
-		if err := rows.Scan(&traceID, &startUs, &spanCount, &hasErrorInt); err != nil {
+		if err := rows.Scan(&tr.TraceID, &tr.StartTimeUs, &tr.SpanCount, &hasErrorInt,
+			&tr.RootName, &tr.RootService, &tr.RootDuration); err != nil {
 			rows.Close()
 			return nil, err
 		}
-		order = append(order, traceID)
-		accs[traceID] = &acc{startUs: startUs, spanCount: spanCount, hasError: hasErrorInt == 1}
+		tr.HasError = hasErrorInt == 1
+		row := tr
+		order = append(order, tr.TraceID)
+		byTrace[tr.TraceID] = &row
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
@@ -358,106 +370,33 @@ func (r *Repository) SearchTraceSummaries(f SpanFilter, minSpans int) ([]TraceSu
 		return nil, nil
 	}
 
-	// Step 2: look up the root span (parent_span_id NULL/'') per trace.
-	// Limited to the page we just fetched, so this is cheap.
-	placeholders := strings.Repeat("?,", len(order))
-	placeholders = placeholders[:len(placeholders)-1]
-	rootArgs := make([]any, 0, len(order)*2)
-	for _, t := range order {
-		rootArgs = append(rootArgs, t)
+	// Enrich the page with model + prompt count from prompt_records.
+	prPlaceholders := strings.Repeat("?,", len(order))
+	prPlaceholders = prPlaceholders[:len(prPlaceholders)-1]
+	prArgs := make([]any, len(order))
+	for i, t := range order {
+		prArgs[i] = t
 	}
-	for _, t := range order {
-		rootArgs = append(rootArgs, t)
-	}
-	rootQ := fmt.Sprintf(`
-		SELECT trace_id, name, service, duration_us, start_time_us, COALESCE(parent_span_id,'') AS parent
-		FROM (
-			SELECT trace_id, name, service, duration_us, start_time_us, parent_span_id
-			FROM spans WHERE trace_id IN (%s)
-			UNION ALL
-			SELECT trace_id, name, service, duration_us, start_time_us, parent_span_id
-			FROM error_samples WHERE trace_id IN (%s)
-		)
-		ORDER BY (CASE WHEN COALESCE(parent_span_id,'') = '' THEN 0 ELSE 1 END), start_time_us`,
-		placeholders, placeholders)
-
-	rootCtx, rootCancel := r.queryContext()
-	defer rootCancel()
-	rrows, err := r.db.QueryContext(rootCtx, rootQ, rootArgs...)
-	if err != nil {
-		return nil, err
-	}
-	defer rrows.Close()
-
-	type rootInfo struct {
-		name     string
-		service  string
-		duration int64
-		isRoot   bool
-	}
-	roots := make(map[string]rootInfo, len(order))
-	for rrows.Next() {
-		var traceID, name, service, parent string
-		var dur, startUs int64
-		if err := rrows.Scan(&traceID, &name, &service, &dur, &startUs, &parent); err != nil {
-			return nil, err
-		}
-		existing, ok := roots[traceID]
-		// Prefer a real root (parent==""), else first-seen.
-		isRoot := parent == ""
-		if !ok || (isRoot && !existing.isRoot) {
-			roots[traceID] = rootInfo{name: name, service: service, duration: dur, isRoot: isRoot}
-		}
-	}
-	if err := rrows.Err(); err != nil {
-		return nil, err
-	}
-
-	// Step 3: fetch model and prompt count from prompt_records for each trace.
-	type promptInfo struct {
-		model string
-		count int
-	}
-	promptsByTrace := make(map[string]promptInfo, len(order))
-	if len(order) > 0 {
-		prPlaceholders := strings.Repeat("?,", len(order))
-		prPlaceholders = prPlaceholders[:len(prPlaceholders)-1]
-		prArgs := make([]any, len(order))
-		for i, t := range order {
-			prArgs[i] = t
-		}
-		prQ := fmt.Sprintf(`SELECT trace_id, MIN(model), COUNT(*) FROM prompt_records WHERE trace_id IN (%s) GROUP BY trace_id`, prPlaceholders)
-		prCtx, prCancel := r.queryContext()
-		defer prCancel()
-		prRows, err := r.db.QueryContext(prCtx, prQ, prArgs...)
-		if err == nil {
-			for prRows.Next() {
-				var tid, model string
-				var cnt int
-				if err := prRows.Scan(&tid, &model, &cnt); err == nil {
-					promptsByTrace[tid] = promptInfo{model: model, count: cnt}
+	prQ := fmt.Sprintf(`SELECT trace_id, MIN(model), COUNT(*) FROM prompt_records WHERE trace_id IN (%s) GROUP BY trace_id`, prPlaceholders)
+	prCtx, prCancel := r.queryContext()
+	defer prCancel()
+	if prRows, err := r.db.QueryContext(prCtx, prQ, prArgs...); err == nil {
+		for prRows.Next() {
+			var tid, model string
+			var cnt int
+			if err := prRows.Scan(&tid, &model, &cnt); err == nil {
+				if row := byTrace[tid]; row != nil {
+					row.RootModel = model
+					row.PromptCount = cnt
 				}
 			}
-			prRows.Close()
 		}
+		prRows.Close()
 	}
 
 	out := make([]TraceSummaryRow, 0, len(order))
-	for _, traceID := range order {
-		a := accs[traceID]
-		ri := roots[traceID]
-		pi := promptsByTrace[traceID]
-		out = append(out, TraceSummaryRow{
-			TraceID:      traceID,
-			StartTimeUs:  a.startUs,
-			SpanCount:    a.spanCount,
-			HasError:     a.hasError,
-			RootName:     ri.name,
-			RootService:  ri.service,
-			RootDuration: ri.duration,
-			RootModel:    pi.model,
-			PromptCount:  pi.count,
-		})
+	for _, t := range order {
+		out = append(out, *byTrace[t])
 	}
 	return out, nil
 }

--- a/internal/repository/repo_spans_staging.go
+++ b/internal/repository/repo_spans_staging.go
@@ -133,6 +133,14 @@ func (r *Repository) CommitStagingFlush(ctx context.Context, traceIDs []string, 
 			stmt.Close()
 		}
 
+		// Roll up the persisted spans into trace_summaries in the same tx so the
+		// trace list has a pre-grouped, indexed row instead of scanning spans.
+		if sums := buildTraceSummaries(interesting, time.Now().UTC()); len(sums) > 0 {
+			if err := upsertTraceSummariesTx(ctx, tx, sums); err != nil {
+				return err
+			}
+		}
+
 		placeholders := strings.Repeat("?,", len(traceIDs))
 		placeholders = placeholders[:len(placeholders)-1]
 		args := make([]any, len(traceIDs))

--- a/internal/repository/repo_trace_summaries.go
+++ b/internal/repository/repo_trace_summaries.go
@@ -1,0 +1,190 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// traceSummaryAgg is the per-trace rollup upserted into trace_summaries. It is
+// derived from the spans being persisted for a trace (see buildTraceSummaries).
+type traceSummaryAgg struct {
+	projectID   int64
+	traceID     string
+	rootName    string // "" when this batch holds no true root span (parent == "")
+	rootService string
+	rootDurUs   int64
+	startTimeUs int64
+	spanCount   int64
+	hasError    bool
+	ingestedAt  time.Time
+	expiresAt   *time.Time // nil when any span in the trace is kept indefinitely (interesting)
+}
+
+// buildTraceSummaries reduces a batch of persisted spans into one rollup per
+// (project_id, trace_id). now supplies ingested_at for spans that don't carry
+// one yet (the inline insert path lets the DB default it). The rollup mirrors the
+// span-list semantics: min start time, total span count, has_error = any error,
+// root fields from the true root span, and an expires_at that is nil unless every
+// span in the trace is a sampled-boring span (so the summary outlives its spans
+// no longer than the spans themselves).
+func buildTraceSummaries(spans []Span, now time.Time) []traceSummaryAgg {
+	if len(spans) == 0 {
+		return nil
+	}
+	type key struct {
+		projectID int64
+		traceID   string
+	}
+	byTrace := make(map[key]*traceSummaryAgg, len(spans))
+	order := make([]key, 0, len(spans))
+
+	for i := range spans {
+		s := &spans[i]
+		k := key{s.ProjectID, s.TraceID}
+		ing := s.IngestedAt
+		if ing.IsZero() {
+			ing = now
+		}
+		agg, ok := byTrace[k]
+		if !ok {
+			agg = &traceSummaryAgg{
+				projectID:   s.ProjectID,
+				traceID:     s.TraceID,
+				startTimeUs: s.StartTimeUs,
+				ingestedAt:  ing,
+				expiresAt:   s.ExpiresAt,
+			}
+			byTrace[k] = agg
+			order = append(order, k)
+		}
+		agg.spanCount++
+		if s.StartTimeUs < agg.startTimeUs {
+			agg.startTimeUs = s.StartTimeUs
+		}
+		if ing.Before(agg.ingestedAt) {
+			agg.ingestedAt = ing
+		}
+		if strings.EqualFold(s.Status, "error") {
+			agg.hasError = true
+		}
+		// expires_at: nil wins (an indefinitely-kept span means the whole trace is
+		// kept), otherwise take the latest expiry so the summary lives as long as
+		// its last span.
+		agg.expiresAt = mergeExpiry(agg.expiresAt, s.ExpiresAt, ok)
+		// Root fields come only from the true root span (no parent). Leaving them
+		// empty when this batch has no root lets a later upsert keep an
+		// already-recorded root instead of clobbering it with a child span.
+		if s.ParentSpanID == "" {
+			agg.rootName = s.Name
+			agg.rootService = s.Service
+			agg.rootDurUs = s.DurationUs
+		}
+	}
+
+	out := make([]traceSummaryAgg, 0, len(order))
+	for _, k := range order {
+		out = append(out, *byTrace[k])
+	}
+	return out
+}
+
+// mergeExpiry combines the accumulated expiry with a span's expiry. seen reports
+// whether the accumulator already held a span (so the first span's value was
+// taken verbatim by the caller and must not be re-merged). A nil expiry always
+// wins — it marks a span kept until the interesting/error cutoff rather than the
+// short boring window.
+func mergeExpiry(acc, span *time.Time, seen bool) *time.Time {
+	if !seen {
+		return acc // first span: caller already assigned span's expiry
+	}
+	if acc == nil || span == nil {
+		return nil
+	}
+	if span.After(*acc) {
+		return span
+	}
+	return acc
+}
+
+// upsertTraceSummariesTx writes the rollups within an existing transaction, so
+// they land atomically with the spans that produced them. Accumulating columns
+// use MIN/SUM/MAX; root fields only overwrite when the incoming batch actually
+// carried a root (root_name != ”).
+func upsertTraceSummariesTx(ctx context.Context, tx *sql.Tx, sums []traceSummaryAgg) error {
+	if len(sums) == 0 {
+		return nil
+	}
+	stmt, err := tx.PrepareContext(ctx, `INSERT INTO trace_summaries
+		(project_id, trace_id, root_name, root_service, root_duration_us, start_time_us, span_count, has_error, ingested_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(project_id, trace_id) DO UPDATE SET
+			start_time_us    = MIN(start_time_us, excluded.start_time_us),
+			span_count       = span_count + excluded.span_count,
+			has_error        = MAX(has_error, excluded.has_error),
+			ingested_at      = MIN(ingested_at, excluded.ingested_at),
+			root_name        = CASE WHEN excluded.root_name != '' THEN excluded.root_name        ELSE root_name        END,
+			root_service     = CASE WHEN excluded.root_name != '' THEN excluded.root_service     ELSE root_service     END,
+			root_duration_us = CASE WHEN excluded.root_name != '' THEN excluded.root_duration_us ELSE root_duration_us END,
+			expires_at       = CASE WHEN expires_at IS NULL OR excluded.expires_at IS NULL THEN NULL
+			                        ELSE MAX(expires_at, excluded.expires_at) END`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+
+	for _, s := range sums {
+		hasErr := 0
+		if s.hasError {
+			hasErr = 1
+		}
+		if _, err := stmt.ExecContext(ctx,
+			s.projectID, s.traceID, s.rootName, s.rootService, s.rootDurUs,
+			s.startTimeUs, s.spanCount, hasErr, s.ingestedAt, s.expiresAt,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DeleteExpiredTraceSummaries drops summaries whose stamped expires_at has passed
+// (boring-sampled traces), mirroring DeleteExpiredBoringSpans. Batched so a large
+// backlog never holds the write connection for long.
+func (r *Repository) DeleteExpiredTraceSummaries(ctx context.Context, now time.Time) (int64, error) {
+	n := now.UTC()
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			`DELETE FROM trace_summaries WHERE rowid IN (
+				SELECT rowid FROM trace_summaries WHERE expires_at IS NOT NULL AND expires_at < ? LIMIT ?)`,
+			n, retentionDeleteBatch)
+		if e != nil {
+			return 0, e
+		}
+		c, _ := res.RowsAffected()
+		return c, nil
+	})
+}
+
+// DeleteTraceSummariesOlderThan drops indefinitely-kept summaries once their
+// spans are gone: non-error traces at interestingCutoff (matching the span
+// aggregate-then-delete pass) and error traces at errorCutoff (matching
+// error_samples retention, so errors keep listing for exactly as long).
+func (r *Repository) DeleteTraceSummariesOlderThan(ctx context.Context, interestingCutoff, errorCutoff time.Time) (int64, error) {
+	ic, ec := interestingCutoff.UTC(), errorCutoff.UTC()
+	return r.batchedDelete(ctx, func() (int64, error) {
+		res, e := r.db.ExecContext(ctx,
+			`DELETE FROM trace_summaries WHERE rowid IN (
+				SELECT rowid FROM trace_summaries
+				WHERE expires_at IS NULL
+				  AND ((has_error = 0 AND ingested_at < ?) OR (has_error = 1 AND ingested_at < ?))
+				LIMIT ?)`,
+			ic, ec, retentionDeleteBatch)
+		if e != nil {
+			return 0, e
+		}
+		c, _ := res.RowsAffected()
+		return c, nil
+	})
+}

--- a/internal/repository/repo_trace_summaries_test.go
+++ b/internal/repository/repo_trace_summaries_test.go
@@ -1,0 +1,166 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func tsSpan(trace, span, parent, name, service, status string, startUs, durUs int64) Span {
+	return Span{
+		ProjectID: 1, TraceID: trace, SpanID: span, ParentSpanID: parent,
+		Name: name, Service: service, Kind: "server", Status: status,
+		StartTimeUs: startUs, DurationUs: durUs, Attributes: "{}", Events: "[]",
+	}
+}
+
+// InsertSpans upserts trace_summaries, so SearchTraceSummaries reads back the
+// rolled-up rows without touching the spans table's group-by.
+func TestTraceSummariesUpsertAndSearch(t *testing.T) {
+	repo := setupTestDB(t)
+
+	// Trace A: root + error child.
+	if err := repo.InsertSpans([]Span{
+		tsSpan("A", "a1", "", "GET /orders", "web", "ok", 1000, 5000),
+		tsSpan("A", "a2", "a1", "SELECT", "db", "error", 1200, 300),
+	}); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	// Trace B: single root, no error.
+	if err := repo.InsertSpans([]Span{
+		tsSpan("B", "b1", "", "GET /health", "web", "ok", 500, 80),
+	}); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+
+	rows, err := repo.SearchTraceSummaries(SpanFilter{ProjectID: 1}, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("want 2 summaries, got %d: %+v", len(rows), rows)
+	}
+	byID := map[string]TraceSummaryRow{}
+	for _, r := range rows {
+		byID[r.TraceID] = r
+	}
+	a := byID["A"]
+	if a.SpanCount != 2 {
+		t.Errorf("A span count = %d, want 2", a.SpanCount)
+	}
+	if !a.HasError {
+		t.Errorf("A should have error")
+	}
+	if a.RootName != "GET /orders" || a.RootService != "web" || a.RootDuration != 5000 {
+		t.Errorf("A root = %q/%q/%d, want GET /orders/web/5000", a.RootName, a.RootService, a.RootDuration)
+	}
+	if a.StartTimeUs != 1000 {
+		t.Errorf("A start = %d, want 1000 (min)", a.StartTimeUs)
+	}
+	if b := byID["B"]; b.SpanCount != 1 || b.HasError {
+		t.Errorf("B = %+v, want 1 span, no error", b)
+	}
+}
+
+// Late-arriving spans of an already-summarised trace accumulate: count sums,
+// has_error ORs, start_time takes the min, and a child batch does not clobber
+// the recorded root.
+func TestTraceSummariesAccumulate(t *testing.T) {
+	repo := setupTestDB(t)
+
+	if err := repo.InsertSpans([]Span{tsSpan("A", "a1", "", "root", "web", "ok", 1000, 500)}); err != nil {
+		t.Fatalf("insert root: %v", err)
+	}
+	// A later batch with only a child (no root) that errored and started earlier.
+	if err := repo.InsertSpans([]Span{tsSpan("A", "a2", "a1", "child", "db", "error", 900, 100)}); err != nil {
+		t.Fatalf("insert child: %v", err)
+	}
+
+	rows, err := repo.SearchTraceSummaries(SpanFilter{ProjectID: 1}, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("want 1 summary, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.SpanCount != 2 {
+		t.Errorf("span count = %d, want 2 (accumulated)", r.SpanCount)
+	}
+	if !r.HasError {
+		t.Errorf("has_error should OR to true after the late error span")
+	}
+	if r.RootName != "root" {
+		t.Errorf("root name = %q, want 'root' (child batch must not clobber it)", r.RootName)
+	}
+	if r.StartTimeUs != 900 {
+		t.Errorf("start = %d, want 900 (min after earlier late span)", r.StartTimeUs)
+	}
+}
+
+// The production path is the staging flush: CommitStagingFlush must roll the
+// persisted spans into a summary in the same transaction.
+func TestTraceSummariesViaStagingFlush(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	spans := []Span{
+		tsSpan("A", "a1", "", "GET /x", "web", "ok", 1000, 400),
+		tsSpan("A", "a2", "a1", "db.query", "db", "error", 1100, 50),
+	}
+	for i := range spans {
+		spans[i].IngestedAt = now
+	}
+	if err := repo.CommitStagingFlush(ctx, []string{"A"}, spans); err != nil {
+		t.Fatalf("commit staging flush: %v", err)
+	}
+
+	rows, err := repo.SearchTraceSummaries(SpanFilter{ProjectID: 1}, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(rows) != 1 || rows[0].SpanCount != 2 || !rows[0].HasError || rows[0].RootName != "GET /x" {
+		t.Fatalf("staging flush did not roll up the trace: %+v", rows)
+	}
+}
+
+// Retention drops summaries in lockstep with their spans: boring-sampled by
+// expires_at, non-error at the interesting cutoff, error at the (later) error
+// cutoff.
+func TestTraceSummariesRetention(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	mk := func(trace, status string, ingested time.Time, expires *time.Time) {
+		s := tsSpan(trace, trace+"root", "", "root", "web", status, 1000, 100)
+		s.IngestedAt = ingested
+		s.ExpiresAt = expires
+		if err := repo.InsertSpans([]Span{s}); err != nil {
+			t.Fatalf("insert %s: %v", trace, err)
+		}
+	}
+	pastExpiry := now.Add(-1 * time.Hour)
+	mk("A", "ok", now.Add(-100*time.Hour), nil)       // interesting, non-error, old
+	mk("B", "error", now.Add(-100*time.Hour), nil)    // interesting, error, old
+	mk("C", "ok", now.Add(-2*time.Hour), &pastExpiry) // boring-sampled, expired
+
+	// Boring cleanup removes C only.
+	if _, err := repo.DeleteExpiredTraceSummaries(ctx, now); err != nil {
+		t.Fatalf("delete expired: %v", err)
+	}
+	// interestingCutoff = -50h removes A (non-error, ingested -100h); errorCutoff
+	// = -200h keeps B (error, ingested -100h is newer than the error cutoff).
+	if _, err := repo.DeleteTraceSummariesOlderThan(ctx, now.Add(-50*time.Hour), now.Add(-200*time.Hour)); err != nil {
+		t.Fatalf("delete older: %v", err)
+	}
+
+	rows, err := repo.SearchTraceSummaries(SpanFilter{ProjectID: 1}, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(rows) != 1 || rows[0].TraceID != "B" {
+		t.Fatalf("want only B to survive retention, got %+v", rows)
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -41,6 +41,8 @@ type Repository interface {
 	DeleteSpansByMaxID(maxID int64) (int64, error)
 	DeleteSpansOlderThan(cutoff time.Time) (int64, error)
 	DeleteExpiredBoringSpans(ctx context.Context, now time.Time) (int64, error)
+	DeleteExpiredTraceSummaries(ctx context.Context, now time.Time) (int64, error)
+	DeleteTraceSummariesOlderThan(ctx context.Context, interestingCutoff, errorCutoff time.Time) (int64, error)
 	InsertErrorSamples(spans []repository.Span) error
 	DeleteErrorSamplesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteAggregatesOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
@@ -329,6 +331,17 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 	// status/duration_us (which had wedged the writer for 30s+).
 	boringDeleted, err := w.repo.DeleteExpiredBoringSpans(ctx, now)
 	if err != nil {
+		return err
+	}
+
+	// Clean up trace_summaries in lockstep with the spans they describe: early
+	// for boring-sampled traces (stamped expires_at), then non-error at the
+	// interesting cutoff and error traces at the error cutoff (matching
+	// error_samples), so the trace list drops rows exactly when its spans go.
+	if _, err := w.repo.DeleteExpiredTraceSummaries(ctx, now); err != nil {
+		return err
+	}
+	if _, err := w.repo.DeleteTraceSummariesOlderThan(ctx, interestingCutoff, errorCutoff); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Problem (diagnosed from self-instrumentation)

Loading traces via `sb traces` / the Traces page was slow to the point of failure. Self-instrumentation on the `spanbarn` project pinpointed it:

| Probe | Result |
|---|---|
| `sb trace <id>` (detail) | ~0.11s (indexed) |
| trace list, low-volume project | ~0.39s |
| trace list, `spanbarn` (8.2M spans), 1h/6h/24h | **30s timeout** |

The cost is the **trace-list** query `SearchTraceSummaries`, which `GROUP BY`s every span in the whole window over `spans ∪ error_samples` **before** applying `LIMIT` — so it scales with span volume, not the page size (`limit=20` still timed out). Because the request never completed, the 60s response cache never populated, so every load paid full price. (The `sb` CLI itself is fine — one bulk GET, trivial client work.)

## Fix

A per-trace **`trace_summaries`** table (one indexed row per `(project_id, trace_id)`: root name/service/duration, start time, span count, has_error), maintained by an `UPSERT` inside `CommitStagingFlush` (and the inline `InsertSpansContext`) — **atomic** with the span write. The list becomes an indexed `ORDER BY ingested_at DESC LIMIT` scan, independent of span volume.

- **Read path** `SearchTraceSummaries` rewritten to read the table. Filters map onto rollup columns (Service→root_service, Operation/Exclude→root_name, Status→has_error, MinDuration→root_duration_us, From/To→ingested_at, minSpans→span_count). `SearchTraces` service layer unchanged.
- **Retention** drops summaries in lockstep with their spans: boring-sampled via stamped `expires_at`, non-error at the interesting cutoff, **error traces at the error cutoff** (matching `error_samples`), so dropping the old `spans ∪ error_samples` UNION loses no error traces.
- **No migration backfill** — a group-by over the live 5GB spans table at startup would wedge the writer mid-deploy (the failure mode migration 030's notes call out). The table fills forward from flushes; the list is fast immediately and self-populates within the flush window.

### Behavior notes
- Trace-list filters (service/operation/status/min-duration) are now evaluated against the **root span / whole-trace** rollup rather than "any span in the trace" — more intuitive for an entry-point list, and a minor, deliberate semantic refinement.
- Brief post-deploy gap: traces flushed in the minute or two *before* deploy won't have summaries until they age out. Acceptable — the current behavior is a 30s timeout that shows nothing.

## Tests
`internal/repository/repo_trace_summaries_test.go`: upsert + search, accumulation of late spans (count sums, has_error ORs, root not clobbered), the production staging-flush path, and retention (boring/interesting/error cutoffs).

## Verification
- `go build ./...`, full `go test ./...`, `go test -race` on repository/retention/worker — green
- `make quality-gate` — passes (repository coverage 70.0% ≥ 69.0%)
- `make lint` — "All checks passed!"
- Post-deploy: re-run `sb traces --project spanbarn` and confirm it returns fast instead of timing out.