### PR TITLE
fix(cmd): move key-lookup adapters out of main.go, under the 1200 hard cap

### DIFF
--- a/cmd/spanbarn/apikeytouch.go
+++ b/cmd/spanbarn/apikeytouch.go
@@ -9,6 +9,41 @@ import (
 	"github.com/wiebe-xyz/spanbarn/internal/repository"
 )
 
+type keyLookupAdapter struct {
+	repo *repository.Repository
+}
+
+func (a *keyLookupAdapter) GetAPIKeyByHash(keyHash string) (auth.APIKeyRecord, error) {
+	k, err := a.repo.GetAPIKeyByHash(keyHash)
+	if err != nil {
+		return auth.APIKeyRecord{}, err
+	}
+	return auth.APIKeyRecord{
+		ID:        k.ID,
+		ProjectID: k.ProjectID,
+		Scope:     k.Scope,
+	}, nil
+}
+
+func (a *keyLookupAdapter) TouchAPIKey(id int64) error {
+	return a.repo.TouchAPIKey(id)
+}
+
+// readOnlyKeyLookupAdapter serves pods that open the database read-only and
+// have no write queue to forward touches over. It reuses keyLookupAdapter's
+// GetAPIKeyByHash and drops TouchAPIKey.
+//
+// Dropping the touch used to be the behaviour everywhere read-only, on the
+// grounds that last_used_at was inferable from the spans a key produced. Tail
+// sampling keeps 1 trace in 1000 by default, so a perfectly healthy key can
+// produce no spans and look identical to a dead one — see newReadOnlyKeyLookup,
+// which routes touches through the write queue wherever one exists.
+type readOnlyKeyLookupAdapter struct {
+	keyLookupAdapter
+}
+
+func (a *readOnlyKeyLookupAdapter) TouchAPIKey(_ int64) error { return nil }
+
 // queuedKeyLookupAdapter looks keys up in a read-only repository and sends
 // last_used_at bumps to the writer over the write queue, so a pod that cannot
 // write still records key usage.

--- a/cmd/spanbarn/main.go
+++ b/cmd/spanbarn/main.go
@@ -991,41 +991,6 @@ func (a *workerRepoAdapter) InsertPromptRecords(_ context.Context, records []rep
 	return a.repo.InsertPromptRecords(records)
 }
 
-type keyLookupAdapter struct {
-	repo *repository.Repository
-}
-
-func (a *keyLookupAdapter) GetAPIKeyByHash(keyHash string) (auth.APIKeyRecord, error) {
-	k, err := a.repo.GetAPIKeyByHash(keyHash)
-	if err != nil {
-		return auth.APIKeyRecord{}, err
-	}
-	return auth.APIKeyRecord{
-		ID:        k.ID,
-		ProjectID: k.ProjectID,
-		Scope:     k.Scope,
-	}, nil
-}
-
-func (a *keyLookupAdapter) TouchAPIKey(id int64) error {
-	return a.repo.TouchAPIKey(id)
-}
-
-// readOnlyKeyLookupAdapter serves pods that open the database read-only and
-// have no write queue to forward touches over. It reuses keyLookupAdapter's
-// GetAPIKeyByHash and drops TouchAPIKey.
-//
-// Dropping the touch used to be the behaviour everywhere read-only, on the
-// grounds that last_used_at was inferable from the spans a key produced. Tail
-// sampling keeps 1 trace in 1000 by default, so a perfectly healthy key can
-// produce no spans and look identical to a dead one — see newReadOnlyKeyLookup,
-// which routes touches through the write queue wherever one exists.
-type readOnlyKeyLookupAdapter struct {
-	keyLookupAdapter
-}
-
-func (a *readOnlyKeyLookupAdapter) TouchAPIKey(_ int64) error { return nil }
-
 type userLookupAdapter struct {
 	repo *repository.Repository
 }


### PR DESCRIPTION
Fixes the red `quality` job on main.

`cmd/spanbarn/main.go` hit **1205 lines**, past the gate's 1200 hard cap:

```
files over 500 lines:    5 (max 5, cap 1200) FAIL
  over hard cap 1200:
    1205 cmd/spanbarn/main.go
```

## How it slipped through

#152 and #153 each measured fine against main *in isolation* (1158 and 1156 lines) — but they were never measured **together**, and main itself grew via #148–#151 while they were in review. The additions stacked past the cap. Every PR was green; their combination was not. My mistake: I flagged the ~50 lines of headroom and then measured each branch separately anyway.

## The fix

Move `keyLookupAdapter` and `readOnlyKeyLookupAdapter` to `apikeytouch.go`, where `newReadOnlyKeyLookup` and `queuedKeyLookupAdapter` already live.

- `main.go` 1205 → **1170**
- `apikeytouch.go` 63 → 98

Pure code motion, no behaviour change — and the adapters now sit beside the constructor that picks between them, which is where they belonged.

`go build`, `go vet`, `go test ./...` and `quality-gate` all pass on the combined tree:

```
files over 500 lines:    5 (max 5, cap 1200) OK
dupl clone groups (@100):  16 (max 17)     OK
quality gate passed.
```