### PR TITLE
fix(ingest): sample self-instrument spans instead of exempting them

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -436,7 +436,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 	if roRepo != nil {
 		ratioLookup = ingest.NewCachedRatioLookup(roRepo, time.Minute)
 	}
-	traceBuffer := ingest.NewTraceBuffer(ingest.DefaultTraceBufferTTL, ratioLookup)
+	traceBuffer := ingest.NewTraceBuffer(ingest.DefaultTraceBufferTTL, ratioLookup, logger)
 	safeGo("trace-buffer-drain", &wg, func() {
 		for {
 			select {

--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -65,16 +65,16 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 		span.SetAttributes(attribute.Int("span_count", len(records)))
 	}
 
-	if selfExport {
-		// Self-instrument spans bypass the TraceBuffer so they are never
-		// dropped by project-level sampling — the pod's own traces must
-		// always reach the writer.
-		for _, rec := range records {
-			s.ingest.Enqueue(rec)
-		}
-	} else if s.traceBuffer != nil {
+	if s.traceBuffer != nil {
 		// Tail-based sampling: add to the trace buffer and let it decide
 		// per-trace after the configured TTL. Error traces always pass.
+		//
+		// Self-instrument spans go through the buffer like any other project.
+		// They used to bypass it so the pod's own traces "always reached the
+		// writer", but self-telemetry is by far the largest span producer, so
+		// exempting it made its sample ratio unenforceable and let it fill the
+		// disk. keep() still passes every error trace, so the traces that
+		// matter are unaffected.
 		for _, rec := range records {
 			s.traceBuffer.Add(rec)
 		}

--- a/internal/api/otlp_selfsample_test.go
+++ b/internal/api/otlp_selfsample_test.go
@@ -1,0 +1,143 @@
+package api_test
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/wiebe-xyz/spanbarn/internal/api"
+	"github.com/wiebe-xyz/spanbarn/internal/ingest"
+	"github.com/wiebe-xyz/spanbarn/internal/spool"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// selfInstrumentUA must match observability.selfInstrumentUA — the User-Agent
+// SpanBarn's own OTLP exporter sets, which TracingMiddleware turns into the
+// context flag handleOTLP reads.
+const selfInstrumentUA = "spanbarn-self-instrument"
+
+// setupSampledOTLPServer builds a server wired the way the reader pod is: a
+// TraceBuffer in front of the ingest queue. Returns the queue (what reached
+// storage directly, bypassing sampling) and the buffer.
+//
+// The ingest handler flush loop is NOT started, so anything enqueued stays in
+// the queue for inspection.
+func setupSampledOTLPServer(t *testing.T, ratio int) (*httptest.Server, *ingest.Queue, *ingest.TraceBuffer) {
+	t.Helper()
+	q := ingest.NewQueue(1024)
+	sp, err := spool.NewSpool(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("spool: %v", err)
+	}
+	t.Cleanup(func() { sp.Close() })
+
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := ingest.NewHandler(q, sp, 0, discard)
+	tb := ingest.NewTraceBuffer(time.Hour, ingest.NewStaticRatioLookup(ratio), discard)
+
+	srv := api.NewServerWithQuery(api.ServerConfig{
+		APIKey:       testAPIKey,
+		MaxBodyBytes: 4 << 20,
+		Version:      "test",
+	}, h, nil, nil, discard, api.WithTraceBuffer(tb))
+
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return ts, q, tb
+}
+
+func postTraces(t *testing.T, ts *httptest.Server, status *tracepb.Status, userAgent string) {
+	t.Helper()
+	// buildOTLPRequest's trace ID starts 0x0102030405060708 = 72623859790382856,
+	// which is not divisible by the 1000000 ratio used below — so it is dropped
+	// unless something bypasses the sampler.
+	otlpReq := buildOTLPRequest("spanbarn", "sqlite.insert", tracepb.Span_SPAN_KIND_CLIENT, status, 1700000000000000, 1700000001000000)
+	body, err := proto.Marshal(otlpReq)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/traces", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/x-protobuf")
+	r.Header.Set("X-SpanBarn-Api-Key", testAPIKey)
+	if userAgent != "" {
+		r.Header.Set("User-Agent", userAgent)
+	}
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestSelfInstrumentSpansAreSampled is the regression test for the bug that let
+// self-telemetry fill production's disk. Self-instrument spans used to bypass the
+// TraceBuffer entirely, which made ingest.sample_ratio.project.N unenforceable for
+// SpanBarn's own spans — by far the largest producer. They must go through the
+// buffer like any other project.
+func TestSelfInstrumentSpansAreSampled(t *testing.T) {
+	ts, q, tb := setupSampledOTLPServer(t, 1000000)
+
+	postTraces(t, ts, nil, selfInstrumentUA)
+
+	if n := q.Len(); n != 0 {
+		t.Fatalf("self-instrument spans bypassed the sampler: %d span(s) enqueued directly, want 0", n)
+	}
+
+	// They landed in the buffer; the ratio must then drop them.
+	tb.Flush(time.Now().Add(2 * time.Hour))
+	select {
+	case spans := <-tb.Out:
+		t.Fatalf("unsampled self trace was kept: %d span(s)", len(spans))
+	case <-time.After(50 * time.Millisecond):
+		// Correct: dropped by ratio.
+	}
+}
+
+// TestSelfInstrumentErrorSpansAlwaysPass guards the original intent of the removed
+// bypass: SpanBarn must never lose its own error traces, even at a sample ratio
+// that drops everything else.
+func TestSelfInstrumentErrorSpansAlwaysPass(t *testing.T) {
+	ts, q, tb := setupSampledOTLPServer(t, 1000000)
+
+	postTraces(t, ts, &tracepb.Status{Code: tracepb.Status_STATUS_CODE_ERROR}, selfInstrumentUA)
+
+	if n := q.Len(); n != 0 {
+		t.Fatalf("expected the error trace to go through the buffer, got %d enqueued directly", n)
+	}
+
+	tb.Flush(time.Now().Add(2 * time.Hour))
+	select {
+	case spans := <-tb.Out:
+		if len(spans) != 1 {
+			t.Fatalf("want 1 self error span kept, got %d", len(spans))
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("self-instrument error trace was dropped — errors must always pass")
+	}
+}
+
+// TestNonSelfSpansStillSampled pins that ordinary tenant traffic is unchanged.
+func TestNonSelfSpansStillSampled(t *testing.T) {
+	ts, q, tb := setupSampledOTLPServer(t, 1000000)
+
+	postTraces(t, ts, nil, "some-tenant-sdk/1.0")
+
+	if n := q.Len(); n != 0 {
+		t.Fatalf("tenant spans should go through the buffer, got %d enqueued directly", n)
+	}
+	tb.Flush(time.Now().Add(2 * time.Hour))
+	select {
+	case <-tb.Out:
+		t.Fatal("unsampled tenant trace was kept")
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,7 +143,7 @@ func Load() Config {
 			ErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
 			InterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 48),
 			BoringMinutes:      getenvInt("SPANBARN_BORING_RETENTION_MINUTES", 30),
-			MetricsDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 90),
+			MetricsDays:        getenvInt("SPANBARN_METRICS_RETENTION_DAYS", 7),
 			LogHours:           getenvInt("SPANBARN_LOG_RETENTION_HOURS", 24),
 			ErrorLogDays:       getenvInt("SPANBARN_ERROR_LOG_RETENTION_DAYS", 30),
 			DeleteBatchYieldMS: getenvInt("SPANBARN_RETENTION_DELETE_BATCH_YIELD_MS", 200),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,3 +76,16 @@ func TestRetentionInterestingHoursEnvOverride(t *testing.T) {
 		t.Fatalf("Retention.InterestingHours = %d, want 12", got)
 	}
 }
+
+func TestMetricsRetentionDaysDefault(t *testing.T) {
+	if got := Load().Retention.MetricsDays; got != 7 {
+		t.Fatalf("default Retention.MetricsDays = %d, want 7", got)
+	}
+}
+
+func TestMetricsRetentionDaysEnvOverride(t *testing.T) {
+	t.Setenv("SPANBARN_METRICS_RETENTION_DAYS", "30")
+	if got := Load().Retention.MetricsDays; got != 30 {
+		t.Fatalf("Retention.MetricsDays = %d, want 30", got)
+	}
+}

--- a/internal/ingest/trace_buffer.go
+++ b/internal/ingest/trace_buffer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -20,6 +21,15 @@ const (
 	DefaultSampleRatio = 1000
 
 	gcInterval = 30 * time.Second
+
+	// DefaultMaxBufferedSpans bounds how many spans are held across all in-flight
+	// traces. Every span waits out the full TTL before a sampling decision is
+	// made, so the buffer holds TTL-worth of *unsampled* traffic — including
+	// self-instrument spans, whose volume scales with writer load. An unbounded
+	// map therefore grows fastest exactly when the pod is already struggling, so
+	// it is capped: the reader runs under a 448MiB GOMEMLIMIT and this map is
+	// live data the GC cannot reclaim.
+	DefaultMaxBufferedSpans = 50_000
 )
 
 // SampleRatioLookup returns the configured ratio for a (projectID, operation)
@@ -42,6 +52,14 @@ type TraceBuffer struct {
 	traces map[string]*bufferedTrace
 	ttl    time.Duration
 	lookup SampleRatioLookup
+	logger *slog.Logger
+
+	// maxSpans caps spanCount, the number of spans buffered across all traces.
+	// 0 disables the cap. spanCount may overshoot slightly: spans on traces
+	// already known to contain an error are always accepted (see Add).
+	maxSpans  int
+	spanCount int
+	dropped   int64
 
 	// Accepted spans are sent to this channel for the caller to drain.
 	Out <-chan []model.SpanRecord
@@ -57,15 +75,21 @@ type bufferedTrace struct {
 	firstSeen time.Time
 }
 
-// NewTraceBuffer creates a buffer with the given TTL and ratio lookup.
-func NewTraceBuffer(ttl time.Duration, lookup SampleRatioLookup) *TraceBuffer {
+// NewTraceBuffer creates a buffer with the given TTL and ratio lookup, capped at
+// DefaultMaxBufferedSpans.
+func NewTraceBuffer(ttl time.Duration, lookup SampleRatioLookup, logger *slog.Logger) *TraceBuffer {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	ch := make(chan []model.SpanRecord, 256)
 	tb := &TraceBuffer{
-		traces: make(map[string]*bufferedTrace),
-		ttl:    ttl,
-		lookup: lookup,
-		out:    ch,
-		Out:    ch,
+		traces:   make(map[string]*bufferedTrace),
+		ttl:      ttl,
+		lookup:   lookup,
+		logger:   logger,
+		maxSpans: DefaultMaxBufferedSpans,
+		out:      ch,
+		Out:      ch,
 	}
 	go tb.gcLoop()
 	return tb
@@ -77,19 +101,37 @@ func (tb *TraceBuffer) Add(rec model.SpanRecord) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
+	atCap := tb.maxSpans > 0 && tb.spanCount >= tb.maxSpans
+
 	tr := tb.traces[rec.TraceID]
 	if tr == nil {
+		if atCap {
+			tb.dropped++
+			return
+		}
 		tr = &bufferedTrace{
 			projectID: rec.ProjectID,
 			firstSeen: time.Now(),
 		}
 		tb.traces[rec.TraceID] = tr
 	}
-	tr.spans = append(tr.spans, rec)
 
+	// Latch the error status before the cap check: even when the span's payload
+	// is dropped, the trace must still be recognised as an error trace so keep()
+	// passes whatever spans of it we did retain.
 	if isErrorStatus(rec.Status) {
 		tr.hasError = true
 	}
+
+	// Over capacity, keep collecting error traces — they bypass sampling and are
+	// the traces worth protecting — but stop growing everything else.
+	if atCap && !tr.hasError {
+		tb.dropped++
+		return
+	}
+
+	tr.spans = append(tr.spans, rec)
+	tb.spanCount++
 
 	// The root span has no parent; use its name as the representative operation
 	// for the ratio lookup. If we see it, latch it.
@@ -108,13 +150,30 @@ func (tb *TraceBuffer) Flush(now time.Time) {
 			expired = append(expired, id)
 		}
 	}
-	// Move expired traces out of the map before releasing the lock.
+	// Move expired traces out of the map before releasing the lock, releasing
+	// their span budget back to the cap as they go.
 	toDecide := make([]*bufferedTrace, 0, len(expired))
 	for _, id := range expired {
-		toDecide = append(toDecide, tb.traces[id])
+		tr := tb.traces[id]
+		toDecide = append(toDecide, tr)
+		tb.spanCount -= len(tr.spans)
 		delete(tb.traces, id)
 	}
+	if tb.spanCount < 0 {
+		tb.spanCount = 0
+	}
+	dropped := tb.dropped
+	tb.dropped = 0
+	buffered, tracesHeld := tb.spanCount, len(tb.traces)
 	tb.mu.Unlock()
+
+	if dropped > 0 {
+		tb.logger.Warn("trace buffer over capacity, spans dropped",
+			"dropped", dropped,
+			"max_spans", tb.maxSpans,
+			"buffered_spans", buffered,
+			"buffered_traces", tracesHeld)
+	}
 
 	for _, tr := range toDecide {
 		if tb.keep(tr) {

--- a/internal/ingest/trace_buffer_test.go
+++ b/internal/ingest/trace_buffer_test.go
@@ -2,11 +2,17 @@ package ingest
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/wiebe-xyz/spanbarn/internal/model"
 )
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 func span(traceID, spanID, parentID, name, status string) model.SpanRecord {
 	return model.SpanRecord{
@@ -20,7 +26,7 @@ func span(traceID, spanID, parentID, name, status string) model.SpanRecord {
 }
 
 func TestTraceBuffer_ErrorTraceAlwaysKept(t *testing.T) {
-	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1000000))
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1000000), testLogger())
 	tb.Add(span("trace1", "s1", "", "GET /health", "OK"))
 	tb.Add(span("trace1", "s2", "s1", "db.query", "ERROR"))
 
@@ -38,7 +44,7 @@ func TestTraceBuffer_ErrorTraceAlwaysKept(t *testing.T) {
 
 func TestTraceBuffer_NonErrorDroppedByRatio(t *testing.T) {
 	// Ratio 1000000 so almost nothing passes; deterministically check a known trace.
-	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1000000))
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1000000), testLogger())
 
 	// Use a trace ID that we know does NOT sample at ratio 1000000.
 	// "aaaaaaaaaaaaaaaa..." → upper bytes all 0xaa → 0xaaaa...aa % 1000000 ≠ 0
@@ -55,7 +61,7 @@ func TestTraceBuffer_NonErrorDroppedByRatio(t *testing.T) {
 }
 
 func TestTraceBuffer_RatioOneKeepsAll(t *testing.T) {
-	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1))
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1), testLogger())
 	tb.Add(span("trace1", "s1", "", "POST /api/data", "OK"))
 	tb.Flush(time.Now().Add(time.Second))
 
@@ -76,7 +82,7 @@ func TestTraceBuffer_RootSpanDeterminesOperation(t *testing.T) {
 		}
 		called = true
 	}}
-	tb := NewTraceBuffer(10*time.Millisecond, lookup)
+	tb := NewTraceBuffer(10*time.Millisecond, lookup, testLogger())
 	tb.Add(span("t1", "child", "root", "child-op", "OK")) // child first
 	tb.Add(span("t1", "root", "", "root-op", "OK"))       // root second
 	tb.Flush(time.Now().Add(time.Second))
@@ -91,4 +97,81 @@ type opCheckLookup struct{ check func(string) }
 func (l *opCheckLookup) Ratio(_ context.Context, _ int64, op string) int {
 	l.check(op)
 	return 1
+}
+
+// TestTraceBuffer_CapDropsNewTraces pins the memory bound: once maxSpans is
+// reached, spans for traces the buffer has not seen are dropped rather than
+// growing the map. Spans wait out the full TTL before any sampling decision, so
+// without this an ingest burst can OOM the reader pod.
+func TestTraceBuffer_CapDropsNewTraces(t *testing.T) {
+	tb := NewTraceBuffer(time.Hour, NewStaticRatioLookup(1), testLogger())
+	tb.maxSpans = 2
+
+	tb.Add(span("t1", "s1", "", "op", "OK"))
+	tb.Add(span("t2", "s1", "", "op", "OK"))
+	tb.Add(span("t3", "s1", "", "op", "OK")) // over cap — dropped
+
+	tb.mu.Lock()
+	held, dropped := len(tb.traces), tb.dropped
+	tb.mu.Unlock()
+
+	if held != 2 {
+		t.Fatalf("buffered traces = %d, want 2 (third should be dropped)", held)
+	}
+	if dropped != 1 {
+		t.Fatalf("dropped = %d, want 1", dropped)
+	}
+}
+
+// TestTraceBuffer_CapKeepsErrorTraces guards the contract that made removing the
+// self-instrument sampling bypass safe: error traces must survive even when the
+// buffer is over capacity.
+func TestTraceBuffer_CapKeepsErrorTraces(t *testing.T) {
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1000000), testLogger())
+	tb.maxSpans = 1
+
+	// First span creates the trace and marks it an error.
+	tb.Add(span("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "s1", "", "op", "ERROR"))
+	// Now at cap: a further span on the same error trace is still accepted...
+	tb.Add(span("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "s2", "s1", "db.query", "OK"))
+	// ...but a brand-new non-error trace is not.
+	tb.Add(span("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "s1", "", "op", "OK"))
+
+	tb.Flush(time.Now().Add(time.Second))
+
+	select {
+	case spans := <-tb.Out:
+		if len(spans) != 2 {
+			t.Fatalf("want 2 spans on the error trace, got %d", len(spans))
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("error trace was dropped at cap — the always-pass contract is broken")
+	}
+}
+
+// TestTraceBuffer_FlushReleasesCapBudget ensures the cap is not a one-way latch:
+// flushed traces must return their span budget, or the buffer wedges permanently
+// after the first burst.
+func TestTraceBuffer_FlushReleasesCapBudget(t *testing.T) {
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1), testLogger())
+	tb.maxSpans = 1
+
+	tb.Add(span("t1", "s1", "", "op", "OK"))
+	tb.Flush(time.Now().Add(time.Second))
+
+	tb.mu.Lock()
+	count := tb.spanCount
+	tb.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("spanCount after flush = %d, want 0", count)
+	}
+
+	// The buffer must accept work again.
+	tb.Add(span("t2", "s1", "", "op", "OK"))
+	tb.mu.Lock()
+	held, dropped := len(tb.traces), tb.dropped
+	tb.mu.Unlock()
+	if held != 1 || dropped != 0 {
+		t.Fatalf("after flush: traces=%d dropped=%d, want 1 and 0", held, dropped)
+	}
 }

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -65,7 +65,7 @@ type Config struct {
 	BoringRetentionMinutes    int           // minutes to keep sampled boring spans (default 30); 0 disables boring cleanup
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
-	MetricsRetentionDays      int           // days to keep raw metric data points (default 90)
+	MetricsRetentionDays      int           // days to keep raw metric data points (default 7). Raw points are only ever read for ranges <= rollupQueryThreshold (6h); longer ranges read metric_rollups, which have their own (much longer) window.
 	MetricRollupRetentionDays int           // days to keep downsampled metric rollups (default 365)
 	LogRetentionHours         int           // hours to keep log records (default 24)
 	ErrorLogRetentionDays     int           // days to keep logs for error-sampled traces (default 30)
@@ -94,7 +94,7 @@ func (c Config) withDefaults() Config {
 		c.AggregateRetentionDays = 365
 	}
 	if c.MetricsRetentionDays <= 0 {
-		c.MetricsRetentionDays = 90
+		c.MetricsRetentionDays = 7
 	}
 	if c.MetricRollupRetentionDays <= 0 {
 		c.MetricRollupRetentionDays = 365

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -506,3 +506,16 @@ func TestWithDefaultsInterestingRetentionHours(t *testing.T) {
 		t.Fatalf("explicit InterestingRetentionHours = %d, want 12", got)
 	}
 }
+
+// TestWithDefaultsMetricsRetentionDays pins the raw-metric window. Raw points are
+// only ever queried for ranges <= 6h (api.rollupQueryThreshold); anything longer
+// reads metric_rollups. The old 90-day default therefore retained GBs of raw
+// points no query could reach.
+func TestWithDefaultsMetricsRetentionDays(t *testing.T) {
+	if got := (Config{}).withDefaults().MetricsRetentionDays; got != 7 {
+		t.Fatalf("default MetricsRetentionDays = %d, want 7", got)
+	}
+	if got := (Config{MetricsRetentionDays: 30}).withDefaults().MetricsRetentionDays; got != 30 {
+		t.Fatalf("explicit MetricsRetentionDays = %d, want 30", got)
+	}
+}


### PR DESCRIPTION
## The bug

`ingest.sample_ratio.project.5 = 100` had no effect. Self-instrument spans bypassed the `TraceBuffer` entirely (`internal/api/otlp.go`), so the ratio was unenforceable for SpanBarn's own telemetry — by far the largest span producer. On production that was **89% of all spans** (6,751 of 7,565 over 12 min) still arriving *after* the ratio was set, and it is what filled the disk in the 2026-07-16 outage.

The bypass was deliberate — *"the pod's own traces must always reach the writer"* — but `keep()` already forces every error trace through regardless of ratio, so that intent survives. Only the boring bulk is dropped now.

## This removes the exception; it does not work around it

The sampler was never at fault. It's deterministic (`upper(traceID) % ratio == 0`), so `ratio=2` must yield only even trace IDs. Measured against live production:

| cohort | even | odd | reading |
|---|---|---|---|
| brandtrace (ratio=2), non-error | **242** | **0** | ratio honored exactly |
| brandtrace, incl. errors | 248 | 9 | the 9 odd are errors — `keep()` passes them by design |
| project 5 (self, ratio=100) | **3703** | **3702** | perfectly uniform → sampler never ran |

Every project the buffer reaches is sampled exactly as configured. Project 5's dead-even split is an untouched distribution. The settings lookup, ratio cache and reader wiring are all correct — the only reason the ratio wasn't applied was the `if selfExport` branch routing those spans around it. So the fix deletes that branch.

## Also here

**TraceBuffer cap** — required by the above, not a drive-by. Spans wait out the full 10m TTL *before* any sampling decision, so the map held TTL-worth of unsampled traffic and was **unbounded**. Self-telemetry volume scales with writer load, so it grew fastest exactly when the reader (512Mi, `GOMEMLIMIT: 448MiB`) was already under pressure — routing more traffic into it without a bound would have been pointing a feedback loop at an unbounded map. At the cap, new traces and further spans on non-error traces are dropped and counted (WARN); error traces keep accumulating so the always-pass contract holds. `Flush` returns span budget so the cap can't latch permanently.

**Raw metrics retention 90d → 7d** — raw points are only ever read for ranges ≤ 6h (`api.rollupQueryThreshold`); longer ranges read `metric_rollups`, which have their own window, and alerts read rollups too. The 90-day default retained GBs of raw points no query could reach. At production's rate this was heading for ~9.4M rows.

## Tests

The self-instrument tests **fail against the previous code** — verified, not assumed:
```
--- FAIL: TestSelfInstrumentSpansAreSampled
    self-instrument spans bypassed the sampler: 1 span(s) enqueued directly, want 0
--- FAIL: TestSelfInstrumentErrorSpansAlwaysPass
```
`TestNonSelfSpansStillSampled` passes on both old and new code — tenant traffic was always sampled, which independently confirms the diagnosis.

Also pins the retention defaults. None of them were pinned, which is how they drifted out of line with the disk unnoticed.

`go build ./...`, `go vet ./...`, `go test ./...` and `make quality-gate` all pass.

## Follow-ups (not here)

- **`retention_full_hours` is a dead setting** — assigned in `retention.go` / `runtime.go`, never read. Prod has it set to `72`, doing nothing, and the README advertises it as "Hours to keep all spans" — almost certainly where the 72 came from.
- **`runIngestMode` is legacy dead code** — no manifest sets `SPANBARN_MODE=ingest` (all use `reader`). Its missing `WithTraceBuffer` is real but unreachable.
- **`TraceBuffer.Out` silently drops kept traces** when its 256 buffer is full — including error traces.
- **`project_id=0` self-attribution** — currently empty, but `warnOrphanedIngest` exempts self spans, so a regression would be silent.