### PR TITLE
fix(auth): record api-key last_used_at from read-only pods

### DIFF
--- a/cmd/spanbarn/apikeytouch.go
+++ b/cmd/spanbarn/apikeytouch.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/wiebe-xyz/spanbarn/internal/auth"
+	"github.com/wiebe-xyz/spanbarn/internal/queue"
+	"github.com/wiebe-xyz/spanbarn/internal/repository"
+)
+
+// queuedKeyLookupAdapter looks keys up in a read-only repository and sends
+// last_used_at bumps to the writer over the write queue, so a pod that cannot
+// write still records key usage.
+type queuedKeyLookupAdapter struct {
+	keyLookupAdapter
+	toucher interface{ TouchAPIKey(id int64) error }
+}
+
+func (a *queuedKeyLookupAdapter) TouchAPIKey(id int64) error { return a.toucher.TouchAPIKey(id) }
+
+// newReadOnlyKeyLookup builds the KeyLookup used by pods that open SQLite
+// read-only (reader, ingest).
+//
+// Without a write queue there is nowhere to send the touch, so it is dropped
+// and last_used_at stays NULL — the same behaviour these pods had before, and
+// still preferable to failing auth over a diagnostic column.
+func newReadOnlyKeyLookup(roRepo *repository.Repository, writeQueue *queue.RedisQueue, logger *slog.Logger) auth.KeyLookup {
+	base := keyLookupAdapter{repo: roRepo}
+	if writeQueue == nil {
+		return &readOnlyKeyLookupAdapter{base}
+	}
+	return &queuedKeyLookupAdapter{
+		keyLookupAdapter: base,
+		toucher:          queue.NewTouchPublisher(writeQueue, queue.DefaultTouchInterval, logger),
+	}
+}
+
+// runTouchConsumer drains api-key touches published by reader pods and applies
+// them. Runs on the writer, which owns the only read-write connection.
+//
+// Touches are best-effort telemetry about telemetry: a failure is logged and
+// the batch moves on rather than retrying, since a stale last_used_at is not
+// worth contending for the write connection with actual span ingest.
+func runTouchConsumer(ctx context.Context, writeQueue *queue.RedisQueue, repo *repository.Repository, logger *slog.Logger) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		ids, err := writeQueue.ConsumeAPIKeyTouches(ctx)
+		if err != nil {
+			logger.Error("apikey touch consumer error", "error", err)
+			continue
+		}
+		for _, id := range ids {
+			if err := repo.TouchAPIKey(id); err != nil {
+				logger.Warn("apikey touch failed", "id", id, "error", err)
+			}
+		}
+	}
+}

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -415,7 +415,7 @@ func runReaderMode(cfg config.Config, logger *slog.Logger) error {
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}
-			keyLookup = &readOnlyKeyLookupAdapter{keyLookupAdapter{repo: roRepo}}
+			keyLookup = newReadOnlyKeyLookup(roRepo, writeQueue, logger)
 
 			sessions = newSessionService(roRepo, cfg, logger)
 			userAuth = auth.NewUserAuthenticator(&userLookupAdapter{repo: roRepo}, logger)
@@ -791,6 +791,7 @@ func runWriterMode(cfg config.Config, logger *slog.Logger) error {
 			}
 		}
 	})
+	safeGo("apikey-touch-consumer", &wg, func() { runTouchConsumer(workerCtx, writeQueue, repo, logger) })
 	safeGo("wal-checkpoint", &wg, func() { db.RunPeriodicCheckpoint(workerCtx, 30*time.Second, logger) })
 
 	// Retention queries (DELETE/SELECT on the full spans table) can take
@@ -1002,10 +1003,15 @@ func (a *keyLookupAdapter) TouchAPIKey(id int64) error {
 	return a.repo.TouchAPIKey(id)
 }
 
-// readOnlyKeyLookupAdapter is used by the ingest pod which opens the database
-// in read-only mode. It reuses keyLookupAdapter's GetAPIKeyByHash and overrides
-// TouchAPIKey to a no-op, because last_used_at can be inferred from the presence
-// of spans in the writer's database.
+// readOnlyKeyLookupAdapter serves pods that open the database read-only and
+// have no write queue to forward touches over. It reuses keyLookupAdapter's
+// GetAPIKeyByHash and drops TouchAPIKey.
+//
+// Dropping the touch used to be the behaviour everywhere read-only, on the
+// grounds that last_used_at was inferable from the spans a key produced. Tail
+// sampling keeps 1 trace in 1000 by default, so a perfectly healthy key can
+// produce no spans and look identical to a dead one — see newReadOnlyKeyLookup,
+// which routes touches through the write queue wherever one exists.
 type readOnlyKeyLookupAdapter struct {
 	keyLookupAdapter
 }
@@ -1074,7 +1080,7 @@ func runIngestMode(cfg config.Config, logger *slog.Logger) error {
 			if cfg.QueryTimeoutSeconds > 0 {
 				roRepo.SetQueryTimeout(time.Duration(cfg.QueryTimeoutSeconds) * time.Second)
 			}
-			keyLookup = &readOnlyKeyLookupAdapter{keyLookupAdapter{repo: roRepo}}
+			keyLookup = newReadOnlyKeyLookup(roRepo, nil, logger)
 			logger.Info("read-only DB attached for failover reads", "path", cfg.DBPath)
 		}
 	}

--- a/internal/queue/redis_touch_queue.go
+++ b/internal/queue/redis_touch_queue.go
@@ -1,0 +1,103 @@
+package queue
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	// TouchQueueKey carries api_keys.id values whose last_used_at the writer
+	// should bump.
+	TouchQueueKey       = "spanbarn:apikey-touch-queue"
+	touchQueueBatchSize = 100
+
+	// touchPublishTimeout bounds how long an authenticating request can wait on
+	// Redis. Authorize ignores the touch result, so a slow or dead Redis must
+	// cost a bounded pause rather than hanging auth.
+	touchPublishTimeout = time.Second
+
+	// DefaultTouchInterval is how stale last_used_at is allowed to be. Authorize
+	// runs on every request, so touches are coalesced to at most one publish per
+	// key per interval — "when was this key last used" needs minutes, not
+	// milliseconds, and one LPUSH per request would be absurd.
+	DefaultTouchInterval = time.Minute
+)
+
+// PublishAPIKeyTouches LPUSHes api-key IDs onto the touch queue.
+func (q *RedisQueue) PublishAPIKeyTouches(ctx context.Context, ids []int64) error {
+	return publishBatch(ctx, q, TouchQueueKey, "apikey-touch", touchQueueBatchSize, ids)
+}
+
+// ConsumeAPIKeyTouches blocks for up to brpopTimeout waiting for a batch of
+// api-key IDs. Returns nil, nil when the queue is empty. Called by the writer's
+// touch consumer goroutine.
+func (q *RedisQueue) ConsumeAPIKeyTouches(ctx context.Context) ([]int64, error) {
+	return consumeBatch[int64](ctx, q, TouchQueueKey, "apikey-touch")
+}
+
+// TouchPublisher records api-key usage from a pod that cannot write.
+//
+// The reader and ingest pods open SQLite read-only, so they previously dropped
+// every touch on the floor and last_used_at was permanently NULL. The column
+// was supposed to be inferable from the presence of spans, but tail sampling
+// keeps only 1 trace in 1000 by default: a busy key can legitimately produce no
+// spans at all, making a live key and a revoked-in-all-but-name key look
+// identical. That inference cost real time during the 2026-07-13 key outage.
+//
+// Publishing through the write queue keeps the read-only invariant intact — the
+// reader only enqueues; the writer performs the UPDATE.
+type TouchPublisher struct {
+	queue    *RedisQueue
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu   sync.Mutex
+	seen map[int64]time.Time
+	now  func() time.Time // injectable for tests
+}
+
+// NewTouchPublisher returns a TouchPublisher that coalesces touches per key to
+// at most one publish per interval.
+func NewTouchPublisher(q *RedisQueue, interval time.Duration, logger *slog.Logger) *TouchPublisher {
+	if interval <= 0 {
+		interval = DefaultTouchInterval
+	}
+	return &TouchPublisher{
+		queue:    q,
+		interval: interval,
+		logger:   logger,
+		seen:     make(map[int64]time.Time),
+		now:      time.Now,
+	}
+}
+
+// TouchAPIKey enqueues a last_used_at bump for id, coalesced to one publish per
+// key per interval.
+//
+// It always reports success: a failed touch must never fail authentication over
+// a diagnostic column. Failures are logged instead.
+func (p *TouchPublisher) TouchAPIKey(id int64) error {
+	if !p.claim(id) {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), touchPublishTimeout)
+	defer cancel()
+	if err := p.queue.PublishAPIKeyTouches(ctx, []int64{id}); err != nil && p.logger != nil {
+		p.logger.Warn("failed to publish api key touch", "id", id, "error", err)
+	}
+	return nil
+}
+
+// claim reports whether id is due to be published, recording the attempt.
+func (p *TouchPublisher) claim(id int64) bool {
+	now := p.now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if last, ok := p.seen[id]; ok && now.Sub(last) < p.interval {
+		return false
+	}
+	p.seen[id] = now
+	return true
+}

--- a/internal/queue/redis_touch_queue_test.go
+++ b/internal/queue/redis_touch_queue_test.go
@@ -1,0 +1,44 @@
+package queue
+
+import (
+	"testing"
+	"time"
+)
+
+// Authorize calls TouchAPIKey on every authenticated request, so the coalescing
+// window is what keeps this off the hot path. Without it a busy key would LPUSH
+// once per request.
+func TestTouchPublisherCoalescesPerKey(t *testing.T) {
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	p := NewTouchPublisher(nil, time.Minute, nil)
+	p.now = func() time.Time { return now }
+
+	if !p.claim(1) {
+		t.Fatal("first claim = false, want true")
+	}
+	for i := 0; i < 100; i++ {
+		if p.claim(1) {
+			t.Fatal("claim within the interval = true, want false")
+		}
+	}
+
+	// A different key is tracked independently.
+	if !p.claim(2) {
+		t.Error("claim for a new key = false, want true")
+	}
+
+	// Once the interval elapses the key is due again.
+	now = now.Add(time.Minute)
+	if !p.claim(1) {
+		t.Error("claim after the interval = false, want true")
+	}
+}
+
+func TestNewTouchPublisherDefaultsInterval(t *testing.T) {
+	if got := NewTouchPublisher(nil, 0, nil).interval; got != DefaultTouchInterval {
+		t.Errorf("interval = %v, want %v", got, DefaultTouchInterval)
+	}
+	if got := NewTouchPublisher(nil, -1, nil).interval; got != DefaultTouchInterval {
+		t.Errorf("interval = %v, want %v", got, DefaultTouchInterval)
+	}
+}


### PR DESCRIPTION
Makes `last_used_at` a real signal instead of a column that is always `-`.

## The problem

`last_used_at` is permanently NULL in every CQRS deployment. The reader and ingest pods open SQLite read-only, so `readOnlyKeyLookupAdapter` dropped the touch — deliberately:

```go
// ... overrides TouchAPIKey to a no-op, because last_used_at can be inferred
// from the presence of spans in the writer's database.
func (a *readOnlyKeyLookupAdapter) TouchAPIKey(_ int64) error { return nil }
```

**That inference does not hold.** Tail sampling keeps 1 trace in 1000 by default, so a perfectly healthy key can produce no spans — making a live key indistinguishable from a dead one.

This is not theoretical. During the 2026-07-13 key outage, `apikey list` showed `-` for every key, including the `self-metrics` key in constant use since the database was built. The column said nothing about whether any key was working, and cost real debugging time: iambarn and funnelbarn keys were authenticating fine (200s) while showing zero spans and `Last Used: -`.

## The fix

Publish touches over the **existing Redis write queue** (same shape as `MetricsPublisher`/`LogsPublisher`): the reader only enqueues, the writer performs the UPDATE. The read-only invariant is untouched.

Design points, all deliberate:
- **Coalesced** to one publish per key per minute (`Authorize` runs per request; "when was this key last used" wants minutes, not milliseconds). Precedent: `NewCachedRatioLookup`.
- **The window is claimed before publishing**, so a Redis outage costs one bounded 1s timeout per key per minute rather than a retry storm.
- **A failed touch never fails auth** — logged, request proceeds. A diagnostic column must not be able to take down authentication.
- No write queue (single-node/legacy ingest) → unchanged no-op rather than a hard dependency.

## Verification

Ran a real writer + reader + Redis locally, mirroring the production split:

| check | result |
|---|---|
| Authenticate on the **reader** with a DB key | `last_used_at = 2026-07-17 12:45:17` via the writer |
| 50 authenticated requests | **0** extra publishes (coalesced), not 50 |
| Redis **stopped**, fresh key | auth still **200**, WARN logged, bounded 1s |
| Redis stopped, repeat requests | 1.01s once, then 0.01s — no per-request stall |

`quality-gate` passes; `dupl` holds at 16/17 (the consumer loop lives in a helper rather than a third inline copy in `main.go`), no new file over 500 lines, `main.go` +6.

## Note

Stacked conceptually with #152 but independent — no file overlap beyond `main.go`, which touches different regions.