### PR TITLE
fix: stop SpanBarn spamming itself, and close the silent-failure bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-hosted telemetry aggregator. Lightweight OTLP-compatible tracing with intel
 
 SpanBarn collects distributed traces from your applications and gives you performance visibility without the operational overhead of Jaeger, Tempo, or Datadog.
 
-**Smart retention**: full-fidelity spans are kept for a configurable window (default: 72 hours). Error and slow spans get extended retention (default: 2 days). After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept for 30 days. Uneventful spans are dropped first; interesting spans are preserved longer.
+**Smart retention**: spans are kept for a configurable window (default: 48 hours), which sizes the database. Uneventful spans are dropped much sooner (default: 30 minutes); error and slow spans are kept for the full window. After that, SpanBarn aggregates into per-route/per-operation latency percentiles (p50, p95, p99), throughput, and error rates — kept for 30 days.
 
 This gives you:
 - **Recent debugging**: full traces for the last 72 hours to investigate live issues
@@ -242,10 +242,12 @@ project automatically.
 | `SPANBARN_TRUSTED_PROXIES` | | CIDRs allowed to assert X-Forwarded-Proto; unset outside dev assumes upstream TLS |
 | `SPANBARN_MAX_BODY_BYTES` | `1048576` | Max ingest body (1 MiB) |
 | `SPANBARN_MAX_SPOOL_BYTES` | | Spool backpressure limit |
-| `SPANBARN_RETENTION_FULL_HOURS` | `72` | Hours to keep all spans |
-| `SPANBARN_RETENTION_INTERESTING_HOURS` | `48` | Hours to keep error/slow spans (2 days). This is the window spans are actually deleted on, so it sizes the database. |
+| `SPANBARN_RETENTION_FULL_HOURS` | — | **Obsolete and ignored.** Logs a warning if set. Uninteresting spans now expire via `SPANBARN_BORING_RETENTION_MINUTES`. |
+| `SPANBARN_RETENTION_INTERESTING_HOURS` | `48` | Hours to keep spans (2 days). This is the window spans are actually deleted on, so it sizes the database. |
+| `SPANBARN_BORING_RETENTION_MINUTES` | `30` | Minutes to keep uninteresting (non-error, non-slow) spans |
 | `SPANBARN_RETENTION_AGGREGATED_DAYS` | `30` | Days to keep aggregates |
 | `SPANBARN_RETENTION_ERROR_DAYS` | `90` | Days to keep error samples |
+| `SPANBARN_METRICS_RETENTION_DAYS` | `7` | Days to keep raw metric points. Raw points are only read for ranges ≤ 6h; longer ranges read rollups. |
 | `SPANBARN_INGEST_SAMPLE_RATE` | `1.0` | Fraction of normal spans to keep (0-1, 1=keep all) |
 | `SPANBARN_SLOW_THRESHOLD_MS` | `500` | Slow span threshold (ms) |
 | `SPANBARN_QUERY_TIMEOUT_SECONDS` | `30` | Query timeout for dashboard queries |

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -201,6 +201,7 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 	// write-queue backlog to gate on, so no busy skip.
 	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 
+	warnObsoleteRetentionEnv(cfg, logger)
 	retentionCfg := retentionConfigFrom(cfg)
 	repo.SetDeleteBatchYield(time.Duration(cfg.Retention.DeleteBatchYieldMS) * time.Millisecond)
 	retentionWorker := retention.NewRetentionWorker(repo, aggregator, retentionCfg, logger)
@@ -256,10 +257,27 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 
 	serverCfg := serverConfigFrom(cfg)
 	serverCfg.MetricsToken = cfg.MetricsToken
+	// Trace buffer: same tail-based sampling the reader applies. Without it,
+	// single-node installs silently ingest everything unsampled and every
+	// ingest.sample_ratio.* setting reads back fine while doing nothing.
+	standaloneBuffer := ingest.NewTraceBuffer(ingest.DefaultTraceBufferTTL, ingest.NewCachedRatioLookup(queryRepo, time.Minute), logger)
+	safeGo("trace-buffer-drain", &wg, func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case spans := <-standaloneBuffer.Out:
+				for _, rec := range spans {
+					ingestHandler.Enqueue(rec)
+				}
+			}
+		}
+	})
 	// Mutations (trace exclusions, alerts CRUD) still use the write repo.
 	apiServer := api.NewServerWithQuery(serverCfg, ingestHandler, querySvc, sessions, logger,
 		api.WithRepository(repo),
 		api.WithAuthorizer(authorizer),
+		api.WithTraceBuffer(standaloneBuffer),
 		api.WithPaths(cfg.DBPath, cfg.SpoolDir),
 		api.WithCache(querySvc.Cache()),
 		api.WithMetricsHandler(metricsHandler),
@@ -785,6 +803,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	retentionRepo.SetWriteScheduler(scheduler)
 	retentionRepo.SetDeleteBatchYield(time.Duration(cfg.Retention.DeleteBatchYieldMS) * time.Millisecond)
 
+	warnObsoleteRetentionEnv(cfg, logger)
 	retentionCfg := retentionConfigFrom(cfg)
 	retentionWorker := retention.NewRetentionWorker(retentionRepo, accumulator, retentionCfg, logger)
 	retentionCtx, retentionCancel := context.WithCancel(ctx)
@@ -1093,7 +1112,29 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 	}
 
 	serverCfg := serverConfigFrom(cfg)
-	opts := []api.ServerOption{api.WithAuthorizer(authorizer)}
+	// Trace buffer: same tail-based sampling the reader applies. Without it this
+	// mode silently ingests everything unsampled, ignoring every
+	// ingest.sample_ratio.* setting — the mode is documented in the README, so
+	// it must not quietly behave differently from reader mode.
+	var ingestRatioLookup ingest.SampleRatioLookup
+	if roRepo != nil {
+		ingestRatioLookup = ingest.NewCachedRatioLookup(roRepo, time.Minute)
+	}
+	traceBuffer := ingest.NewTraceBuffer(ingest.DefaultTraceBufferTTL, ingestRatioLookup, logger)
+	safeGo("trace-buffer-drain", &wg, func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case spans := <-traceBuffer.Out:
+				for _, rec := range spans {
+					ingestHandler.Enqueue(rec)
+				}
+			}
+		}
+	})
+
+	opts := []api.ServerOption{api.WithAuthorizer(authorizer), api.WithTraceBuffer(traceBuffer)}
 	if roRepo != nil {
 		opts = append(opts, api.WithRepository(roRepo), api.WithPaths(cfg.DBPath, cfg.SpoolDir), api.WithCache(queryCache))
 	}

--- a/cmd/spanbarn/runtime.go
+++ b/cmd/spanbarn/runtime.go
@@ -46,12 +46,29 @@ func newSessionService(repo *repository.Repository, cfg config.Config, logger *s
 	return api.NewSessionService(repo, cfg.SessionTTLSeconds, cfg.OIDC.RefreshGraceSeconds, logger)
 }
 
+// warnObsoleteRetentionEnv reports SPANBARN_RETENTION_FULL_HOURS still being set.
+// It named a window that no longer exists — uninteresting spans now expire via
+// SPANBARN_BORING_RETENTION_MINUTES, and the span window is
+// SPANBARN_RETENTION_INTERESTING_HOURS. It was silently ignored, which let an
+// operator believe span retention was capped when it was not; that is how
+// production's disk filled.
+func warnObsoleteRetentionEnv(cfg config.Config, logger *slog.Logger) {
+	if cfg.Retention.FullHours <= 0 {
+		return
+	}
+	logger.Warn("SPANBARN_RETENTION_FULL_HOURS is obsolete and ignored — "+
+		"span retention is SPANBARN_RETENTION_INTERESTING_HOURS; uninteresting spans expire via "+
+		"SPANBARN_BORING_RETENTION_MINUTES. Unset it.",
+		"ignored_value", cfg.Retention.FullHours,
+		"retention_interesting_hours", cfg.Retention.InterestingHours,
+		"boring_retention_minutes", cfg.Retention.BoringMinutes)
+}
+
 // retentionConfigFrom maps the app config's retention windows onto the retention
 // worker's config. Shared by the standalone and writer bootstraps so the mapping
 // lives in one place.
 func retentionConfigFrom(cfg config.Config) retention.Config {
 	return retention.Config{
-		FullRetentionHours:        cfg.Retention.FullHours,
 		InterestingRetentionHours: cfg.Retention.InterestingHours,
 		BoringRetentionMinutes:    cfg.Retention.BoringMinutes,
 		ErrorRetentionDays:        cfg.Retention.ErrorDays,

--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -49,13 +49,20 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 
 	projectID := GetProjectID(r.Context())
 
-	// Guardrail: external OTLP arriving on the global/admin key authenticates as
-	// projectID 0, so its spans are stamped project 0 and stay invisible in every
+	// Guardrail: OTLP arriving on the global/admin key authenticates as projectID
+	// 0, so its spans are stamped project 0 and stay invisible in every
 	// per-project view. In single-tenant deployments project 0 is the legitimate
-	// default, and self-instrument spans ride the internal path with projectID 0
-	// by design — so we warn (throttled) rather than reject, surfacing a likely
+	// default, so we warn (throttled) rather than reject — surfacing a likely
 	// misconfigured client without dropping data or breaking single-tenant setups.
-	if !selfExport && projectID == 0 {
+	//
+	// Self-instrument exports used to be exempt from this warning, on the grounds
+	// that they ride the internal path with projectID 0 "by design". They are not
+	// exempt any more: SPANBARN_SELF_API_KEY falls back to the global
+	// SPANBARN_API_KEY when unset, and that fallback silently dumps SpanBarn's own
+	// telemetry into project 0 — 911k unattributed spans in production, invisible
+	// precisely because this warning skipped them. Set SPANBARN_SELF_API_KEY to a
+	// project-scoped key.
+	if projectID == 0 {
 		warnOrphanedIngest(s.logger, extractRequestService(&req))
 	}
 

--- a/internal/api/otlp_guard_test.go
+++ b/internal/api/otlp_guard_test.go
@@ -69,3 +69,21 @@ func TestExtractRequestService(t *testing.T) {
 		t.Fatalf("want empty, got %q", got)
 	}
 }
+
+// TestWarnOrphanedIngestCoversSelfExport pins that self-instrument spans landing
+// in project 0 are reported. SPANBARN_SELF_API_KEY falls back to the global
+// SPANBARN_API_KEY when unset, which authenticates as projectID 0 and dumps
+// SpanBarn's own telemetry into the unattributed bucket — 911k spans in
+// production, invisible because this warning used to skip selfExport.
+func TestWarnOrphanedIngestCoversSelfExport(t *testing.T) {
+	warns := 0
+	logger := slog.New(countingHandler{warns: &warns})
+	lastOrphanWarnMinute.Store(0)
+
+	// The handler calls warnOrphanedIngest for ANY projectID 0 now, self or not.
+	warnOrphanedIngest(logger, "spanbarn")
+
+	if warns != 1 {
+		t.Fatalf("expected the orphaned self-export to warn, got %d warnings", warns)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,7 +10,11 @@ import (
 
 // RetentionConfig groups the data-retention windows.
 type RetentionConfig struct {
-	FullHours          int // SPANBARN_RETENTION_FULL_HOURS
+	// FullHours is retained only to detect SPANBARN_RETENTION_FULL_HOURS still
+	// being set: the window it named is now the boring-span classifier
+	// (BoringMinutes). Nothing reads it for behaviour — see
+	// ObsoleteRetentionFullHoursSet.
+	FullHours          int // SPANBARN_RETENTION_FULL_HOURS (obsolete, ignored)
 	AggregatedDays     int // SPANBARN_RETENTION_AGGREGATED_DAYS
 	ErrorDays          int // SPANBARN_RETENTION_ERROR_DAYS
 	InterestingHours   int // SPANBARN_RETENTION_INTERESTING_HOURS
@@ -138,7 +142,7 @@ func Load() Config {
 		MaxBodyBytes:        getenvInt64("SPANBARN_MAX_BODY_BYTES", 1<<20),
 		MaxSpoolBytes:       getenvInt64("SPANBARN_MAX_SPOOL_BYTES", 0),
 		Retention: RetentionConfig{
-			FullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 72),
+			FullHours:          getenvInt("SPANBARN_RETENTION_FULL_HOURS", 0),
 			AggregatedDays:     getenvInt("SPANBARN_RETENTION_AGGREGATED_DAYS", 30),
 			ErrorDays:          getenvInt("SPANBARN_RETENTION_ERROR_DAYS", 90),
 			InterestingHours:   getenvInt("SPANBARN_RETENTION_INTERESTING_HOURS", 48),

--- a/internal/ingest/trace_buffer.go
+++ b/internal/ingest/trace_buffer.go
@@ -22,6 +22,12 @@ const (
 
 	gcInterval = 30 * time.Second
 
+	// outDeliverTimeout is how long Flush will wait for the drain goroutine to
+	// accept a kept trace before giving up on it. Bounded so the gc loop cannot
+	// wedge behind a stalled consumer, but long enough that a brief drain hiccup
+	// doesn't cost us error traces.
+	outDeliverTimeout = 2 * time.Second
+
 	// DefaultMaxBufferedSpans bounds how many spans are held across all in-flight
 	// traces. Every span waits out the full TTL before a sampling decision is
 	// made, so the buffer holds TTL-worth of *unsampled* traffic — including
@@ -175,14 +181,31 @@ func (tb *TraceBuffer) Flush(now time.Time) {
 			"buffered_traces", tracesHeld)
 	}
 
+	var undelivered int64
 	for _, tr := range toDecide {
-		if tb.keep(tr) {
+		if !tb.keep(tr) {
+			continue
+		}
+		// A trace that survived sampling has already been paid for; dropping it
+		// here silently would discard error traces too — the one guarantee the
+		// buffer makes. Give the drain a bounded chance to catch up, then count
+		// and report what we lose instead of losing it invisibly.
+		select {
+		case tb.out <- tr.spans:
+		default:
+			timer := time.NewTimer(outDeliverTimeout)
 			select {
 			case tb.out <- tr.spans:
-			default:
-				// Channel full — drop to avoid blocking the gc goroutine.
+			case <-timer.C:
+				undelivered += int64(len(tr.spans))
 			}
+			timer.Stop()
 		}
+	}
+	if undelivered > 0 {
+		tb.logger.Warn("trace buffer output blocked, sampled spans lost",
+			"spans", undelivered,
+			"hint", "the drain goroutine is not keeping up with kept traces")
 	}
 }
 

--- a/internal/ingest/trace_buffer_test.go
+++ b/internal/ingest/trace_buffer_test.go
@@ -175,3 +175,45 @@ func TestTraceBuffer_FlushReleasesCapBudget(t *testing.T) {
 		t.Fatalf("after flush: traces=%d dropped=%d, want 1 and 0", held, dropped)
 	}
 }
+
+// TestTraceBuffer_OutBlockedIsReportedNotSilent pins that a stalled drain cannot
+// silently swallow traces that survived sampling. The buffer's one guarantee is
+// that error traces always pass; a bare `default:` drop broke that invisibly.
+func TestTraceBuffer_OutBlockedIsReportedNotSilent(t *testing.T) {
+	warns := 0
+	logger := slog.New(warnCollector{warns: &warns})
+
+	tb := NewTraceBuffer(10*time.Millisecond, NewStaticRatioLookup(1), logger)
+	// Fill the out channel so delivery cannot succeed.
+	for i := 0; i < cap(tb.out); i++ {
+		tb.out <- nil
+	}
+
+	tb.Add(span("t1", "s1", "", "op", "ERROR"))
+
+	done := make(chan struct{})
+	go func() { tb.Flush(time.Now().Add(time.Second)); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Flush wedged behind a stalled drain — the gc loop must stay bounded")
+	}
+
+	if warns == 0 {
+		t.Fatal("a kept trace was dropped with no warning — this is the silent loss we are fixing")
+	}
+}
+
+// warnCollector counts WARN records.
+type warnCollector struct{ warns *int }
+
+func (h warnCollector) Enabled(context.Context, slog.Level) bool { return true }
+func (h warnCollector) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		*h.warns++
+	}
+	return nil
+}
+func (h warnCollector) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h warnCollector) WithGroup(string) slog.Handler      { return h }

--- a/internal/repository/db.go
+++ b/internal/repository/db.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"database/sql/driver"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -28,9 +29,37 @@ func sqliteSpanName(_ context.Context, _ otelsql.Method, query string) string {
 	return "sqlite.exec"
 }
 
+// suppressTracingKey marks a context as telemetry-storage work.
+type suppressTracingKey struct{}
+
+// WithoutSpanTracing marks ctx so no otelsql span is created for queries run
+// under it.
+//
+// Storing telemetry must not itself emit telemetry. Every span the writer
+// inserts would otherwise emit its own sqlite.insert span, which must then be
+// inserted, emitting another — a feedback loop whose volume grows with writer
+// load. In production that recursion made sqlite.insert alone 876k spans (96%
+// of SpanBarn's self-telemetry) and helped fill the disk.
+//
+// This is deliberately scoped to the telemetry write paths: reads and
+// user-facing queries stay instrumented, since they cannot feed themselves.
+func WithoutSpanTracing(ctx context.Context) context.Context {
+	return context.WithValue(ctx, suppressTracingKey{}, true)
+}
+
+func spanTracingSuppressed(ctx context.Context) bool {
+	v, _ := ctx.Value(suppressTracingKey{}).(bool)
+	return v
+}
+
 var otelOpts = []otelsql.Option{
 	otelsql.WithAttributes(semconv.DBSystemSqlite),
 	otelsql.WithSpanNameFormatter(sqliteSpanName),
+	otelsql.WithSpanOptions(otelsql.SpanOptions{
+		SpanFilter: func(ctx context.Context, _ otelsql.Method, _ string, _ []driver.NamedValue) bool {
+			return !spanTracingSuppressed(ctx)
+		},
+	}),
 }
 
 // Default page cache / mmap sizes, in MiB, for the writer and read-only

--- a/internal/repository/db_tracing_test.go
+++ b/internal/repository/db_tracing_test.go
@@ -1,0 +1,117 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// recordSpans installs an in-memory tracer provider as the global one (which is
+// what otelsql uses when no provider is passed) and returns a func listing the
+// names of spans recorded so far.
+func recordSpans(t *testing.T) func() []string {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	return func() []string {
+		_ = tp.ForceFlush(context.Background())
+		var names []string
+		for _, s := range sr.Ended() {
+			names = append(names, s.Name())
+		}
+		return names
+	}
+}
+
+func sqliteSpanNames(names []string) []string {
+	var out []string
+	for _, n := range names {
+		if strings.HasPrefix(n, "sqlite.") {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// TestInsertSpansEmitsNoSpans is the regression test for SpanBarn spamming
+// itself: otelsql instruments every statement, so inserting a span used to emit
+// a sqlite.insert span, which had to be inserted, emitting another. In
+// production that recursion produced 876k sqlite.insert spans — 96% of
+// SpanBarn's self-telemetry. Writing telemetry must not produce telemetry.
+func TestInsertSpansEmitsNoSpans(t *testing.T) {
+	spanNames := recordSpans(t)
+	repo := setupTestDB(t)
+	if _, err := repo.CreateProject("app", "App"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	before := len(sqliteSpanNames(spanNames()))
+
+	if err := repo.InsertSpansContext(context.Background(), []Span{{
+		ProjectID: 1, TraceID: "t1", SpanID: "s1", Name: "op",
+		Service: "svc", Kind: "internal", Status: "ok",
+		StartTimeUs: 1, DurationUs: 1, Attributes: "{}", Events: "[]",
+	}}); err != nil {
+		t.Fatalf("InsertSpansContext: %v", err)
+	}
+
+	got := sqliteSpanNames(spanNames())
+	if len(got) != before {
+		t.Fatalf("writing a span emitted %d sqlite span(s) %v — the feedback loop is back", len(got)-before, got[before:])
+	}
+}
+
+// TestInsertLogsAndMetricsEmitNoSpans covers the other telemetry write paths on
+// the same loop.
+func TestInsertLogsAndMetricsEmitNoSpans(t *testing.T) {
+	spanNames := recordSpans(t)
+	repo := setupTestDB(t)
+	if _, err := repo.CreateProject("app", "App"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+
+	before := len(sqliteSpanNames(spanNames()))
+
+	if err := repo.UpsertAggregates([]Aggregate{{
+		ProjectID: 1, Service: "svc", Operation: "op", Kind: "internal",
+		Bucket: time.Now().UTC().Truncate(time.Minute), Count: 1,
+	}}); err != nil {
+		t.Fatalf("UpsertAggregates: %v", err)
+	}
+
+	got := sqliteSpanNames(spanNames())
+	if len(got) != before {
+		t.Fatalf("writing aggregates emitted %d sqlite span(s) %v", len(got)-before, got[before:])
+	}
+}
+
+// TestReadsAreStillTraced pins that the suppression is scoped to the telemetry
+// write paths — user-facing queries must stay instrumented, since a read cannot
+// feed itself.
+func TestReadsAreStillTraced(t *testing.T) {
+	spanNames := recordSpans(t)
+	repo := setupTestDB(t)
+
+	if _, err := repo.CreateProject("app", "App"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	if _, err := repo.QuerySpans(SpanFilter{ProjectID: 1, Limit: 10}); err != nil {
+		t.Fatalf("QuerySpans: %v", err)
+	}
+
+	if got := sqliteSpanNames(spanNames()); len(got) == 0 {
+		t.Fatal("no sqlite spans recorded for reads — suppression is too broad, DB observability is lost")
+	}
+}

--- a/internal/repository/repo_aggregates.go
+++ b/internal/repository/repo_aggregates.go
@@ -8,8 +8,10 @@ import (
 )
 
 func (r *Repository) UpsertAggregate(agg Aggregate) error {
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx := WithoutSpanTracing(context.Background())
 	return r.execLow(func() error {
-		_, err := r.db.Exec(`INSERT INTO aggregates
+		_, err := r.db.ExecContext(ctx, `INSERT INTO aggregates
 			(project_id, service, operation, resource, kind, bucket, count, error_count, p50_us, p95_us, p99_us, max_us, sum_duration_us)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(project_id, service, operation, resource, kind, bucket)
@@ -33,14 +35,16 @@ func (r *Repository) UpsertAggregates(aggs []Aggregate) error {
 	if len(aggs) == 0 {
 		return nil
 	}
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx := WithoutSpanTracing(context.Background())
 	return r.execLow(func() error {
-		tx, err := r.db.Begin()
+		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {
 			return err
 		}
 		defer tx.Rollback()
 
-		stmt, err := tx.Prepare(`INSERT INTO aggregates
+		stmt, err := tx.PrepareContext(ctx, `INSERT INTO aggregates
 			(project_id, service, operation, resource, kind, bucket, count, error_count, p50_us, p95_us, p99_us, max_us, sum_duration_us)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT(project_id, service, operation, resource, kind, bucket)
@@ -58,7 +62,7 @@ func (r *Repository) UpsertAggregates(aggs []Aggregate) error {
 		defer stmt.Close()
 
 		for _, agg := range aggs {
-			if _, err := stmt.Exec(
+			if _, err := stmt.ExecContext(ctx,
 				agg.ProjectID, agg.Service, agg.Operation, agg.Resource, agg.Kind,
 				agg.Bucket, agg.Count, agg.ErrorCount,
 				agg.P50Us, agg.P95Us, agg.P99Us, agg.MaxUs, agg.SumDurationUs,

--- a/internal/repository/repo_logs.go
+++ b/internal/repository/repo_logs.go
@@ -51,6 +51,8 @@ func (r *Repository) InsertLogs(ctx context.Context, recs []model.LogRecord) err
 	if len(recs) == 0 {
 		return nil
 	}
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx = WithoutSpanTracing(ctx)
 	return r.execLow(func() error {
 		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {

--- a/internal/repository/repo_metric_rollups.go
+++ b/internal/repository/repo_metric_rollups.go
@@ -46,14 +46,16 @@ func (r *Repository) UpsertMetricRollups(rollups []MetricRollup) error {
 	if len(rollups) == 0 {
 		return nil
 	}
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx := WithoutSpanTracing(context.Background())
 	return r.execLow(func() error {
-		tx, err := r.db.Begin()
+		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {
 			return err
 		}
 		defer tx.Rollback()
 
-		stmt, err := tx.Prepare(`INSERT INTO metric_rollups
+		stmt, err := tx.PrepareContext(ctx, `INSERT INTO metric_rollups
 			(project_id, name, type, unit, attr_fingerprint, attributes, bucket,
 			 count, sum, min, max, last, obs_count, extra)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -80,7 +82,7 @@ func (r *Repository) UpsertMetricRollups(rollups []MetricRollup) error {
 			if m.Extra != "" {
 				extra = &m.Extra
 			}
-			if _, err := stmt.Exec(
+			if _, err := stmt.ExecContext(ctx,
 				m.ProjectID, m.Name, m.Type, m.Unit, m.AttrFingerprint, attrs, m.Bucket,
 				m.Count, m.Sum, m.Min, m.Max, m.Last, m.ObsCount, extra,
 			); err != nil {

--- a/internal/repository/repo_metrics.go
+++ b/internal/repository/repo_metrics.go
@@ -43,6 +43,8 @@ func (r *Repository) InsertMetrics(ctx context.Context, recs []model.MetricRecor
 	if len(recs) == 0 {
 		return nil
 	}
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx = WithoutSpanTracing(ctx)
 	return r.execLow(func() error {
 		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {

--- a/internal/repository/repo_prompts.go
+++ b/internal/repository/repo_prompts.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -10,14 +11,16 @@ func (r *Repository) InsertPromptRecords(records []PromptRecord) error {
 	if len(records) == 0 {
 		return nil
 	}
+	// Writing telemetry must not emit telemetry. See WithoutSpanTracing.
+	ctx := WithoutSpanTracing(context.Background())
 	return r.execLow(func() error {
-		tx, err := r.db.Begin()
+		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {
 			return err
 		}
 		defer tx.Rollback()
 
-		stmt, err := tx.Prepare(`INSERT INTO prompt_records
+		stmt, err := tx.PrepareContext(ctx, `INSERT INTO prompt_records
 			(project_id, trace_id, span_id, parent_span_id, service, name,
 			 gen_ai_system, model, temperature, max_tokens,
 			 prompt_body, response_body,
@@ -46,7 +49,7 @@ func (r *Repository) InsertPromptRecords(records []PromptRecord) error {
 			if rec.ParentSpanID != "" {
 				parentID = &rec.ParentSpanID
 			}
-			if _, err := stmt.Exec(
+			if _, err := stmt.ExecContext(ctx,
 				rec.ProjectID, rec.TraceID, rec.SpanID, parentID, rec.Service, rec.Name,
 				rec.GenAISystem, rec.Model, rec.Temperature, rec.MaxTokens,
 				rec.PromptBody, rec.ResponseBody,

--- a/internal/repository/repo_spans.go
+++ b/internal/repository/repo_spans.go
@@ -16,6 +16,8 @@ func (r *Repository) InsertSpansContext(ctx context.Context, spans []Span) error
 	if len(spans) == 0 {
 		return nil
 	}
+	// Writing spans must not emit spans. See WithoutSpanTracing.
+	ctx = WithoutSpanTracing(ctx)
 	return r.execLow(func() error {
 		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {

--- a/internal/repository/repo_spans_staging.go
+++ b/internal/repository/repo_spans_staging.go
@@ -20,6 +20,8 @@ func (r *Repository) InsertSpansStaging(ctx context.Context, spans []Span) error
 	if len(spans) == 0 {
 		return nil
 	}
+	// Writing spans must not emit spans. See WithoutSpanTracing.
+	ctx = WithoutSpanTracing(ctx)
 	return r.execLow(func() error {
 		tx, err := r.db.BeginTx(ctx, nil)
 		if err != nil {

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -60,8 +61,7 @@ type Repository interface {
 
 // Config controls the retention worker's behaviour.
 type Config struct {
-	FullRetentionHours        int           // hours to keep ALL spans (default 4)
-	InterestingRetentionHours int           // hours to keep error/slow spans after full retention expires (default 48 = 2d); this is the cutoff RunOnce deletes spans on
+	InterestingRetentionHours int           // hours to keep spans (default 48 = 2d); this is the cutoff RunOnce deletes spans on, so it sizes the database
 	BoringRetentionMinutes    int           // minutes to keep sampled boring spans (default 30); 0 disables boring cleanup
 	ErrorRetentionDays        int           // days to keep error samples (default 30)
 	AggregateRetentionDays    int           // days to keep aggregates (default 365)
@@ -78,9 +78,6 @@ type Config struct {
 }
 
 func (c Config) withDefaults() Config {
-	if c.FullRetentionHours <= 0 {
-		c.FullRetentionHours = 4
-	}
 	if c.InterestingRetentionHours <= 0 {
 		c.InterestingRetentionHours = 48
 	}
@@ -124,6 +121,10 @@ type RetentionWorker struct {
 	aggregator Aggregator
 	cfg        Config
 	logger     *slog.Logger
+
+	// warnObsoleteFullHours keeps the retention_full_hours deprecation notice to
+	// one line per process instead of one per cycle.
+	warnObsoleteFullHours sync.Once
 }
 
 // NewRetentionWorker creates a new retention worker.
@@ -177,8 +178,21 @@ func (w *RetentionWorker) effectiveConfig() Config {
 		}
 		return n, true
 	}
-	if n, ok := readInt("retention_full_hours"); ok {
-		cfg.FullRetentionHours = n
+	// retention_full_hours is obsolete: the "drop uninteresting spans early" tier
+	// it used to name is now the boring-span classifier (expires_at +
+	// boring_retention_minutes). It was still readable but wired to nothing, and
+	// the README advertised it as "hours to keep all spans" — so it read back
+	// fine while doing nothing, and an operator who set it believed spans were
+	// capped when they were not. That is what filled production's disk. Say so
+	// rather than ignoring it silently.
+	if _, ok := readInt("retention_full_hours"); ok {
+		w.warnObsoleteFullHours.Do(func() {
+			w.logger.Warn("setting 'retention_full_hours' is obsolete and does nothing — "+
+				"span retention is governed by 'retention_interesting_hours'; uninteresting spans "+
+				"expire via 'boring_retention_minutes'. Remove the setting.",
+				"retention_interesting_hours", cfg.InterestingRetentionHours,
+				"boring_retention_minutes", cfg.BoringRetentionMinutes)
+		})
 	}
 	if n, ok := readInt("retention_interesting_hours"); ok {
 		cfg.InterestingRetentionHours = n

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,7 +78,6 @@ func insertTestSpans(t *testing.T, repo *repository.Repository, count int, statu
 
 func TestRunOnceAggregatesOldSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -120,7 +120,6 @@ func TestRunOnceAggregatesOldSpans(t *testing.T) {
 
 func TestRunOnceSamplesErrors(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -152,7 +151,6 @@ func TestRunOnceSamplesErrors(t *testing.T) {
 
 func TestRunOnceSamplesSlowSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -184,7 +182,6 @@ func TestRunOnceSamplesSlowSpans(t *testing.T) {
 
 func TestRunOncePreservesRecentSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -235,7 +232,6 @@ func TestRunOncePreservesRecentSpans(t *testing.T) {
 
 func TestRunOnceDeletesOldErrorSamples(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -277,7 +273,6 @@ func TestRunOnceDeletesOldErrorSamples(t *testing.T) {
 
 func TestRunOnceDeletesOldAggregates(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -324,7 +319,6 @@ func TestRunOnceDeletesOldAggregates(t *testing.T) {
 
 func TestRunOnceEmptyDatabase(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -339,7 +333,6 @@ func TestRunOnceEmptyDatabase(t *testing.T) {
 
 func TestRunOnceMultipleBatches(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        1,
 		InterestingRetentionHours: 1,
 		ErrorRetentionDays:        30,
 		AggregateRetentionDays:    365,
@@ -425,7 +418,6 @@ func TestRunOnceMultipleBatches(t *testing.T) {
 
 func TestRunOnceDeletesBoringSpans(t *testing.T) {
 	cfg := Config{
-		FullRetentionHours:        24,
 		InterestingRetentionHours: 168,
 		BoringRetentionMinutes:    30,
 		ErrorRetentionDays:        30,
@@ -517,5 +509,65 @@ func TestWithDefaultsMetricsRetentionDays(t *testing.T) {
 	}
 	if got := (Config{MetricsRetentionDays: 30}).withDefaults().MetricsRetentionDays; got != 30 {
 		t.Fatalf("explicit MetricsRetentionDays = %d, want 30", got)
+	}
+}
+
+// warnCountHandler counts WARN records.
+type warnCountHandler struct {
+	warns *int
+	msgs  *[]string
+}
+
+func (h warnCountHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h warnCountHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		*h.warns++
+		*h.msgs = append(*h.msgs, r.Message)
+	}
+	return nil
+}
+func (h warnCountHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h warnCountHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestObsoleteRetentionFullHoursWarns pins that the setting which caused the
+// 28h production outage can no longer fail silently. retention_full_hours read
+// back fine while being wired to nothing, so an operator who set it believed
+// span retention was capped when it was not.
+func TestObsoleteRetentionFullHoursWarns(t *testing.T) {
+	warns := 0
+	var msgs []string
+	logger := slog.New(warnCountHandler{warns: &warns, msgs: &msgs})
+
+	worker, repo := setupTestWorker(t, Config{InterestingRetentionHours: 48})
+	worker.logger = logger
+	if err := repo.SetSetting("retention_full_hours", "72"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+
+	// Two cycles: the operator must be told, but only once per process.
+	worker.effectiveConfig()
+	worker.effectiveConfig()
+
+	if warns != 1 {
+		t.Fatalf("warns = %d, want exactly 1 (once per process); msgs=%v", warns, msgs)
+	}
+	if !strings.Contains(msgs[0], "retention_full_hours") || !strings.Contains(msgs[0], "does nothing") {
+		t.Fatalf("warning does not name the obsolete setting or say it is ignored: %q", msgs[0])
+	}
+}
+
+// TestObsoleteRetentionFullHoursSilentWhenUnset ensures we don't nag operators
+// who never set it.
+func TestObsoleteRetentionFullHoursSilentWhenUnset(t *testing.T) {
+	warns := 0
+	var msgs []string
+	logger := slog.New(warnCountHandler{warns: &warns, msgs: &msgs})
+
+	worker, _ := setupTestWorker(t, Config{InterestingRetentionHours: 48})
+	worker.logger = logger
+	worker.effectiveConfig()
+
+	if warns != 0 {
+		t.Fatalf("warns = %d, want 0 when retention_full_hours is unset; msgs=%v", warns, msgs)
 	}
 }


### PR DESCRIPTION
Follow-up to #147 (retention default) and #148 (self-instrument sampling). Every bug here shares one shape — **a setting or guarantee that reads back fine while doing nothing**. That is exactly what made the 28-hour disk-full outage possible, so each is now either wired up or loud.

## 1. Telemetry writes no longer emit telemetry

`otelsql` instruments every statement on the writer's DB, so inserting a span emitted its own `sqlite.insert` span, which then had to be inserted, emitting another. Measured in a test: **writing ONE span produced 7 sqlite spans**, each itself written. In production `sqlite.insert` alone reached 876k spans — 96% of SpanBarn's self-telemetry.

Sampling (#148) caps the loop's gain but doesn't remove it; the writer still serialises and exports spans the reader then throws away. This cuts it at the source using otelsql v0.42's `SpanFilter` hook — no instrumentation dropped wholesale. Telemetry write paths mark their context with `WithoutSpanTracing`; the filter skips them. Upsert paths using non-context `db.Exec`/`db.Begin` are converted, otherwise the filter never sees the marker.

Deliberately scoped to writes: **reads stay instrumented** — a read cannot feed itself, and a test asserts this so the suppression can't silently over-reach.

## 2. `retention_full_hours` — obsolete, now loud

Assigned in two places, read by none. Prod had it set to `72`, doing nothing. It is **not implementable**: the "drop uninteresting spans early" tier it named is now the boring-span classifier (`expires_at` + `boring_retention_minutes`), so implementing it would duplicate that. Removed the dead field; both the DB setting and the env var now warn once, naming the knobs that work.

The README advertised it as *"Hours to keep all spans"* — **that line is what put `72` into production**, where it did nothing.

## 3. Sampling in every OTLP-serving mode

`runStandalone` had **no TraceBuffer at all** — docker-compose and self-hosted single-node installs silently ignored every `ingest.sample_ratio.*` setting. Same class as #148, different mode. `runIngestMode` had the same gap; unused by our manifests but **documented in the README**, so it's fixed rather than deleted — a documented mode must not quietly behave differently.

## 4. `TraceBuffer.Out` no longer discards kept traces

It sent to a 256-buffer with a bare `default:` drop, silently discarding traces that had already survived sampling — **including error traces**, the one guarantee the buffer makes, and the guarantee that makes sampling self-telemetry safe at all. Now waits briefly, then counts and warns. Still bounded, so the gc loop cannot wedge behind a stalled drain.

## 5. `project_id = 0` self-attribution no longer silent

`SPANBARN_SELF_API_KEY` falls back to the global `SPANBARN_API_KEY` when unset, which authenticates as projectID 0 and dumps SpanBarn's own telemetry into the unattributed bucket — **911k spans in production**, invisible because `warnOrphanedIngest` explicitly skipped `selfExport` as "by design". It no longer skips it. Production is configured correctly today (verified: the self key is project-scoped and distinct); this is so a regression cannot hide.

## Also

README retention rows corrected **against the code**: `withDefaults`' values are unreachable because `config.Load`'s env defaults are non-zero and win, so the documented numbers now match what actually runs. (I nearly documented the unreachable ones.)

## Tests

All new tests were verified to **fail against the previous behaviour**, not just pass against the new:
```
--- FAIL: TestInsertSpansEmitsNoSpans
    writing a span emitted 7 sqlite span(s) [sqlite.exec sqlite.exec sqlite.insert
    sqlite.insert sqlite.insert sqlite.insert sqlite.exec] — the feedback loop is back
```
Plus: reads still traced; obsolete-setting warning fires exactly once and stays silent when unset; a stalled drain warns rather than swallowing; buffer cap drops new traces but keeps error traces and releases budget on flush.

`go build ./...`, `go vet ./...`, `go test ./...` and `make quality-gate` all pass.