### PR TITLE
feat(retention): per-project retention caps (max hours / max traces)

### DIFF
--- a/internal/api/settings.go
+++ b/internal/api/settings.go
@@ -162,6 +162,8 @@ func serveSWR[T any](
 // Boring span keys: boring.sample_ratio, boring.sample_ratio.project.{id},
 // boring_retention_minutes, boring.verbose_until.project.{id},
 // boring.min_traces_per_minute, boring.min_traces_per_minute.project.{id}.
+// Per-project retention caps: retention.max_hours.project.{id},
+// retention.max_traces.project.{id}.
 func isAllowedSettingKey(k string) bool {
 	switch k {
 	case "retention_full_hours", "retention_interesting_hours",
@@ -174,7 +176,9 @@ func isAllowedSettingKey(k string) bool {
 	return strings.HasPrefix(k, "ingest.sample_ratio.") ||
 		strings.HasPrefix(k, "boring.sample_ratio.") ||
 		strings.HasPrefix(k, "boring.min_traces_per_minute.") ||
-		strings.HasPrefix(k, "boring.verbose_until.")
+		strings.HasPrefix(k, "boring.verbose_until.") ||
+		strings.HasPrefix(k, "retention.max_hours.project.") ||
+		strings.HasPrefix(k, "retention.max_traces.project.")
 }
 
 func (h *settingsHandlers) handleStatsDBSize(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/settings_retention_test.go
+++ b/internal/api/settings_retention_test.go
@@ -1,0 +1,27 @@
+package api
+
+import "testing"
+
+func TestIsAllowedSettingKeyRetention(t *testing.T) {
+	allowed := []string{
+		"retention.max_hours.project.5",
+		"retention.max_traces.project.42",
+	}
+	for _, k := range allowed {
+		if !isAllowedSettingKey(k) {
+			t.Errorf("%q should be an allowed setting key", k)
+		}
+	}
+	denied := []string{
+		"retention.max_hours",            // must be project-scoped
+		"retention.max_traces",           // must be project-scoped
+		"retention.evil.project.5",       // unknown retention subkey
+		"retention_full_hours.project.5", // global key is not a project prefix
+		"random.key",
+	}
+	for _, k := range denied {
+		if isAllowedSettingKey(k) {
+			t.Errorf("%q should NOT be an allowed setting key", k)
+		}
+	}
+}

--- a/internal/repository/repo_retention_project.go
+++ b/internal/repository/repo_retention_project.go
@@ -1,0 +1,130 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+)
+
+// evictCascadeTables lists the trace_id-keyed tables a victim trace is removed
+// from. spans/error_samples/prompt_records/logs each have a trace_id index;
+// trace_summaries is keyed by (project_id, trace_id). Order doesn't matter — the
+// whole set is deleted in one transaction.
+var evictCascadeTables = []string{"spans", "error_samples", "prompt_records", "logs", "trace_summaries"}
+
+// EvictProjectTracesOlderThan enforces a per-project retention cap by deleting a
+// project's NON-ERROR, non-pinned traces whose ingested_at is before cutoff,
+// cascading across every trace_id-keyed table. Error traces are never evicted
+// (they remain the health signal), pinned traces are protected, and metrics are
+// untouched (aggregates are rolled up at ingest, independent of raw-trace
+// storage). Batched like the other retention deletes so the single write
+// connection is released — and the WAL checkpoint/readers un-starved — between
+// batches.
+func (r *Repository) EvictProjectTracesOlderThan(ctx context.Context, projectID int64, cutoff time.Time) (int64, error) {
+	c := cutoff.UTC()
+	var total int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		var deleted int64
+		if err := r.execLow(func() error {
+			n, e := r.evictTraceBatch(ctx, projectID, c)
+			deleted = n
+			return e
+		}); err != nil {
+			return total, err
+		}
+		total += deleted
+		if deleted < retentionDeleteBatch {
+			return total, nil
+		}
+		if r.deleteBatchYield > 0 {
+			select {
+			case <-ctx.Done():
+				return total, ctx.Err()
+			case <-time.After(r.deleteBatchYield):
+			}
+		}
+	}
+}
+
+// evictTraceBatch selects up to retentionDeleteBatch victim trace_ids and deletes
+// them across evictCascadeTables in one transaction. Returns the number of traces
+// evicted (0 means nothing was eligible).
+func (r *Repository) evictTraceBatch(ctx context.Context, projectID int64, cutoff time.Time) (int64, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.QueryContext(ctx, `
+		SELECT trace_id FROM trace_summaries
+		WHERE project_id = ? AND has_error = 0 AND ingested_at < ?
+		  AND NOT EXISTS (SELECT 1 FROM pinned_traces p
+		                  WHERE p.project_id = trace_summaries.project_id
+		                    AND p.trace_id  = trace_summaries.trace_id)
+		ORDER BY ingested_at
+		LIMIT ?`, projectID, cutoff, retentionDeleteBatch)
+	if err != nil {
+		return 0, err
+	}
+	var ids []any
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	placeholders := strings.Repeat("?,", len(ids))
+	placeholders = placeholders[:len(placeholders)-1]
+	for _, table := range evictCascadeTables {
+		if _, err := tx.ExecContext(ctx, "DELETE FROM "+table+" WHERE trace_id IN ("+placeholders+")", ids...); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return int64(len(ids)), nil
+}
+
+// ProjectNonErrorTraceCountCutoff returns the ingested_at boundary that keeps the
+// newest keepN non-error traces for a project: traces at or before the cutoff are
+// beyond the cap. ok is false when the project has keepN or fewer non-error traces
+// (nothing to evict). Count-based eviction composes this with
+// EvictProjectTracesOlderThan(cutoff).
+func (r *Repository) ProjectNonErrorTraceCountCutoff(ctx context.Context, projectID int64, keepN int) (time.Time, bool, error) {
+	if keepN <= 0 {
+		return time.Time{}, false, nil
+	}
+	// Offset keepN-1 lands on the keepN-th newest non-error trace; evicting
+	// strictly older than its ingested_at keeps at least keepN (ties at the
+	// boundary are kept).
+	var cutoff time.Time
+	err := r.db.QueryRowContext(ctx, `
+		SELECT ingested_at FROM trace_summaries
+		WHERE project_id = ? AND has_error = 0
+		ORDER BY ingested_at DESC
+		LIMIT 1 OFFSET ?`, projectID, keepN-1).Scan(&cutoff)
+	if errors.Is(err, sql.ErrNoRows) {
+		return time.Time{}, false, nil
+	}
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	return cutoff, true, nil
+}

--- a/internal/repository/repo_retention_project_test.go
+++ b/internal/repository/repo_retention_project_test.go
@@ -1,0 +1,114 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// insertTraceAt stores a one-span trace for project 1 with a controlled
+// ingested_at (which flows into trace_summaries.ingested_at) and status.
+func insertTraceAt(t *testing.T, repo *Repository, trace, status string, ingested time.Time) {
+	t.Helper()
+	s := tsSpan(trace, trace+"s1", "", "GET /"+trace, "svc", status, 1000, 100)
+	s.IngestedAt = ingested
+	if err := repo.InsertSpans([]Span{s}); err != nil {
+		t.Fatalf("insert %s: %v", trace, err)
+	}
+}
+
+func summaryTraceIDs(t *testing.T, repo *Repository) map[string]bool {
+	t.Helper()
+	rows, err := repo.SearchTraceSummaries(SpanFilter{ProjectID: 1}, 0)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[r.TraceID] = true
+	}
+	return got
+}
+
+func TestEvictProjectTracesOlderThan(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	old := now.Add(-10 * time.Hour)
+	recent := now.Add(-1 * time.Hour)
+
+	insertTraceAt(t, repo, "old1", "ok", old)      // evictable
+	insertTraceAt(t, repo, "old2", "ok", old)      // evictable
+	insertTraceAt(t, repo, "olderr", "error", old) // error → kept
+	insertTraceAt(t, repo, "oldpin", "ok", old)    // pinned → kept
+	insertTraceAt(t, repo, "new1", "ok", recent)   // newer than cutoff → kept
+	if err := repo.PinTrace(ctx, 1, "oldpin", "keep"); err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+
+	evicted, err := repo.EvictProjectTracesOlderThan(ctx, 1, now.Add(-5*time.Hour))
+	if err != nil {
+		t.Fatalf("evict: %v", err)
+	}
+	if evicted != 2 {
+		t.Fatalf("evicted = %d, want 2 (old1, old2)", evicted)
+	}
+
+	got := summaryTraceIDs(t, repo)
+	for _, keep := range []string{"olderr", "oldpin", "new1"} {
+		if !got[keep] {
+			t.Errorf("%s should have survived eviction", keep)
+		}
+	}
+	for _, gone := range []string{"old1", "old2"} {
+		if got[gone] {
+			t.Errorf("%s should have been evicted", gone)
+		}
+	}
+
+	// Cascade: the evicted trace's spans are gone; a survivor's remain.
+	if spans, _ := repo.QuerySpans(SpanFilter{ProjectID: 1, TraceID: "old1"}); len(spans) != 0 {
+		t.Errorf("old1 spans not cascaded: %d remain", len(spans))
+	}
+	if spans, _ := repo.QuerySpans(SpanFilter{ProjectID: 1, TraceID: "new1"}); len(spans) != 1 {
+		t.Errorf("new1 spans should remain, got %d", len(spans))
+	}
+}
+
+func TestEvictProjectTracesByCount(t *testing.T) {
+	repo := setupTestDB(t)
+	ctx := context.Background()
+	base := time.Now().UTC().Add(-time.Hour)
+
+	// Five non-error traces oldest→newest, plus one old error trace.
+	for i := 0; i < 5; i++ {
+		insertTraceAt(t, repo, "n"+string(rune('0'+i)), "ok", base.Add(time.Duration(i)*time.Minute))
+	}
+	insertTraceAt(t, repo, "err", "error", base) // oldest, error → always kept
+
+	// Fewer-than-N: nothing to evict.
+	if _, ok, err := repo.ProjectNonErrorTraceCountCutoff(ctx, 1, 10); err != nil || ok {
+		t.Fatalf("count cutoff with keepN>rows: ok=%v err=%v, want ok=false", ok, err)
+	}
+
+	// Keep newest 3 non-error → cutoff at the 3rd-newest (n2); evict n0, n1.
+	cutoff, ok, err := repo.ProjectNonErrorTraceCountCutoff(ctx, 1, 3)
+	if err != nil || !ok {
+		t.Fatalf("count cutoff: ok=%v err=%v, want ok=true", ok, err)
+	}
+	if _, err := repo.EvictProjectTracesOlderThan(ctx, 1, cutoff); err != nil {
+		t.Fatalf("evict: %v", err)
+	}
+
+	got := summaryTraceIDs(t, repo)
+	for _, keep := range []string{"n2", "n3", "n4", "err"} {
+		if !got[keep] {
+			t.Errorf("%s should have survived (newest 3 non-error + error)", keep)
+		}
+	}
+	for _, gone := range []string{"n0", "n1"} {
+		if got[gone] {
+			t.Errorf("%s should have been evicted", gone)
+		}
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -2,6 +2,7 @@ package retention
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"time"
@@ -52,6 +53,9 @@ type Repository interface {
 	DeleteMetricRollupsOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
 	DeleteLogsOlderThan(ctx context.Context, cutoff, errorLogCutoff time.Time) (int64, error)
 	GetSetting(key string) (string, error)
+	ListProjectIDs() ([]int64, error)
+	EvictProjectTracesOlderThan(ctx context.Context, projectID int64, cutoff time.Time) (int64, error)
+	ProjectNonErrorTraceCountCutoff(ctx context.Context, projectID int64, keepN int) (time.Time, bool, error)
 }
 
 // Config controls the retention worker's behaviour.
@@ -376,6 +380,14 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		return err
 	}
 
+	// Enforce per-project retention caps (max age in hours and/or max non-error
+	// trace count). Only shortens retention; never touches errors, pinned traces,
+	// or metrics.
+	projectTracesEvicted, err := w.evictPerProjectCaps(ctx, now)
+	if err != nil {
+		return err
+	}
+
 	span.SetAttributes(
 		attribute.Int64("spans_aggregated", totalAggregated),
 		attribute.Int64("errors_sampled", totalSampled),
@@ -388,6 +400,7 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		attribute.Int64("logs_deleted", logsDeleted),
 		attribute.Int64("e2e_users_deleted", e2eUsersDeleted),
 		attribute.Int64("web_sessions_deleted", webSessionsDeleted),
+		attribute.Int64("project_traces_evicted", projectTracesEvicted),
 		attribute.Bool("backlog_remains", backlogRemains),
 	)
 	w.logger.Info("retention cycle complete",
@@ -402,7 +415,61 @@ func (w *RetentionWorker) RunOnce(ctx context.Context) error {
 		"logs_deleted", logsDeleted,
 		"e2e_users_deleted", e2eUsersDeleted,
 		"web_sessions_deleted", webSessionsDeleted,
+		"project_traces_evicted", projectTracesEvicted,
 		"backlog_remains", backlogRemains,
 	)
 	return nil
+}
+
+// evictPerProjectCaps enforces the per-project retention caps configured via the
+// settings table: retention.max_hours.project.{id} (delete non-error traces older
+// than that many hours) and retention.max_traces.project.{id} (keep only the
+// newest N non-error traces). Both only ever shorten retention; absent/≤0 keys
+// are skipped. Returns the total traces evicted across all projects.
+func (w *RetentionWorker) evictPerProjectCaps(ctx context.Context, now time.Time) (int64, error) {
+	pids, err := w.repo.ListProjectIDs()
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, pid := range pids {
+		if err := ctx.Err(); err != nil {
+			return total, err
+		}
+		if h := w.settingInt(fmt.Sprintf("retention.max_hours.project.%d", pid)); h > 0 {
+			n, err := w.repo.EvictProjectTracesOlderThan(ctx, pid, now.Add(-time.Duration(h)*time.Hour))
+			if err != nil {
+				return total, err
+			}
+			total += n
+		}
+		if maxN := w.settingInt(fmt.Sprintf("retention.max_traces.project.%d", pid)); maxN > 0 {
+			cutoff, ok, err := w.repo.ProjectNonErrorTraceCountCutoff(ctx, pid, maxN)
+			if err != nil {
+				return total, err
+			}
+			if ok {
+				n, err := w.repo.EvictProjectTracesOlderThan(ctx, pid, cutoff)
+				if err != nil {
+					return total, err
+				}
+				total += n
+			}
+		}
+	}
+	return total, nil
+}
+
+// settingInt reads a positive int from the settings table, returning 0 when the
+// key is absent, empty, unparseable, or non-positive.
+func (w *RetentionWorker) settingInt(key string) int {
+	v, err := w.repo.GetSetting(key)
+	if err != nil || v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
 }

--- a/internal/retention/retention_project_test.go
+++ b/internal/retention/retention_project_test.go
@@ -1,0 +1,74 @@
+package retention
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// A per-project max-hours cap evicts that project's old non-error traces while
+// keeping errors, and leaves other projects (no cap) untouched.
+func TestRunOncePerProjectHoursCap(t *testing.T) {
+	cfg := Config{
+		InterestingRetentionHours: 100000, // keep the main aggregate-then-delete loop off test data
+		ErrorRetentionDays:        3650,
+		AggregateRetentionDays:    3650,
+		SlowThresholdUS:           1_000_000,
+	}
+	worker, repo := setupTestWorker(t, cfg)
+	ctx := context.Background()
+	if _, err := repo.CreateProject("p1", "P1"); err != nil { // id 1 (capped)
+		t.Fatalf("CreateProject p1: %v", err)
+	}
+	if _, err := repo.CreateProject("p2", "P2"); err != nil { // id 2 (no cap)
+		t.Fatalf("CreateProject p2: %v", err)
+	}
+
+	old := time.Now().UTC().Add(-10 * time.Hour)
+	mk := func(projectID int64, trace, status string) {
+		s := repository.Span{
+			ProjectID: projectID, TraceID: trace, SpanID: trace + "s", Name: "op", Service: "svc",
+			Kind: "server", Status: status, StartTimeUs: 1000, DurationUs: 100,
+			Attributes: "{}", Events: "[]", IngestedAt: old,
+		}
+		if err := repo.InsertSpans([]repository.Span{s}); err != nil {
+			t.Fatalf("insert %s: %v", trace, err)
+		}
+	}
+	mk(1, "p1-ok1", "ok")
+	mk(1, "p1-ok2", "ok")
+	mk(1, "p1-err", "error")
+	mk(2, "p2-ok", "ok") // different project, no cap → must survive
+
+	if err := repo.SetSetting("retention.max_hours.project.1", "5"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if err := worker.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	survives := func(projectID int64, trace string) bool {
+		rows, err := repo.SearchTraceSummaries(repository.SpanFilter{ProjectID: projectID}, 0)
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		for _, r := range rows {
+			if r.TraceID == trace {
+				return true
+			}
+		}
+		return false
+	}
+
+	if survives(1, "p1-ok1") || survives(1, "p1-ok2") {
+		t.Error("project 1 old non-error traces should be evicted by the 5h cap")
+	}
+	if !survives(1, "p1-err") {
+		t.Error("project 1 error trace must survive the cap")
+	}
+	if !survives(2, "p2-ok") {
+		t.Error("project 2 (no cap) trace must not be touched")
+	}
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -384,6 +384,138 @@ function SamplingSettingsPanel() {
   )
 }
 
+// ─── Per-project retention caps ────────────────────────────────────────────
+
+type RetentionCapProject = {
+  id: number
+  slug: string
+  maxHours: string   // '' means no age cap
+  maxTraces: string  // '' means no count cap
+}
+
+function PerProjectRetentionPanel() {
+  const [projects, setProjects] = useState<RetentionCapProject[]>([])
+  const [saving, setSaving] = useState<string | null>(null)
+  const [savedKey, setSavedKey] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    Promise.all([
+      fetchJSON<{ id: number; slug: string; name: string; status: string; createdAt: string }[]>('/api/v1/projects'),
+      fetchJSON<Record<string, string>>('/api/v1/settings'),
+    ]).then(([projs, settings]) => {
+      if (projs) {
+        setProjects(
+          projs
+            .filter(p => p.status === 'active')
+            .sort((a, b) => a.slug.localeCompare(b.slug))
+            .map(p => ({
+              id: p.id,
+              slug: p.slug,
+              maxHours: settings?.[`retention.max_hours.project.${p.id}`] ?? '',
+              maxTraces: settings?.[`retention.max_traces.project.${p.id}`] ?? '',
+            }))
+        )
+      }
+    }).catch(() => {}).finally(() => setLoading(false))
+  }, [])
+
+  // One PUT carries both keys for the row; an empty value clears that cap.
+  const saveProject = async (p: RetentionCapProject) => {
+    const rowKey = `retention.project.${p.id}`
+    setSaving(rowKey)
+    try {
+      await fetchJSON('/api/v1/settings', {
+        method: 'PUT',
+        body: JSON.stringify({
+          [`retention.max_hours.project.${p.id}`]: p.maxHours,
+          [`retention.max_traces.project.${p.id}`]: p.maxTraces,
+        }),
+      })
+      setSavedKey(rowKey)
+      setTimeout(() => setSavedKey(null), 1500)
+    } catch { /* ignore */ } finally {
+      setSaving(null)
+    }
+  }
+
+  if (loading) return <div className="skeleton" style={{ height: 120, marginBottom: '1.5rem' }} />
+
+  const inputStyle: React.CSSProperties = {
+    padding: '0.3rem 0.5rem',
+    fontSize: '0.8125rem',
+    width: 90,
+    textAlign: 'right',
+  }
+
+  return (
+    <div className="card" style={{ marginBottom: '1.5rem' }}>
+      <div style={{ fontWeight: 700, fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+        Per-project Retention Caps
+      </div>
+      <div style={{ fontSize: '0.6875rem', color: 'var(--text-muted)', marginBottom: '1rem' }}>
+        Cap a project to a maximum age (hours) and/or a maximum number of traces; the
+        oldest non-error traces beyond the limit are dropped. Error traces and metrics
+        are always kept. Leave blank for no cap. Applies within a few minutes.
+      </div>
+
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid var(--border)' }}>
+              <th style={{ textAlign: 'left', padding: '0.375rem 0.5rem', fontWeight: 600, color: 'var(--text-muted)', fontSize: '0.75rem' }}>Project</th>
+              <th style={{ textAlign: 'right', padding: '0.375rem 0.5rem', fontWeight: 600, color: 'var(--text-muted)', fontSize: '0.75rem' }}>Max hours</th>
+              <th style={{ textAlign: 'right', padding: '0.375rem 0.5rem', fontWeight: 600, color: 'var(--text-muted)', fontSize: '0.75rem' }}>Max traces</th>
+              <th style={{ width: 60 }} />
+            </tr>
+          </thead>
+          <tbody>
+            {projects.map(p => {
+              const rowKey = `retention.project.${p.id}`
+              return (
+                <tr key={p.id} style={{ borderBottom: '1px solid var(--border)' }}>
+                  <td style={{ padding: '0.375rem 0.5rem' }}>
+                    <span style={{ fontFamily: 'var(--font-mono)', fontSize: '0.75rem' }}>{p.slug}</span>
+                  </td>
+                  <td style={{ padding: '0.375rem 0.5rem', textAlign: 'right' }}>
+                    <input
+                      type="number"
+                      min="1"
+                      placeholder="∞"
+                      value={p.maxHours}
+                      onChange={e => setProjects(ps => ps.map(x => x.id === p.id ? { ...x, maxHours: e.target.value } : x))}
+                      style={inputStyle}
+                    />
+                  </td>
+                  <td style={{ padding: '0.375rem 0.5rem', textAlign: 'right' }}>
+                    <input
+                      type="number"
+                      min="1"
+                      placeholder="∞"
+                      value={p.maxTraces}
+                      onChange={e => setProjects(ps => ps.map(x => x.id === p.id ? { ...x, maxTraces: e.target.value } : x))}
+                      style={inputStyle}
+                    />
+                  </td>
+                  <td style={{ padding: '0.375rem 0.5rem' }}>
+                    <button
+                      onClick={() => saveProject(p)}
+                      disabled={saving === rowKey}
+                      className="btn btn-sm"
+                    >
+                      {savedKey === rowKey ? '✓' : saving === rowKey ? '…' : 'Save'}
+                    </button>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
 // ─── Projects ────────────────────────────────────────────────────────────────
 
 type Project = {
@@ -605,6 +737,7 @@ export function SettingsPage(): ReactElement {
       {/* System health + retention + sampling */}
       <SystemHealthPanel />
       <RetentionSettingsPanel />
+      <PerProjectRetentionPanel />
       <SamplingSettingsPanel />
 
       {/* LLM Setup reference */}


### PR DESCRIPTION
## Why

Self-telemetry projects (e.g. spanbarn, which grew to 8.2M spans) don't need full trace history — the health signal is **metrics + error traces**. Sampling (`ingest.sample_ratio.project.*`, keep-errors) already bounds ingest; this adds a **hard storage cap** so a project keeps only its most recent traces and drops the oldest.

## What

Two optional per-project settings-table keys:
- `retention.max_hours.project.{id}` — drop non-error traces older than N hours
- `retention.max_traces.project.{id}` — keep only the newest N non-error traces

The retention worker's `RunOnce` gains a per-project eviction pass. For each project it reads the two keys and, driven by `trace_summaries` (indexed `(project_id, ingested_at)`), deletes the oldest eligible traces, cascading across `spans` / `error_samples` / `prompt_records` / `logs` / `trace_summaries` by `trace_id`. Batched through the existing `execLow` + `deleteBatchYield` path so write-lock holds stay bounded (mirrors `deleteOlderThanPerProject`).

### Guarantees
- **Errors always kept** — the cap evicts non-error traces only (`has_error = 0`), consistent with the sampling that already keeps all errors.
- **Pinned traces kept** — excluded via `NOT EXISTS pinned_traces`.
- **Metrics untouched** — aggregates are rolled up at ingest (`staging_flush.go` → `Accumulator` before classification), independent of raw-trace storage, so evicting traces never loses the health signal.
- **Only shortens retention** — absent/≤0 keys = no cap.

Count-based eviction composes `ProjectNonErrorTraceCountCutoff` (the ingested_at of the Nth-newest non-error trace) with `EvictProjectTracesOlderThan`.

### Config surface
Operators set the caps on the **Settings page** — a new per-project retention table (Max hours / Max traces) next to the existing per-project sampling control. Saved via `PUT /api/v1/settings`; empty clears a cap. New keys are whitelisted in `isAllowedSettingKey`.

## Tests
- `repo_retention_project_test.go` — age + count eviction; errors and pinned traces survive; cascade removes the evicted trace's spans; survivors intact.
- `retention_project_test.go` — full `RunOnce` with a per-project `max_hours` setting: old non-error evicted, error kept, a second uncapped project untouched.
- `settings_retention_test.go` — the new keys pass `isAllowedSettingKey`, global/unknown variants rejected.

## Verification
- `go build ./...`, full `go test ./...`, `make quality-gate` (repo coverage 70.3% ≥ 69.0%), `make lint` ("All checks passed!"), web tsc + 59 Vitest tests — all green.
- Post-deploy: set spanbarn (project 5) to 1/1000 sampling + a cap on the Settings page and watch the span count fall while metrics and error traces persist.