### PR TITLE
feat(observability): count telemetry orphaned to project 0

### DIFF
--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -14,6 +14,7 @@ import (
 type Metrics struct {
 	SpansIngested  prometheus.Counter
 	SpansProcessed prometheus.Counter
+	OrphanedIngest *prometheus.CounterVec
 	HTTPRequests   *prometheus.CounterVec
 	HTTPDuration   *prometheus.HistogramVec
 	registry       *prometheus.Registry
@@ -33,6 +34,15 @@ func NewMetrics() *Metrics {
 			Name: "spans_processed_total",
 			Help: "Total number of spans processed.",
 		}),
+		// Labelled by signal only (traces|metrics|logs). Deliberately not by
+		// service.name: that is client-supplied and unbounded, and this counter
+		// fires exactly when a client is misconfigured — the worst moment to
+		// hand it control of label cardinality. The service name is in the
+		// throttled warn log instead.
+		OrphanedIngest: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "orphaned_ingest_total",
+			Help: "Telemetry accepted on the global/admin key and stamped project 0, making it invisible in every per-project view. Non-zero means a client is authenticating with the wrong key (or, on a single-tenant install, that project 0 is simply in use).",
+		}, []string{"signal"}),
 		HTTPRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "http_requests_total",
 			Help: "Total number of HTTP requests by route, method, and status.",
@@ -47,6 +57,7 @@ func NewMetrics() *Metrics {
 
 	reg.MustRegister(m.SpansIngested)
 	reg.MustRegister(m.SpansProcessed)
+	reg.MustRegister(m.OrphanedIngest)
 	reg.MustRegister(m.HTTPRequests)
 	reg.MustRegister(m.HTTPDuration)
 

--- a/internal/api/otlp.go
+++ b/internal/api/otlp.go
@@ -62,11 +62,12 @@ func (s *Server) handleOTLP(w http.ResponseWriter, r *http.Request) {
 	// telemetry into project 0 — 911k unattributed spans in production, invisible
 	// precisely because this warning skipped them. Set SPANBARN_SELF_API_KEY to a
 	// project-scoped key.
+	records := otlpToSpanRecords(&req, projectID)
+
 	if projectID == 0 {
+		s.countOrphanedIngest("traces", len(records))
 		warnOrphanedIngest(s.logger, extractRequestService(&req))
 	}
-
-	records := otlpToSpanRecords(&req, projectID)
 
 	if span != nil {
 		span.SetAttributes(attribute.Int("span_count", len(records)))
@@ -160,6 +161,22 @@ func otlpToSpanRecords(req *collectorpb.ExportTraceServiceRequest, projectID int
 		}
 	}
 	return records
+}
+
+// countOrphanedIngest records n orphaned data points for signal. Counting is
+// unthrottled — a counter is cheap, and rate() needs every increment to be
+// meaningful. Only the accompanying log is throttled.
+//
+// The warn alone was never enough: it is only visible to someone reading
+// SpanBarn's own logs, which is nobody, because the symptom presents as
+// "my telemetry is missing" and points at the client. That blind spot cost
+// 911k unattributed spans in production (#148) and ~62k orphaned metric rows
+// still sitting in testing and staging. A counter is scrapeable and alertable.
+func (s *Server) countOrphanedIngest(signal string, n int) {
+	if s.metrics == nil || n == 0 {
+		return
+	}
+	s.metrics.OrphanedIngest.WithLabelValues(signal).Add(float64(n))
 }
 
 // lastOrphanWarnMinute throttles the orphaned-ingest warning to at most once per

--- a/internal/api/otlp_guard_test.go
+++ b/internal/api/otlp_guard_test.go
@@ -5,6 +5,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
@@ -86,4 +89,55 @@ func TestWarnOrphanedIngestCoversSelfExport(t *testing.T) {
 	if warns != 1 {
 		t.Fatalf("expected the orphaned self-export to warn, got %d warnings", warns)
 	}
+}
+
+// orphanCount reads the orphaned_ingest_total counter for one signal.
+func orphanCount(t *testing.T, m *Metrics, signal string) float64 {
+	t.Helper()
+	var out dto.Metric
+	c, err := m.OrphanedIngest.GetMetricWithLabelValues(signal)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues: %v", err)
+	}
+	if err := c.(prometheus.Metric).Write(&out); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	return out.GetCounter().GetValue()
+}
+
+// Project-0 ingest is accepted with a 200 and then hidden from every
+// per-project view, so this counter is the only scrapeable evidence of the
+// loss. The warn is only visible to someone reading SpanBarn's own logs.
+func TestCountOrphanedIngest(t *testing.T) {
+	s := &Server{metrics: NewMetrics()}
+
+	s.countOrphanedIngest("traces", 3)
+	s.countOrphanedIngest("traces", 2)
+	s.countOrphanedIngest("metrics", 7)
+
+	if got := orphanCount(t, s.metrics, "traces"); got != 5 {
+		t.Errorf("traces = %v, want 5", got)
+	}
+	if got := orphanCount(t, s.metrics, "metrics"); got != 7 {
+		t.Errorf("metrics = %v, want 7", got)
+	}
+	if got := orphanCount(t, s.metrics, "logs"); got != 0 {
+		t.Errorf("logs = %v, want 0", got)
+	}
+}
+
+// An empty batch is not evidence of orphaning; counting it would make
+// rate(orphaned_ingest_total) fire on healthy no-op exports.
+func TestCountOrphanedIngestIgnoresEmpty(t *testing.T) {
+	s := &Server{metrics: NewMetrics()}
+	s.countOrphanedIngest("traces", 0)
+	if got := orphanCount(t, s.metrics, "traces"); got != 0 {
+		t.Errorf("traces = %v, want 0", got)
+	}
+}
+
+// Metrics are optional in several server modes; the guard must not panic.
+func TestCountOrphanedIngestNilMetrics(t *testing.T) {
+	s := &Server{}
+	s.countOrphanedIngest("traces", 1)
 }

--- a/internal/api/otlp_logs.go
+++ b/internal/api/otlp_logs.go
@@ -27,7 +27,13 @@ func (s *Server) handleOTLPLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	projectID := GetProjectID(r.Context())
-	s.logsIngest.Enqueue(otlpToLogRecords(&req, projectID))
+	records := otlpToLogRecords(&req, projectID)
+	// Same guardrail as the trace path, and deliberately without a
+	// self-instrument exemption — see handleOTLPMetrics.
+	if projectID == 0 {
+		s.countOrphanedIngest("logs", len(records))
+	}
+	s.logsIngest.Enqueue(records)
 
 	writeOTLPResponse(w, r, &collectorlogspb.ExportLogsServiceResponse{})
 }

--- a/internal/api/otlp_metrics.go
+++ b/internal/api/otlp_metrics.go
@@ -27,7 +27,16 @@ func (s *Server) handleOTLPMetrics(w http.ResponseWriter, r *http.Request) {
 	}
 
 	projectID := GetProjectID(r.Context())
-	s.metricsIngest.Enqueue(otlpToMetricRecords(&req, projectID))
+	records := otlpToMetricRecords(&req, projectID)
+	// Same guardrail as the trace path, and deliberately without a
+	// self-instrument exemption: SPANBARN_SELF_API_KEY falls back to the global
+	// key, and exempting self-telemetry is exactly what hid 911k unattributed
+	// spans (#148). ~62k orphaned metric rows are still sitting in testing and
+	// staging from that fallback.
+	if projectID == 0 {
+		s.countOrphanedIngest("metrics", len(records))
+	}
+	s.metricsIngest.Enqueue(records)
 
 	writeOTLPResponse(w, r, &collectormetricspb.ExportMetricsServiceResponse{})
 }


### PR DESCRIPTION
Makes silent project-0 data loss measurable, extending #148 from a log line to a metric.

## The problem

Telemetry authenticated with the global/admin key is stamped **project 0** and hidden from every per-project view. The client sees a `200`, the dashboard shows nothing — the loss has no symptom that points at the cause.

#148 removed the self-instrument exemption from the trace warning after that exemption hid **911k unattributed spans in production**. But the warning is still the *only* signal, and it only reaches someone reading SpanBarn's own logs — which is nobody, because the symptom presents as "my telemetry is missing" and points at the client.

**The metrics and logs paths had no signal at all.** There are ~62k orphaned metric rows sitting in testing and staging right now from the same `SPANBARN_SELF_API_KEY` fallback:

```
SELECT COUNT(*) FROM metrics WHERE project_id=0;   -- 61,938 testing / 63,139 staging
```

They stop dead at `2026-07-13 09:29` (when #140 landed), so the leak is closed — but nothing would ever have told us it existed. They are quietly ageing out on the retention window.

## The change

Export `orphaned_ingest_total{signal}` across traces, metrics and logs, so the condition is scrapeable and alertable (`rate(orphaned_ingest_total[5m]) > 0`) instead of merely logged.

- **No self-instrument exemption anywhere**, matching #148. Exempting self-telemetry is exactly what made the production loss invisible. (My first cut of this PR *added* that exemption to metrics/logs on the old rationale — #148 landed while I was working and proved it wrong, so I rebuilt it.)
- **Counting, not rejecting.** Project 0 is legitimate on a single-tenant install, so this stays a measurement, not a behaviour change.
- **Labelled by `signal` only, never `service.name`** — client-supplied and unbounded, and this counter fires precisely when a client is misconfigured: the worst moment to hand it control of label cardinality. The service name stays in the throttled warn, which is where you look once the alert fires.

## Verification

Drove the real server through the orphan path:

```
POST /v1/traces with the STATIC admin key -> 200
orphaned_ingest_total{signal="traces"} 2      # exactly the 2 spans sent
WARN "OTLP ingest on global/admin key is stamped project 0 ..." service=misconfigured-client
```

Negative case: a **project-scoped** client on the same server leaves the counter at `2`. No false positives.

Rebased onto current main (d2e5007). `quality-gate` passes; `dupl` holds at 16/17, no new file over 500 lines.