### PR TITLE
fix(retention): default interesting-span window to 48h, not 168h

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-hosted telemetry aggregator. Lightweight OTLP-compatible tracing with intel
 
 SpanBarn collects distributed traces from your applications and gives you performance visibility without the operational overhead of Jaeger, Tempo, or Datadog.
 
-**Smart retention**: full-fidelity spans are kept for a configurable window (default: 72 hours). Error and slow spans get extended retention (default: 7 days). After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept for 30 days. Uneventful spans are dropped first; interesting spans are preserved longer.
+**Smart retention**: full-fidelity spans are kept for a configurable window (default: 72 hours). Error and slow spans get extended retention (default: 2 days). After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept for 30 days. Uneventful spans are dropped first; interesting spans are preserved longer.
 
 This gives you:
 - **Recent debugging**: full traces for the last 72 hours to investigate live issues
@@ -243,7 +243,7 @@ project automatically.
 | `SPANBARN_MAX_BODY_BYTES` | `1048576` | Max ingest body (1 MiB) |
 | `SPANBARN_MAX_SPOOL_BYTES` | | Spool backpressure limit |
 | `SPANBARN_RETENTION_FULL_HOURS` | `72` | Hours to keep all spans |
-| `SPANBARN_RETENTION_INTERESTING_HOURS` | `168` | Hours to keep error/slow spans (7 days) |
+| `SPANBARN_RETENTION_INTERESTING_HOURS` | `48` | Hours to keep error/slow spans (2 days). This is the window spans are actually deleted on, so it sizes the database. |
 | `SPANBARN_RETENTION_AGGREGATED_DAYS` | `30` | Days to keep aggregates |
 | `SPANBARN_RETENTION_ERROR_DAYS` | `90` | Days to keep error samples |
 | `SPANBARN_INGEST_SAMPLE_RATE` | `1.0` | Fraction of normal spans to keep (0-1, 1=keep all) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,7 +141,7 @@ func Load() Config {
 			FullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
 			AggregatedDays:     getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
 			ErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
-			InterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 168),
+			InterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 48),
 			BoringMinutes:      getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
 			MetricsDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
 			LogHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,3 +63,16 @@ func TestIsDevEnvironment(t *testing.T) {
 		}
 	}
 }
+
+func TestRetentionInterestingHoursDefault(t *testing.T) {
+	if got := Load().Retention.InterestingHours; got != 48 {
+		t.Fatalf("default Retention.InterestingHours = %d, want 48", got)
+	}
+}
+
+func TestRetentionInterestingHoursEnvOverride(t *testing.T) {
+	t.Setenv("SPANBARN_RETENTION_INTERESTING_HOURS", "12")
+	if got := Load().Retention.InterestingHours; got != 12 {
+		t.Fatalf("Retention.InterestingHours = %d, want 12", got)
+	}
+}

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -61,7 +61,7 @@ type Repository interface {
 // Config controls the retention worker's behaviour.
 type Config struct {
 	FullRetentionHours        int           // hours to keep ALL spans (default 4)
-	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 168 = 7d)
+	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 48 = 2d); this is the cutoff RunOnce deletes spans on
 	BoringRetentionMinutes    int           // minutes to keep sampled boring spans (default 30); 0 disables boring cleanup
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
@@ -82,7 +82,7 @@ func (c Config) withDefaults() Config {
 		c.FullRetentionHours = 4
 	}
 	if c.InterestingRetentionHours <= 0 {
-		c.InterestingRetentionHours = 168
+		c.InterestingRetentionHours = 48
 	}
 	if c.BoringRetentionMinutes <= 0 {
 		c.BoringRetentionMinutes = 30

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -492,3 +492,17 @@ func TestRunOnceDeletesBoringSpans(t *testing.T) {
 		}
 	}
 }
+
+// TestWithDefaultsInterestingRetentionHours pins the span-deletion window.
+// InterestingRetentionHours is the cutoff RunOnce actually deletes spans on, so
+// its default sizes the database. It previously defaulted to 168h (7d), which
+// outgrew production's disk before retention was ever due to delete anything.
+func TestWithDefaultsInterestingRetentionHours(t *testing.T) {
+	if got := (Config{}).withDefaults().InterestingRetentionHours; got != 48 {
+		t.Fatalf("default InterestingRetentionHours = %d, want 48", got)
+	}
+	// An explicit value must still win over the default.
+	if got := (Config{InterestingRetentionHours: 12}).withDefaults().InterestingRetentionHours; got != 12 {
+		t.Fatalf("explicit InterestingRetentionHours = %d, want 12", got)
+	}
+}


### PR DESCRIPTION
## Why

Production wedged for ~28h on 2026-07-16: SQLite hit its 5GB volume cap and every write failed with `database or disk is full (13)`, which backed the Redis write-queue up to its 768M `noeviction` cap until ingest rejected everything.

The cause was a default, not a crash. `InterestingRetentionHours` is the cutoff `RunOnce` actually deletes spans on, and it defaulted to **168h (7 days)**. The disk holds roughly **4 days** of spans at current volume, so it filled on day 4 — before retention was ever due to delete anything. Retention reported `pending spans: 0` the entire time and was *correct*: nothing was older than 7 days. It was keeping everything, exactly as configured.

This is unrecoverable once it happens: a `DELETE` needs WAL space (there is none at 100%), and `auto_vacuum=NONE` means freed pages never return to the OS, so deleting rows in place frees zero bytes. The window has to be small enough that it never gets there.

## What

- Default `168 -> 48` in **both** places it is set — the env default in `config.Load` and the struct fallback in `withDefaults`. Changing only one leaves the trap intact.
- Pin both defaults with tests. The old default was completely unpinned, which is how it drifted out of line with the disk unnoticed.
- README: correct the documented default and note that this window sizes the database.

Prod already has `retention_interesting_hours=48` applied as a live setting; this makes it the default so a fresh DB or a new environment can't inherit the 7-day trap.

## Known follow-ups (not in this PR)

- **`retention_full_hours` is a dead setting.** It is assigned in `retention.go` and `runtime.go` and never read by any query. Prod had it set to `72`, believing it capped span retention — it does nothing. The README actively advertises it as "Hours to keep all spans", which is likely where the 72 came from. It should either work or fail loudly.
- The README retention table has other stale defaults (`AGGREGATED_DAYS`, `ERROR_DAYS`) that don't match the code.
- No size/disk-based retention guard exists, so any time-based window can still outrun the disk.

## Test

`go build ./...`, `go vet`, and `go test ./internal/...` all pass.