### PR TITLE
fix(ingress): forward /v1/metrics and /v1/logs for sb.* domains

### DIFF
--- a/deploy/k8s/production/ingress-forward-domains.yaml
+++ b/deploy/k8s/production/ingress-forward-domains.yaml
@@ -17,6 +17,22 @@ spec:
       services:
         - name: spanbarn-ingest
           port: 8080
+    # OTLP metrics + logs share the same writer (spanbarn-ingest registers all
+    # three OTLP handlers). Without these rules the POSTs fall through to the
+    # priority-1 redirect and hit spanbarn-web, which answers 405 — so forwarded
+    # sb.* domains could ship traces but never metrics or logs.
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/v1/metrics`)
+      kind: Rule
+      priority: 101
+      services:
+        - name: spanbarn-ingest
+          port: 8080
+    - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/v1/logs`)
+      kind: Rule
+      priority: 101
+      services:
+        - name: spanbarn-ingest
+          port: 8080
     - match: HostRegexp(`^sb\..+$`) && PathPrefix(`/api/v1/spans`)
       kind: Rule
       priority: 101


### PR DESCRIPTION
## Problem

BrandTrace production (and every other forwarded `sb.*` domain) logs an OTLP metrics-export **error every ~30s**:

```
Failed to export metrics batch code: 405, reason: Method Not Allowed
```

Traces export fine; metrics and logs do not.

## Root cause

The `spanbarn-forward-domains` IngressRoute forwards only `/v1/traces` (and a few `/api/v1/*` paths) to the ingest reader. `/v1/metrics` and `/v1/logs` have **no rule**, so they fall through to the priority-1 catch-all redirect → `spanbarn-web` (static SPA), which answers **405** to a POST.

Result: forwarded `sb.*` domains (brandtrace, pensioenfeest, scanoo, scanbarelinks) can ship traces but never metrics or logs. Staging/testing are unaffected because their ingress has a `PathPrefix(`/v1`)` catch-all pointing at the reader.

## Fix

Add `PathPrefix(`/v1/metrics`)` and `PathPrefix(`/v1/logs`)` rules mirroring `/v1/traces`, routing both to `spanbarn-ingest` (the reader deployment, which registers OTLP handlers for all three signals). Same destination staging/testing already use via their `/v1` catch-all.

## Verification

- `kubectl kustomize deploy/k8s/production` builds clean.
- Confirmed `spanbarn-ingest`/`spanbarn-reads` services both select the `SPANBARN_MODE=reader` deployment, and the reader registers metrics + logs handlers.
- Post-deploy: the 405 loop across brandtrace api/worker/crawler/scheduler should stop and metrics should appear in the spanbarn dashboard.

Additive only — no existing rule changed.