### PR TITLE
feat(auth): register projects and API keys declared in config on boot

### DIFF
--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -136,6 +136,10 @@ func runStandalone(cfg config.Config, logger *slog.Logger) error {
 		repo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 	}
 
+	if err := applySeedKeys(repo, cfg, logger); err != nil {
+		return err
+	}
+
 	// Read-only DB — used exclusively by the query service for dashboard reads.
 	// In WAL mode, readers and the single writer don't block each other.
 	roDB, err := repository.NewReadOnlyDBWithCache(cfg.DBPath, cfg.SQLiteROCacheMB, cfg.SQLiteROMmapMB)
@@ -609,6 +613,10 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 	repo := repository.NewRepository(db.DB)
 	if cfg.QueryTimeoutSeconds > 0 {
 		repo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
+	}
+
+	if err := applySeedKeys(repo, cfg, logger); err != nil {
+		return err
 	}
 
 	if cfg.AdminUsername != "" && cfg.AdminPassword != "" {

--- a/cmd/spanbarn/seed.go
+++ b/cmd/spanbarn/seed.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/wiebe-xyz/spanbarn/internal/config"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+	"github.com/wiebe-xyz/spanbarn/internal/seed"
+)
+
+// applySeedKeys registers the projects and API keys declared in
+// SPANBARN_SEED_KEYS. It runs on the writer and standalone modes only, after
+// migrations and before serving, so clients never authenticate against a
+// half-populated key set.
+//
+// This exists because projects and api_keys are otherwise undeclared DB state:
+// rebuilding a database silently deauthenticates every client, which is exactly
+// what happened to testing and staging on 2026-07-13. Seeding is idempotent, so
+// it is a no-op on an already-populated database and self-heals a rebuilt one.
+func applySeedKeys(repo *repository.Repository, cfg config.Config, logger *slog.Logger) error {
+	keys, err := seed.Parse(cfg.SeedKeys)
+	if err != nil {
+		return fmt.Errorf("seed keys: %w", err)
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	added, err := seed.Apply(repo, keys, logger)
+	if err != nil {
+		return fmt.Errorf("seed keys: %w", err)
+	}
+	logger.Info("seed: api keys ready", "declared", len(keys), "added", added)
+	return nil
+}

--- a/deploy/k8s/staging/configmap-seed-patch.yaml
+++ b/deploy/k8s/staging/configmap-seed-patch.yaml
@@ -1,0 +1,26 @@
+# Projects + API keys registered on writer boot, so a rebuilt database
+# re-authenticates its clients instead of silently rejecting them.
+#
+# On 2026-07-13 this database was rebuilt and only the spanbarn self-project was
+# re-seeded. Every client key below ceased to exist, so bugbarn, iambarn,
+# brandtrace and funnelbarn all failed OTLP export with 401 — invisibly, since
+# an exporter has nowhere to report when the telemetry backend is what's
+# rejecting it. It went unnoticed until someone asked why traces were missing.
+#
+# These are SHA-256 hashes, not keys. A hash cannot authenticate anything
+# (Authorize hashes the presented key and compares), so this is safe to keep in
+# the repo; the key itself lives in each client's own SOPS secret. To rotate:
+# mint the new key, add its hash here, and drop the old entry once the client
+# has moved — seeding adds alongside, it never revokes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spanbarn-config
+data:
+  SPANBARN_SEED_KEYS: |
+    [
+      {"project":"bugbarn",   "name":"bugbarn-otlp",    "scope":"ingest", "key_sha256":"c2eeb72595a863c5abeb9097a51952738cf07862a2648069f9766bb167ec72e1"},
+      {"project":"iambarn",   "name":"iambarn-otlp",    "scope":"ingest", "key_sha256":"c0d55965413c5b9748c10138ed5c4c6b4b94553a6500a5d6f59b21f9fd2cf425"},
+      {"project":"brandtrace","name":"brandtrace-otlp", "scope":"ingest", "key_sha256":"abe01509b81c023c619fdfc7847b96d16adf00c6bbf0e61c63b7e361c3bb662f"},
+      {"project":"funnelbarn","name":"funnelbarn-otlp", "scope":"ingest", "key_sha256":"0c61684470d7a00a411062be61825df0af8aed45973823bd20bf4c93786814ea"}
+    ]

--- a/deploy/k8s/staging/kustomization.yaml
+++ b/deploy/k8s/staging/kustomization.yaml
@@ -15,6 +15,10 @@ patches:
     target:
       kind: ConfigMap
       name: spanbarn-config
+  - path: configmap-seed-patch.yaml
+    target:
+      kind: ConfigMap
+      name: spanbarn-config
   - path: patch-ingest-strategy.yaml
     target:
       kind: Deployment

--- a/deploy/k8s/testing/configmap-seed-patch.yaml
+++ b/deploy/k8s/testing/configmap-seed-patch.yaml
@@ -1,0 +1,26 @@
+# Projects + API keys registered on writer boot, so a rebuilt database
+# re-authenticates its clients instead of silently rejecting them.
+#
+# On 2026-07-13 this database was rebuilt and only the spanbarn self-project was
+# re-seeded. Every client key below ceased to exist, so bugbarn, iambarn,
+# brandtrace and funnelbarn all failed OTLP export with 401 — invisibly, since
+# an exporter has nowhere to report when the telemetry backend is what's
+# rejecting it. It went unnoticed until someone asked why traces were missing.
+#
+# These are SHA-256 hashes, not keys. A hash cannot authenticate anything
+# (Authorize hashes the presented key and compares), so this is safe to keep in
+# the repo; the key itself lives in each client's own SOPS secret. To rotate:
+# mint the new key, add its hash here, and drop the old entry once the client
+# has moved — seeding adds alongside, it never revokes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spanbarn-config
+data:
+  SPANBARN_SEED_KEYS: |
+    [
+      {"project":"bugbarn",   "name":"bugbarn-otlp",    "scope":"ingest", "key_sha256":"289b9ab27beb2b496ee0aa7680fed2685077426cfe57a882d4a5e85969274577"},
+      {"project":"iambarn",   "name":"iambarn-otlp",    "scope":"ingest", "key_sha256":"d6266feb15cf8b8e4483a1daabdcc13f9cdf544d9b98049f23ab077213b9cd21"},
+      {"project":"brandtrace","name":"brandtrace-otlp", "scope":"ingest", "key_sha256":"96a8e2fbde5e3a17a45860443b39c39c9681fff6be07d804fe6ba1223eff21cc"},
+      {"project":"funnelbarn","name":"funnelbarn-otlp", "scope":"ingest", "key_sha256":"798b049d1073277c9759a1bb4ed4e5d10b7f25519a7653e6be75be1aa0f26bbe"}
+    ]

--- a/deploy/k8s/testing/kustomization.yaml
+++ b/deploy/k8s/testing/kustomization.yaml
@@ -15,6 +15,10 @@ patches:
     target:
       kind: ConfigMap
       name: spanbarn-config
+  - path: configmap-seed-patch.yaml
+    target:
+      kind: ConfigMap
+      name: spanbarn-config
 
 images:
   - name: ghcr.io/wiebe-xyz/spanbarn/service

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ type Config struct {
 	SpoolDir                 string
 	APIKey                   string
 	APIKeySHA256             string
+	SeedKeys                 string
 	AdminUsername            string
 	AdminPassword            string
 	AdminPasswordBcrypt      string
@@ -128,12 +129,15 @@ type Config struct {
 // Load reads configuration from SPANBARN_* environment variables with defaults.
 func Load() Config {
 	cfg := Config{
-		Addr:                getenv("SPANBARN_ADDR", ":8080"),
-		PublicURL:           os.Getenv("SPANBARN_PUBLIC_URL"),
-		DBPath:              getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
-		SpoolDir:            getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
-		APIKey:              os.Getenv("SPANBARN_API_KEY"),
-		APIKeySHA256:        os.Getenv("SPANBARN_API_KEY_SHA256"),
+		Addr:         getenv("SPANBARN_ADDR", ":8080"),
+		PublicURL:    os.Getenv("SPANBARN_PUBLIC_URL"),
+		DBPath:       getenv("SPANBARN_DB_PATH", ".data/spanbarn.db"),
+		SpoolDir:     getenv("SPANBARN_SPOOL_DIR", ".data/spool"),
+		APIKey:       os.Getenv("SPANBARN_API_KEY"),
+		APIKeySHA256: os.Getenv("SPANBARN_API_KEY_SHA256"),
+		// SPANBARN_SEED_KEYS: JSON array of projects + API key hashes to
+		// register on boot. Hashes, not keys — see internal/seed.
+		SeedKeys:            os.Getenv("SPANBARN_SEED_KEYS"),
 		AdminUsername:       os.Getenv("SPANBARN_ADMIN_USERNAME"),
 		AdminPassword:       os.Getenv("SPANBARN_ADMIN_PASSWORD"),
 		AdminPasswordBcrypt: os.Getenv("SPANBARN_ADMIN_PASSWORD_BCRYPT"),

--- a/internal/repository/repo_apikeys.go
+++ b/internal/repository/repo_apikeys.go
@@ -16,6 +16,29 @@ func (r *Repository) CreateAPIKey(projectID int64, name, keyHash, scope string) 
 	return id, err
 }
 
+// EnsureAPIKey registers a key by its SHA-256 hash if no key with that hash
+// exists yet, and reports whether it inserted one. It is idempotent via the
+// UNIQUE index on api_keys(key_hash), so seeding can run on every boot.
+//
+// Rotating a key seeds a new row rather than replacing the old one: the
+// previous key keeps working until it is explicitly revoked, so a rotation
+// cannot lock out a client that has not picked up the new value yet.
+func (r *Repository) EnsureAPIKey(projectID int64, name, keyHash, scope string) (inserted bool, err error) {
+	err = r.execHigh(func() error {
+		res, e := r.db.Exec(
+			"INSERT OR IGNORE INTO api_keys (project_id, name, key_hash, scope) VALUES (?, ?, ?, ?)",
+			projectID, name, keyHash, scope,
+		)
+		if e != nil {
+			return e
+		}
+		n, e := res.RowsAffected()
+		inserted = n > 0
+		return e
+	})
+	return inserted, err
+}
+
 func (r *Repository) GetAPIKeyByHash(keyHash string) (APIKey, error) {
 	var k APIKey
 	err := r.db.QueryRow(

--- a/internal/repository/repo_projects.go
+++ b/internal/repository/repo_projects.go
@@ -88,6 +88,28 @@ func (r *Repository) ListProjectIDs() ([]int64, error) {
 	return ids, rows.Err()
 }
 
+// EnsureProject creates an active project if the slug is free and returns it
+// either way. Unlike EnsureProjectPending it needs no approval step: it backs
+// declarative seeding, where the operator has already vouched for the project
+// by putting it in the deployment config.
+//
+// Idempotent via the UNIQUE constraint on projects(slug). An existing project
+// is left untouched — seeding never renames or re-activates a project an
+// operator has since edited or suspended.
+func (r *Repository) EnsureProject(slug, name string) (Project, error) {
+	err := r.execHigh(func() error {
+		_, e := r.db.Exec(
+			"INSERT OR IGNORE INTO projects (slug, name, status) VALUES (?, ?, 'active')",
+			slug, name,
+		)
+		return e
+	})
+	if err != nil {
+		return Project{}, err
+	}
+	return r.GetProjectBySlug(slug)
+}
+
 func (r *Repository) EnsureProjectPending(slug, name string) (Project, error) {
 	// With the write scheduler serialising all writes, SQLITE_BUSY cannot occur
 	// here, so the retry loop is no longer needed.

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -814,3 +814,78 @@ func TestBatchedDeleteRespectsContextCancellation(t *testing.T) {
 		t.Fatalf("expected %d spans intact after cancel, got %d", total, remaining)
 	}
 }
+
+func TestEnsureProjectIsIdempotent(t *testing.T) {
+	repo := setupTestDB(t)
+
+	p1, err := repo.EnsureProject("bugbarn", "bugbarn")
+	if err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+	if p1.Status != "active" {
+		t.Errorf("status = %q, want active", p1.Status)
+	}
+
+	p2, err := repo.EnsureProject("bugbarn", "different name")
+	if err != nil {
+		t.Fatalf("EnsureProject (second): %v", err)
+	}
+	if p2.ID != p1.ID {
+		t.Errorf("ID = %d, want the existing %d", p2.ID, p1.ID)
+	}
+	if p2.Name != "bugbarn" {
+		t.Errorf("name = %q, want the existing project left untouched", p2.Name)
+	}
+	all, err := repo.ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("got %d projects, want 1", len(all))
+	}
+}
+
+func TestEnsureAPIKeyIsIdempotent(t *testing.T) {
+	repo := setupTestDB(t)
+	p, err := repo.EnsureProject("proj", "Proj")
+	if err != nil {
+		t.Fatalf("EnsureProject: %v", err)
+	}
+
+	inserted, err := repo.EnsureAPIKey(p.ID, "otlp", "hash-1", "ingest")
+	if err != nil {
+		t.Fatalf("EnsureAPIKey: %v", err)
+	}
+	if !inserted {
+		t.Error("inserted = false, want true on first call")
+	}
+
+	inserted, err = repo.EnsureAPIKey(p.ID, "otlp", "hash-1", "ingest")
+	if err != nil {
+		t.Fatalf("EnsureAPIKey (second): %v", err)
+	}
+	if inserted {
+		t.Error("inserted = true, want false when the hash already exists")
+	}
+
+	got, err := repo.GetAPIKeyByHash("hash-1")
+	if err != nil {
+		t.Fatalf("GetAPIKeyByHash: %v", err)
+	}
+	if got.ProjectID != p.ID || got.Scope != "ingest" || got.Name != "otlp" {
+		t.Errorf("got %+v, want project=%d scope=ingest name=otlp", got, p.ID)
+	}
+
+	// A rotated key is added alongside the old one: the previous key must keep
+	// working until it is explicitly revoked.
+	if _, err := repo.EnsureAPIKey(p.ID, "otlp", "hash-2", "ingest"); err != nil {
+		t.Fatalf("EnsureAPIKey (rotate): %v", err)
+	}
+	keys, err := repo.ListAPIKeys(p.ID)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("got %d keys after rotation, want 2", len(keys))
+	}
+}

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -1,0 +1,133 @@
+// Package seed registers projects and API keys declared in the deployment
+// config, so a rebuilt database re-registers its clients instead of rejecting
+// them.
+//
+// Projects and api_keys are ordinary rows with no declarative source. When the
+// testing and staging databases were rebuilt on 2026-07-13 only the spanbarn
+// self-project was re-seeded, so every client app's key vanished and all of
+// them started failing 401 — silently, because an OTLP exporter has nowhere to
+// report to when its telemetry backend is the thing rejecting it. Seeding on
+// boot closes that hole.
+//
+// Seeds carry the SHA-256 hash of a key, never the key itself. A hash cannot
+// authenticate anything (Authorize hashes the presented key and compares), so
+// seeds are safe to keep in a ConfigMap or the repo, while the key itself stays
+// in the client's own secret store.
+package seed
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// sha256HexLen is the length of a hex-encoded SHA-256 digest, the format
+// auth.HashKey emits and the only thing Authorize will ever match against.
+const sha256HexLen = 64
+
+// validScopes mirrors the scopes `spanbarn apikey create` accepts.
+var validScopes = map[string]bool{"ingest": true, "read": true, "full": true}
+
+// Key is one declared project + API key pairing.
+type Key struct {
+	Project   string `json:"project"`
+	Name      string `json:"name"`
+	Scope     string `json:"scope"`
+	KeySHA256 string `json:"key_sha256"`
+}
+
+// Store is the subset of the repository seeding needs.
+type Store interface {
+	EnsureProject(slug, name string) (repository.Project, error)
+	EnsureAPIKey(projectID int64, name, keyHash, scope string) (bool, error)
+}
+
+// Parse decodes and validates SPANBARN_SEED_KEYS. An empty string yields no
+// keys and no error, so seeding is opt-in.
+//
+// Validation is deliberately strict. Every field here fails silently at
+// runtime if it is wrong — a mistyped hash simply never matches any presented
+// key, and the operator sees an unexplained 401 rather than a config error. So
+// a bad seed must fail loudly at boot, where it is attributable.
+func Parse(raw string) ([]Key, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var keys []Key
+	if err := json.Unmarshal([]byte(raw), &keys); err != nil {
+		return nil, fmt.Errorf("parse seed keys: %w", err)
+	}
+	seen := make(map[string]bool, len(keys))
+	for i := range keys {
+		if err := keys[i].normalize(); err != nil {
+			return nil, fmt.Errorf("seed key %d: %w", i, err)
+		}
+		if seen[keys[i].KeySHA256] {
+			return nil, fmt.Errorf("seed key %d: duplicate key_sha256", i)
+		}
+		seen[keys[i].KeySHA256] = true
+	}
+	return keys, nil
+}
+
+// normalize trims and lowercases in place, then validates.
+func (k *Key) normalize() error {
+	k.Project = strings.TrimSpace(k.Project)
+	k.Name = strings.TrimSpace(k.Name)
+	k.Scope = strings.TrimSpace(k.Scope)
+	// Hashes are compared as lowercase hex; an uppercase digest would be a
+	// valid SHA-256 that never matches anything.
+	k.KeySHA256 = strings.ToLower(strings.TrimSpace(k.KeySHA256))
+
+	if k.Project == "" {
+		return fmt.Errorf("project is required")
+	}
+	if k.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if k.Scope == "" {
+		k.Scope = "ingest"
+	}
+	if !validScopes[k.Scope] {
+		return fmt.Errorf("invalid scope %q (want ingest|read|full)", k.Scope)
+	}
+	if len(k.KeySHA256) != sha256HexLen {
+		return fmt.Errorf("key_sha256 must be %d hex chars, got %d", sha256HexLen, len(k.KeySHA256))
+	}
+	if _, err := hex.DecodeString(k.KeySHA256); err != nil {
+		return fmt.Errorf("key_sha256 is not hex: %w", err)
+	}
+	return nil
+}
+
+// Apply registers every declared project and key. It is idempotent: on a
+// database that already has them it inserts nothing and reports 0 added.
+//
+// Errors are returned rather than logged-and-swallowed. Seeding runs at boot
+// before serving, so a failure here means clients would authenticate against an
+// incomplete key set — better to fail the process than to come up and 401
+// everyone.
+func Apply(store Store, keys []Key, logger *slog.Logger) (added int, err error) {
+	for _, k := range keys {
+		proj, err := store.EnsureProject(k.Project, k.Project)
+		if err != nil {
+			return added, fmt.Errorf("ensure project %q: %w", k.Project, err)
+		}
+		inserted, err := store.EnsureAPIKey(proj.ID, k.Name, k.KeySHA256, k.Scope)
+		if err != nil {
+			return added, fmt.Errorf("ensure api key %q: %w", k.Name, err)
+		}
+		if inserted {
+			added++
+			if logger != nil {
+				logger.Info("seed: registered API key",
+					"project", k.Project, "name", k.Name, "scope", k.Scope, "project_id", proj.ID)
+			}
+		}
+	}
+	return added, nil
+}

--- a/internal/seed/seed_test.go
+++ b/internal/seed/seed_test.go
@@ -1,0 +1,211 @@
+package seed
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+const (
+	hashA = "aaaa000000000000000000000000000000000000000000000000000000000001"
+	hashB = "bbbb000000000000000000000000000000000000000000000000000000000002"
+)
+
+func TestParseEmptyIsNoop(t *testing.T) {
+	for _, raw := range []string{"", "   ", "\n"} {
+		keys, err := Parse(raw)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", raw, err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("Parse(%q) = %d keys, want 0", raw, len(keys))
+		}
+	}
+}
+
+func TestParseValid(t *testing.T) {
+	raw := `[{"project":"bugbarn","name":"bugbarn-otlp","scope":"ingest","key_sha256":"` + hashA + `"}]`
+	keys, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("got %d keys, want 1", len(keys))
+	}
+	want := Key{Project: "bugbarn", Name: "bugbarn-otlp", Scope: "ingest", KeySHA256: hashA}
+	if keys[0] != want {
+		t.Errorf("got %+v, want %+v", keys[0], want)
+	}
+}
+
+func TestParseDefaultsScopeToIngest(t *testing.T) {
+	raw := `[{"project":"p","name":"k","key_sha256":"` + hashA + `"}]`
+	keys, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if keys[0].Scope != "ingest" {
+		t.Errorf("scope = %q, want ingest", keys[0].Scope)
+	}
+}
+
+// An uppercase digest is a valid SHA-256 that would never match a presented
+// key, since Authorize compares lowercase hex. Normalizing it is the
+// difference between a working key and an unexplained 401.
+func TestParseLowercasesHash(t *testing.T) {
+	raw := `[{"project":"p","name":"k","key_sha256":"` + strings.ToUpper(hashA) + `"}]`
+	keys, err := Parse(raw)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if keys[0].KeySHA256 != hashA {
+		t.Errorf("hash = %q, want lowercase %q", keys[0].KeySHA256, hashA)
+	}
+}
+
+func TestParseRejectsBadInput(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{"malformed json", `[{"project":`},
+		{"missing project", `[{"name":"k","key_sha256":"` + hashA + `"}]`},
+		{"missing name", `[{"project":"p","key_sha256":"` + hashA + `"}]`},
+		{"bad scope", `[{"project":"p","name":"k","scope":"admin","key_sha256":"` + hashA + `"}]`},
+		{"short hash", `[{"project":"p","name":"k","key_sha256":"abc"}]`},
+		{"non-hex hash", `[{"project":"p","name":"k","key_sha256":"zzzz000000000000000000000000000000000000000000000000000000000001"}]`},
+		{"duplicate hash", `[{"project":"a","name":"k","key_sha256":"` + hashA + `"},{"project":"b","name":"k2","key_sha256":"` + hashA + `"}]`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse(tc.raw); err == nil {
+				t.Errorf("Parse(%s) = nil error, want error", tc.raw)
+			}
+		})
+	}
+}
+
+func newTestRepo(t *testing.T) *repository.Repository {
+	t.Helper()
+	db, err := repository.NewDB(":memory:")
+	if err != nil {
+		t.Fatalf("NewDB: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := repository.Migrate(db.DB); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return repository.NewRepository(db.DB)
+}
+
+func TestApplyRegistersAndIsIdempotent(t *testing.T) {
+	repo := newTestRepo(t)
+	keys := []Key{
+		{Project: "bugbarn", Name: "bugbarn-otlp", Scope: "ingest", KeySHA256: hashA},
+		{Project: "iambarn", Name: "iambarn-otlp", Scope: "ingest", KeySHA256: hashB},
+	}
+
+	added, err := Apply(repo, keys, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if added != 2 {
+		t.Errorf("added = %d, want 2", added)
+	}
+
+	// The seeded key must actually authenticate — that is the whole point.
+	rec, err := repo.GetAPIKeyByHash(hashA)
+	if err != nil {
+		t.Fatalf("GetAPIKeyByHash: %v", err)
+	}
+	if rec.Scope != "ingest" || rec.Name != "bugbarn-otlp" {
+		t.Errorf("got %+v, want scope=ingest name=bugbarn-otlp", rec)
+	}
+	proj, err := repo.GetProjectBySlug("bugbarn")
+	if err != nil {
+		t.Fatalf("GetProjectBySlug: %v", err)
+	}
+	if rec.ProjectID != proj.ID {
+		t.Errorf("key project_id = %d, want %d", rec.ProjectID, proj.ID)
+	}
+	if proj.Status != "active" {
+		t.Errorf("project status = %q, want active", proj.Status)
+	}
+
+	// Seeding runs on every boot, so a second pass must add nothing.
+	added, err = Apply(repo, keys, nil)
+	if err != nil {
+		t.Fatalf("Apply (second): %v", err)
+	}
+	if added != 0 {
+		t.Errorf("second Apply added = %d, want 0", added)
+	}
+	all, err := repo.ListAllAPIKeys()
+	if err != nil {
+		t.Fatalf("ListAllAPIKeys: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("got %d keys after re-seed, want 2", len(all))
+	}
+}
+
+// Seeding must not resurrect or rename a project an operator has since edited.
+func TestApplyLeavesExistingProjectAlone(t *testing.T) {
+	repo := newTestRepo(t)
+	if _, err := repo.CreateProject("bugbarn", "Bug Barn (renamed)"); err != nil {
+		t.Fatalf("CreateProject: %v", err)
+	}
+	keys := []Key{{Project: "bugbarn", Name: "k", Scope: "ingest", KeySHA256: hashA}}
+	if _, err := Apply(repo, keys, nil); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	proj, err := repo.GetProjectBySlug("bugbarn")
+	if err != nil {
+		t.Fatalf("GetProjectBySlug: %v", err)
+	}
+	if proj.Name != "Bug Barn (renamed)" {
+		t.Errorf("name = %q, want the operator's name preserved", proj.Name)
+	}
+	projects, err := repo.ListProjects()
+	if err != nil {
+		t.Fatalf("ListProjects: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Errorf("got %d projects, want 1 (no duplicate)", len(projects))
+	}
+}
+
+type failingStore struct{ onKey bool }
+
+func (f *failingStore) EnsureProject(slug, _ string) (repository.Project, error) {
+	if f.onKey {
+		return repository.Project{ID: 1}, nil
+	}
+	return repository.Project{}, errors.New("boom")
+}
+
+func (f *failingStore) EnsureAPIKey(int64, string, string, string) (bool, error) {
+	return false, errors.New("boom")
+}
+
+// A seeding failure must surface, not be swallowed: coming up with an
+// incomplete key set means 401ing every client with no explanation.
+func TestApplyPropagatesErrors(t *testing.T) {
+	keys := []Key{{Project: "p", Name: "k", Scope: "ingest", KeySHA256: hashA}}
+	tests := []struct {
+		name  string
+		store *failingStore
+	}{
+		{"project error", &failingStore{onKey: false}},
+		{"api key error", &failingStore{onKey: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Apply(tc.store, keys, nil); err == nil {
+				t.Error("Apply = nil error, want error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the root cause of the 2026-07-13 telemetry outage.

## The problem

`projects` and `api_keys` were undeclared database state with no source of truth. The testing and staging databases were rebuilt on 2026-07-13 and only the `spanbarn` self-project was re-seeded, so **every client apps key ceased to exist**. bugbarn, iambarn, brandtrace and funnelbarn all failed OTLP export with 401 in both environments — ~160 rejections per 30 minutes each, for four days, unnoticed.

It was invisible by construction:
- an exporter has nowhere to report when the telemetry backend is the thing rejecting it;
- every client mounts its key with `optional: true`, so a missing key produces no CrashLoop and no alert.

The 401s were only visible from inside spanbarn.

## The fix

Seed on **writer/standalone boot**, after migrations, before serving, from `SPANBARN_SEED_KEYS`. Idempotent via the existing `UNIQUE` indexes on `projects(slug)` and `api_keys(key_hash)` — a no-op on a populated database, self-healing on a rebuilt one.

```json
[{"project":"bugbarn","name":"bugbarn-otlp","scope":"ingest","key_sha256":"..."}]
```

**Seeds carry the SHA-256 hash, never the key.** A hash cannot authenticate anything (`Authorize` hashes the presented key and compares), so it lives safely in the ConfigMap while the key stays in each clients own secret store.

Parse validation is deliberately strict: a mistyped or uppercase digest is a *valid* SHA-256 that simply never matches, reproducing the same unexplained 401 this change exists to prevent. A bad seed fails loudly at boot, where it is attributable, rather than at 3am.

## Verification

Beyond unit tests, I ran the real boot path against a fresh database (the rebuild scenario):

- `seed: api keys ready declared=2 added=2` on first boot; **`added=0` on the second** (idempotent).
- **A real production key returns 200** against a database seeded only from its declared hash.
- A bogus key still 401s — auth is not weakened.
- All 8 declared hashes were confirmed to match the `key_hash` values live in testing/staging, so this reproduces the current state exactly rather than minting divergent keys.

## Notes

- **Not seeded from a goose migration** — migration 032 documents why data backfill there holds the single write connection and wedges the writer mid-deploy.
- Seeding is opt-in (empty = no-op). **Production is intentionally not seeded here**: its client keys were not part of this incident, and I did not want to declare keys I had not verified. Worth a follow-up.
- Existing projects are never renamed or re-activated — seeding only adds. Rotation adds alongside, so a client that has not picked up a new key cannot be locked out.
- `quality-gate` passes; `internal/repository` coverage ticks up 70.3% → 70.4%. No new file over 500 lines (that count is at its 5/5 cap), and `main.go` grows 8 lines (1158 of the 1200 cap).