### PR TITLE
test: pin the sampler wiring so a mode cannot silently lose sampling

### DIFF
--- a/cmd/spanbarn/sampler_wiring_test.go
+++ b/cmd/spanbarn/sampler_wiring_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// otlpServingModes are the run modes that accept OTLP spans. Each must route
+// them through the TraceBuffer, which is where ratio sampling happens.
+// runWriterMode is absent deliberately: it passes a nil ingest handler and
+// serves no OTLP.
+var otlpServingModes = []string{"runStandalone", "runReaderMode", "runIngestMode"}
+
+// TestEveryOTLPModeWiresTheSampler pins the wiring that nothing else checks.
+//
+// Sampling lives in ingest.TraceBuffer, and a mode opts into it by passing
+// api.WithTraceBuffer. A mode that forgets still compiles, still serves, still
+// passes every other test — it just silently ingests everything unsampled and
+// ignores every ingest.sample_ratio.* setting. runStandalone shipped that way
+// and runIngestMode never had it at all; nobody noticed until production's disk
+// filled with SpanBarn's own telemetry.
+//
+// This asserts on source structure rather than behaviour because the run*
+// functions build their dependencies inline and then block on Serve, so there is
+// no seam to construct one from a test. If you refactor the wiring (e.g. behind
+// a shared helper), update samplerWiringCall below — do not delete the test.
+func TestEveryOTLPModeWiresTheSampler(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	const samplerWiringCall = "WithTraceBuffer"
+
+	for _, mode := range otlpServingModes {
+		fn := findFunc(file, mode)
+		if fn == nil {
+			t.Fatalf("run mode %s not found in main.go — if it was renamed or removed, update otlpServingModes", mode)
+		}
+		if !bodyCalls(fn, samplerWiringCall) {
+			t.Errorf("%s serves OTLP but never calls api.%s — spans will be ingested unsampled "+
+				"and every ingest.sample_ratio.* setting will be silently ignored", mode, samplerWiringCall)
+		}
+	}
+}
+
+// TestWriterModeServesNoOTLP guards the assumption that lets us exclude the
+// writer from the sampling requirement above: it passes a nil ingest handler, so
+// there is nothing to sample. If that changes, the writer needs a buffer too.
+func TestWriterModeServesNoOTLP(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse main.go: %v", err)
+	}
+
+	fn := findFunc(file, "runWriterMode")
+	if fn == nil {
+		t.Skip("runWriterMode not found")
+	}
+	if bodyCalls(fn, "NewTraceBuffer") {
+		t.Skip("runWriterMode now builds a trace buffer; it presumably serves OTLP — nothing to guard")
+	}
+
+	// It must still pass a nil ingest handler to the server constructor.
+	var passesNilIngest bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !calleeName(call, "NewServerWithQuery") {
+			return true
+		}
+		// signature: NewServerWithQuery(cfg, ingestHandler, querySvc, sessions, logger, opts...)
+		if len(call.Args) >= 2 {
+			if id, ok := call.Args[1].(*ast.Ident); ok && id.Name == "nil" {
+				passesNilIngest = true
+			}
+		}
+		return true
+	})
+	if !passesNilIngest {
+		t.Error("runWriterMode now passes a non-nil ingest handler: it accepts spans, so it must " +
+			"also wire api.WithTraceBuffer — add it to otlpServingModes")
+	}
+}
+
+func findFunc(file *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == name && fn.Recv == nil {
+			return fn
+		}
+	}
+	return nil
+}
+
+// bodyCalls reports whether fn's body contains a call whose callee name matches.
+func bodyCalls(fn *ast.FuncDecl, name string) bool {
+	found := false
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if call, ok := n.(*ast.CallExpr); ok && calleeName(call, name) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// calleeName matches both `name(...)` and `pkg.name(...)`.
+func calleeName(call *ast.CallExpr, name string) bool {
+	switch fn := call.Fun.(type) {
+	case *ast.Ident:
+		return fn.Name == name
+	case *ast.SelectorExpr:
+		return fn.Sel.Name == name
+	}
+	return strings.HasSuffix(exprString(call.Fun), "."+name)
+}
+
+func exprString(e ast.Expr) string {
+	if sel, ok := e.(*ast.SelectorExpr); ok {
+		return sel.Sel.Name
+	}
+	if id, ok := e.(*ast.Ident); ok {
+		return id.Name
+	}
+	return ""
+}

--- a/internal/api/otlp_selfsample_test.go
+++ b/internal/api/otlp_selfsample_test.go
@@ -2,10 +2,12 @@ package api_test
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -139,5 +141,73 @@ func TestNonSelfSpansStillSampled(t *testing.T) {
 	case <-tb.Out:
 		t.Fatal("unsampled tenant trace was kept")
 	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// warnSpy counts WARN records and keeps their messages.
+type warnSpy struct {
+	warns *int
+	msgs  *[]string
+}
+
+func (h warnSpy) Enabled(context.Context, slog.Level) bool { return true }
+func (h warnSpy) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		*h.warns++
+		*h.msgs = append(*h.msgs, r.Message)
+	}
+	return nil
+}
+func (h warnSpy) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h warnSpy) WithGroup(string) slog.Handler      { return h }
+
+func newTestIngestHandler(t *testing.T) *ingest.Handler {
+	t.Helper()
+	sp, err := spool.NewSpool(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("spool: %v", err)
+	}
+	t.Cleanup(func() { sp.Close() })
+	return ingest.NewHandler(ingest.NewQueue(16), sp, 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// TestServerWarnsWhenIngestHasNoSampler is the runtime half of the guard (the
+// compile-time half is TestEveryOTLPModeWiresTheSampler in cmd/spanbarn). A
+// server that accepts spans with no TraceBuffer ingests everything unsampled and
+// ignores every ingest.sample_ratio setting — silently, which is how
+// runStandalone shipped for months.
+func TestServerWarnsWhenIngestHasNoSampler(t *testing.T) {
+	warns := 0
+	var msgs []string
+	logger := slog.New(warnSpy{warns: &warns, msgs: &msgs})
+
+	api.NewServerWithQuery(api.ServerConfig{APIKey: testAPIKey, MaxBodyBytes: 1 << 20},
+		newTestIngestHandler(t), nil, nil, logger)
+
+	if warns == 0 {
+		t.Fatal("a server accepting spans with no trace buffer did not warn — sampling is off and nothing says so")
+	}
+	joined := strings.Join(msgs, " ")
+	if !strings.Contains(joined, "sampling is DISABLED") {
+		t.Fatalf("warning does not say sampling is disabled: %v", msgs)
+	}
+}
+
+// TestServerSilentWhenSamplerWired ensures the guard doesn't cry wolf on a
+// correctly wired server.
+func TestServerSilentWhenSamplerWired(t *testing.T) {
+	warns := 0
+	var msgs []string
+	logger := slog.New(warnSpy{warns: &warns, msgs: &msgs})
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tb := ingest.NewTraceBuffer(time.Hour, ingest.NewStaticRatioLookup(1), discard)
+	api.NewServerWithQuery(api.ServerConfig{APIKey: testAPIKey, MaxBodyBytes: 1 << 20},
+		newTestIngestHandler(t), nil, nil, logger, api.WithTraceBuffer(tb))
+
+	for _, m := range msgs {
+		if strings.Contains(m, "sampling is DISABLED") {
+			t.Fatalf("correctly wired server warned about sampling: %v", msgs)
+		}
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -190,6 +190,15 @@ func NewServerWithQuery(cfg ServerConfig, ingestHandler *ingest.Handler, querySv
 		opt(s)
 	}
 
+	// A server that accepts spans but has no TraceBuffer silently ingests
+	// everything unsampled: handleOTLP falls through to Enqueue, and every
+	// ingest.sample_ratio.* setting reads back fine while doing nothing. That is
+	// exactly how runStandalone shipped for months, so say it out loud rather
+	// than leaving it to be discovered by a full disk.
+	if s.ingest != nil && s.traceBuffer == nil {
+		logger.Warn("ingest is enabled without a trace buffer: span sampling is DISABLED and every ingest.sample_ratio setting will be ignored")
+	}
+
 	// The session service refreshes OIDC sessions through the same client the
 	// server proxies with; resolve at request time because SetOIDCClient runs
 	// after construction.


### PR DESCRIPTION
Closes the gap that let the disk-full outage hide.

## The gap

Nothing asserted that a run mode routes OTLP through the `TraceBuffer` — which is where ratio sampling happens. A mode that forgets still compiles, still serves, and still passes every other test. It just ingests everything unsampled and silently ignores every `ingest.sample_ratio.*` setting.

Not hypothetical: **`runStandalone` shipped that way**, and `runIngestMode` never had it at all. Nobody noticed until production's disk filled with SpanBarn's own telemetry.

## Two guards, catching it at different times

**`TestEveryOTLPModeWiresTheSampler`** (`cmd/spanbarn`) parses `main.go` and asserts each OTLP-serving mode passes `api.WithTraceBuffer`. **Verified against the real bug** — removing that line from `runStandalone` reproduces the historical regression and fails:

```
--- FAIL: TestEveryOTLPModeWiresTheSampler
    runStandalone serves OTLP but never calls api.WithTraceBuffer — spans will be
    ingested unsampled and every ingest.sample_ratio.* setting will be silently ignored
```

It asserts on source structure rather than behaviour, which is unusual and deliberate: the `run*` functions build their dependencies inline and then block on `Serve`, so there's no seam to construct one from a test. The comment says exactly that, and says what to do if the wiring is refactored behind a helper (update the constant — don't delete the test).

`TestWriterModeServesNoOTLP` guards the assumption that lets the writer be excluded — that it passes a nil ingest handler — so the exclusion can't rot silently either.

**Runtime guard**: `NewServerWithQuery` now warns when it has an ingest handler but no trace buffer. That combination always means sampling is off, and it catches any caller the AST test doesn't know about — including library users.

So CI blocks the regression, and the log line catches anything that gets past it.

`go build ./...`, `go vet ./...`, `go test ./...` and `make quality-gate` all pass.