### PR TITLE
chore(deploy): drop the obsolete SPANBARN_RETENTION_FULL_HOURS from the base configmap

### DIFF
--- a/deploy/k8s/base/configmap.yaml
+++ b/deploy/k8s/base/configmap.yaml
@@ -6,7 +6,12 @@ data:
   SPANBARN_ADDR: ":8080"
   SPANBARN_DB_PATH: "/var/lib/spanbarn/spanbarn.db"
   SPANBARN_SPOOL_DIR: "/var/lib/spanbarn/spool"
-  SPANBARN_RETENTION_FULL_HOURS: "4"
+  # SPANBARN_RETENTION_FULL_HOURS is deliberately absent: it was obsolete and
+  # wired to nothing, so every environment ran with "4" here believing spans were
+  # kept 4 hours while they were actually kept for the interesting window. The
+  # app now warns if it is set. Span retention is
+  # SPANBARN_RETENTION_INTERESTING_HOURS; uninteresting spans expire via
+  # SPANBARN_BORING_RETENTION_MINUTES.
   SPANBARN_RETENTION_ERROR_DAYS: "30"
   SPANBARN_RETENTION_AGGREGATED_DAYS: "90"
   SPANBARN_AGGREGATION_INTERVAL: "5m"


### PR DESCRIPTION
Every environment shipped `SPANBARN_RETENTION_FULL_HOURS: "4"` — so testing, staging **and production** all ran believing spans were kept 4 hours. The setting was wired to nothing; spans were actually kept for the interesting window (168h before #147, 48h now). **That gap is what filled production's disk.**

#149 made the setting warn instead of failing silently, and staging surfaced this configmap on its very first boot afterwards:

```
WARN  SPANBARN_RETENTION_FULL_HOURS is obsolete and ignored — span retention is
      SPANBARN_RETENTION_INTERESTING_HOURS; uninteresting spans expire via
      SPANBARN_BORING_RETENTION_MINUTES. Unset it.
      ignored_value=4  retention_interesting_hours=48  boring_retention_minutes=30
```

So this removes the source, rather than leaving every environment warning about a value we ship ourselves.

Span retention is `SPANBARN_RETENTION_INTERESTING_HOURS` (default 48h); uninteresting spans expire via `SPANBARN_BORING_RETENTION_MINUTES` (default 30m). Neither is pinned in the manifests, so both take the code default — which is now correct.